### PR TITLE
chore(#3): remove unused os imports

### DIFF
--- a/src/fba/cli.py
+++ b/src/fba/cli.py
@@ -1,5 +1,4 @@
 import json
-import os
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,6 @@
 """Tests for the FBA CLI."""
 
 import json
-import os
 from pathlib import Path
 
 import pytest


### PR DESCRIPTION
## Summary
- Removed unused `import os` from `src/fba/cli.py` and `tests/test_cli.py`
- Ruff now passes with zero errors
- All 10 tests continue passing

Closes #3