### PR TITLE
feat(#6): complete slash commands definitions and orchestrator validation

### DIFF
--- a/templates/.opencode/agents/orchestrator.yaml
+++ b/templates/.opencode/agents/orchestrator.yaml
@@ -1,9 +1,10 @@
 name: orchestrator
-role: "FBA Orchestrator - Coordinates the full development lifecycle"
+role: "FBA Orchestrator - Coordinates the full Odoo v18 module development lifecycle"
 description: >
   The orchestrator manages phases, validates artifacts, and invokes
   sub-agents based on the current state in .factory/state.json.
-  It ensures the development flow progresses correctly through all phases.
+  It ensures the development flow progresses correctly through all phases:
+  elicit -> specify -> plan -> tasks -> build -> test -> review -> ship.
 
 methodology: BABOK
 tools: ["read", "write", "bash", "glob", "grep"]
@@ -12,70 +13,106 @@ phases:
   - name: init
     agent: orchestrator
     command: /fba:init
+    description: Initialize project structure
   - name: elicitation
     agent: elicitador
     command: /fba:elicit
     input_artifacts: []
     output_artifacts: ["prd.md"]
+    description: Elicit requirements using BABOK methodology
   - name: specification
     agent: documentador
     command: /fba:specify
     input_artifacts: ["prd.md"]
     output_artifacts: ["prd.md"]
+    description: Generate structured PRD document
   - name: planning
     agent: planificador
     command: /fba:plan
     input_artifacts: ["prd.md"]
     output_artifacts: ["sdd.md", "plan.md"]
+    description: Generate SDD and technical plan for Odoo v18
   - name: tasks
     agent: planificador
     command: /fba:tasks
     input_artifacts: ["sdd.md", "plan.md"]
     output_artifacts: ["tasks.md"]
+    description: Decompose plan into implementable tasks
   - name: construction
     agent: constructor
     command: /fba:build
     input_artifacts: ["sdd.md", "tasks.md"]
     output_artifacts: ["odoo_module/"]
+    description: Generate Odoo v18 module code
   - name: testing
     agent: tester
     command: /fba:test
     input_artifacts: ["odoo_module/"]
     output_artifacts: ["test_report.md"]
+    description: Generate and run tests
   - name: review
     agent: revisor
     command: /fba:review
     input_artifacts: ["odoo_module/", "prd.md", "sdd.md"]
     output_artifacts: ["review_report.md"]
+    description: Review code quality, security, and spec adherence
   - name: ci_cd
     agent: cicd_manager
     command: /fba:ship
     input_artifacts: ["odoo_module/"]
     output_artifacts: ["ci_workflow.yml"]
+    description: Generate CI/CD workflow and prepare release
+
+valid_transitions:
+  init: [elicitation]
+  elicitation: [specification]
+  specification: [planning]
+  planning: [tasks]
+  tasks: [construction]
+  construction: [testing]
+  testing: [review]
+  review: [ci_cd]
+  ci_cd: [complete]
 
 prompt: |
   You are the Factory Build Agent Orchestrator. Your role is to coordinate
   the development lifecycle of an Odoo v18 module.
 
   ## State Management
-  - Read .factory/state.json to determine the current phase
-  - Read .factory/events.jsonl for the full audit trail
-  - After each phase transition, update state.json and append to events.jsonl
+  - Read `.factory/state.json` to determine the current phase.
+  - Read `.factory/events.jsonl` for the full audit trail.
+  - After each phase transition, update `state.json` and append to `events.jsonl`.
 
-  ## Phase Transitions
-  Each phase has a corresponding agent and slash command. When a phase
-  completes successfully, transition to the next phase.
+  ## Phase Flow
+  ```
+  /fba:init ──► /fba:elicit ──► /fba:specify ──► /fba:plan ──► /fba:tasks
+                                                                      │
+  /fba:ship ◄── /fba:review ◄── /fba:test ◄── /fba:build ◄───────────┘
+  ```
 
   ## Validation
-  - Before transitioning, validate that output artifacts meet their schemas
-  - Schemas are in .factory/schemas/
-  - If validation fails, keep the current phase and report errors
+  - Before transitioning to the next phase, validate that output artifacts
+    meet their schemas (schemas are in `.factory/schemas/`).
+  - If validation fails, keep the current phase and report errors.
 
   ## Context Injection
-  - When invoking a sub-agent, include relevant context from current artifacts
-  - Include the PRD when moving to planning
-  - Include the SDD and tasks when moving to construction
+  - When invoking a sub-agent, include relevant context from current artifacts.
+  - Include PRD when moving to planning.
+  - Include SDD and tasks when moving to construction.
 
   ## Current Task
-  Read .factory/state.json, determine current phase, and invoke the
-  appropriate sub-agent or guide the user to the next slash command.
+  Read `.factory/state.json`, determine the current phase, validate
+  pre-conditions, invoke the appropriate sub-agent for the current phase,
+  or guide the user to the next slash command.
+
+  ## Commands Reference
+  See `.opencode/commands/` for full documentation of each slash command.
+  - `/fba:init` — Initialize project structure
+  - `/fba:elicit` — Elicit requirements
+  - `/fba:specify` — Generate PRD
+  - `/fba:plan` — Generate SDD and technical plan
+  - `/fba:tasks` — Create task list
+  - `/fba:build` — Generate Odoo module code
+  - `/fba:test` — Run tests
+  - `/fba:review` — Review code
+  - `/fba:ship` — Generate CI/CD and finalize

--- a/templates/.opencode/commands/fba:build.md
+++ b/templates/.opencode/commands/fba:build.md
@@ -1,0 +1,31 @@
+---
+description: Generate Odoo v18 module code from SDD and task list
+agent: constructor
+---
+
+# fba:build
+
+Generate complete Odoo v18 module source code following the SDD and task list.
+
+## Pre-conditions
+- `.factory/state.json` must have `current_phase: "tasks"` (or `"planning"`).
+- `.factory/sdd.md` and `.factory/tasks.md` exist.
+
+## Steps
+
+1. Read `.factory/sdd.md` and `.factory/tasks.md`.
+2. Generate the Odoo v18 module directory with:
+   - `__manifest__.py` — module metadata and dependencies
+   - `models/` — Python model classes with fields and methods
+   - `views/` — XML view definitions (tree, form, search, kanban)
+   - `security/` — `ir.model.access.csv` for access control
+   - `data/` — demo data and initial configuration
+3. Update `.factory/state.json`: set `current_phase` to `"construction"`,
+   mark `phases.construction.status` as `"complete"`.
+4. Append a `build_complete` event to `.factory/events.jsonl`.
+
+## Post-conditions
+- A valid Odoo v18 module directory exists with all required files.
+- Ready for `/fba:test`.
+
+> Note: Full code generation is implemented in M3.

--- a/templates/.opencode/commands/fba:elicit.md
+++ b/templates/.opencode/commands/fba:elicit.md
@@ -1,0 +1,33 @@
+---
+description: Elicit requirements for an Odoo v18 module using BABOK methodology
+agent: elicitador
+---
+
+# fba:elicit
+
+Elicit functional and non-functional requirements following BABOK methodology.
+
+## Pre-conditions
+- `.factory/state.json` must have `current_phase: "init"` or `"elicitation"`.
+- The user provides a brief description of the desired Odoo module.
+
+## Steps
+
+1. Read `.factory/state.json` to confirm the project is in the correct phase.
+2. Interview the user using BABOK structured questions:
+   - Business context and stakeholders
+   - Objectives and goals
+   - Functional requirements
+   - Non-functional requirements
+   - Constraints and dependencies
+   - Acceptance criteria
+3. Document all elicited requirements in `.factory/context/`.
+4. Update `.factory/state.json`: set `current_phase` to `"elicitation"`,
+   mark `phases.elicitation.status` as `"in_progress"`.
+5. Append an `elicitation_start` event to `.factory/events.jsonl`.
+
+## Post-conditions
+- Requirements are documented and ready for the `/fba:specify` phase.
+- `state.json` reflects the elicitation phase status.
+
+> Note: Full elicitation flow is implemented in M1.

--- a/templates/.opencode/commands/fba:init.md
+++ b/templates/.opencode/commands/fba:init.md
@@ -1,14 +1,44 @@
 ---
-description: Initialize project with Factory Build Agent structure
+description: Initialize and validate the Factory Build Agent project structure
+agent: orchestrator
 ---
 
 # fba:init
 
-Initialize the project with Factory Build Agent directories and configuration:
+Initialize a project with Factory Build Agent. This command must be run
+before any other FBA slash command.
 
-1. Create `.factory/` directory with `state.json` and `events.jsonl` for state management.
-2. Create `.opencode/` with slash commands and agent definitions.
-3. Create `.github/workflows/` with CI/CD templates.
-4. Generate a project-specific `AGENTS.md` with workflow instructions.
+## Pre-conditions
+- A project directory exists (the current directory).
+- The user has Python 3.11+ and the `fba` CLI installed.
 
-The project is now ready for the development flow: elicit -> specify -> plan -> tasks -> build -> test -> review -> ship.
+## Steps
+
+1. Confirm `.factory/` does NOT exist. If it does, report that the project
+   is already initialized and exit.
+
+2. Run `fba init` in the project directory to create:
+   - `.factory/state.json` — state machine tracking
+   - `.factory/events.jsonl` — append-only event log
+   - `.opencode/agents/` — agent definitions (YAML)
+   - `.opencode/commands/` — slash command definitions
+   - `.github/workflows/factory-ci.yml` — CI/CD template
+   - `AGENTS.md` — project context for OpenCode agents
+
+3. Verify all key files were created:
+   - `.factory/state.json` exists and is valid JSON
+   - `.opencode/agents/orchestrator.yaml` exists
+   - `.opencode/commands/fba:init.md` exists
+   - `.github/workflows/factory-ci.yml` exists
+   - `AGENTS.md` exists
+
+4. Validate the generated `state.json` against the schema at
+   `schemas/state.schema.json`.
+
+5. Report successful initialization and guide the user to the next step:
+   `/fba:elicit "describe your Odoo module idea"`
+
+## Post-conditions
+- `.factory/state.json` has `current_phase: "init"` and all phases marked `pending`.
+- `.factory/events.jsonl` contains the init event.
+- The project is ready for the elicitation phase.

--- a/templates/.opencode/commands/fba:plan.md
+++ b/templates/.opencode/commands/fba:plan.md
@@ -1,0 +1,38 @@
+---
+description: Generate technical plan and Software Design Document (SDD.md) from PRD
+agent: planificador
+---
+
+# fba:plan
+
+Generate a Software Design Document and technical plan specific to Odoo v18
+architecture, with full traceability to the PRD.
+
+## Pre-conditions
+- `.factory/state.json` must have `current_phase: "documentation"`.
+- `.factory/prd.md` exists and is valid.
+
+## Steps
+
+1. Read `.factory/prd.md` to understand requirements.
+2. Generate `sdd.md` in `.factory/` with:
+   - Odoo v18 architecture (modules, models, views)
+   - Security design (groups, ACLs, access rights)
+   - Module dependencies
+   - File structure for the Odoo module
+3. Generate `plan.md` in `.factory/` with:
+   - Implementation sequence
+   - Technology stack
+   - Identified risks
+   - Estimates
+4. Ensure traceability: each PRD requirement maps to an SDD component.
+5. Update `.factory/state.json`: set `current_phase` to `"planning"`,
+   mark `phases.planning.status` as `"complete"`.
+6. Append a `plan_complete` event to `.factory/events.jsonl`.
+
+## Post-conditions
+- `.factory/sdd.md` and `.factory/plan.md` exist.
+- Traceability matrix PRD -> SDD is documented.
+- Ready for `/fba:tasks`.
+
+> Note: Full SDD generation with traceability is implemented in M2.

--- a/templates/.opencode/commands/fba:review.md
+++ b/templates/.opencode/commands/fba:review.md
@@ -1,0 +1,37 @@
+---
+description: Review code quality, security, and spec adherence for the generated module
+agent: revisor
+---
+
+# fba:review
+
+Review the generated Odoo v18 module for quality, security, and adherence
+to PRD and SDD specifications.
+
+## Pre-conditions
+- `.factory/state.json` must have `current_phase: "testing"`.
+- The Odoo module code and `.factory/prd.md` exist.
+
+## Steps
+
+1. Review code quality:
+   - PEP8 / Odoo coding conventions
+   - Code organization and naming
+   - Proper use of Odoo ORM and patterns
+2. Review security:
+   - Access control definitions (CSV and model-level)
+   - Input validation and sanitization
+   - Sensitive data exposure
+3. Review spec adherence:
+   - Verify each PRD requirement is implemented
+   - Verify each SDD component is correctly built
+4. Generate `review_report.md` in `.factory/` with findings.
+5. Update `.factory/state.json`: set `current_phase` to `"review"`,
+   mark `phases.review.status` as `"complete"` (if no critical issues).
+6. Append a `review_complete` event to `.factory/events.jsonl`.
+
+## Post-conditions
+- `.factory/review_report.md` exists with no critical issues.
+- Ready for `/fba:ship`.
+
+> Note: Full review is implemented in M3.

--- a/templates/.opencode/commands/fba:ship.md
+++ b/templates/.opencode/commands/fba:ship.md
@@ -1,0 +1,27 @@
+---
+description: Generate CI/CD workflow and prepare the module for release
+agent: cicd_manager
+---
+
+# fba:ship
+
+Generate the CI/CD workflow for the Odoo module and prepare for release.
+
+## Pre-conditions
+- `.factory/state.json` must have `current_phase: "review"`.
+- The Odoo module code has passed review with no critical issues.
+
+## Steps
+
+1. Read module structure to determine build requirements.
+2. Generate GitHub Actions workflow for the module.
+3. Update `.factory/state.json`: set `current_phase` to `"ci_cd"`,
+   mark `phases.ci_cd.status` as `"complete"`, set `current_phase` to `"complete"`.
+4. Append a `ship_complete` event to `.factory/events.jsonl`.
+
+## Post-conditions
+- CI/CD workflow is available in `.github/workflows/`.
+- `.factory/state.json` has `current_phase: "complete"`.
+- The module is ready for production deployment.
+
+> Note: Full CI/CD integration is implemented in M3.

--- a/templates/.opencode/commands/fba:specify.md
+++ b/templates/.opencode/commands/fba:specify.md
@@ -1,0 +1,34 @@
+---
+description: Generate a Product Requirements Document (PRD.md) from elicited requirements
+agent: documentador
+---
+
+# fba:specify
+
+Generate a structured PRD.md from the elicited requirements.
+
+## Pre-conditions
+- `.factory/state.json` must have `current_phase: "elicitation"`.
+- Elicited requirements are available in `.factory/context/`.
+
+## Steps
+
+1. Read elicited requirements from `.factory/context/`.
+2. Generate `prd.md` in `.factory/` with the following sections:
+   - Vision
+   - Stakeholders
+   - Objectives
+   - Functional Requirements
+   - Non-Functional Requirements
+   - Acceptance Criteria
+   - Glossary
+3. Validate `prd.md` against the PRD schema (when available in M1).
+4. Update `.factory/state.json`: set `current_phase` to `"documentation"`,
+   mark `phases.documentation.status` as `"complete"`.
+5. Append a `specify_complete` event to `.factory/events.jsonl`.
+
+## Post-conditions
+- `.factory/prd.md` exists and is valid.
+- Ready for `/fba:plan`.
+
+> Note: Full PRD generation with schema validation is implemented in M1.

--- a/templates/.opencode/commands/fba:tasks.md
+++ b/templates/.opencode/commands/fba:tasks.md
@@ -1,0 +1,29 @@
+---
+description: Break down the technical plan into implementable tasks
+agent: planificador
+---
+
+# fba:tasks
+
+Decompose the SDD and technical plan into a sequenced list of implementable
+tasks for the construction phase.
+
+## Pre-conditions
+- `.factory/state.json` must have `current_phase: "planning"`.
+- `.factory/sdd.md` and `.factory/plan.md` exist.
+
+## Steps
+
+1. Read `.factory/sdd.md` and `.factory/plan.md`.
+2. Generate `tasks.md` in `.factory/` with:
+   - Sequenced task list with dependencies
+   - Each task references the SDD component it implements
+   - Estimated effort per task
+3. Update `.factory/state.json`: set `current_phase` to `"tasks"`.
+4. Append a `tasks_complete` event to `.factory/events.jsonl`.
+
+## Post-conditions
+- `.factory/tasks.md` exists with a complete implementation sequence.
+- Ready for `/fba:build`.
+
+> Note: Full task decomposition is implemented in M2.

--- a/templates/.opencode/commands/fba:test.md
+++ b/templates/.opencode/commands/fba:test.md
@@ -1,0 +1,33 @@
+---
+description: Generate and run tests for the generated Odoo v18 module
+agent: tester
+---
+
+# fba:test
+
+Generate Odoo TestCase tests and execute them against the generated module.
+
+## Pre-conditions
+- `.factory/state.json` must have `current_phase: "construction"`.
+- The Odoo v18 module code exists.
+
+## Steps
+
+1. Read the generated module code to understand its structure.
+2. Generate tests in `tests/` using Odoo TestCase:
+   - Model tests (CRUD operations)
+   - View tests (rendering, fields)
+   - Security tests (access rights)
+   - Integration tests (end-to-end flows)
+3. Execute the test suite.
+4. Generate `test_report.md` in `.factory/` with pass/fail summary.
+5. Update `.factory/state.json`: set `current_phase` to `"testing"`,
+   mark `phases.testing.status` as `"complete"` (if all pass).
+6. Append a `test_complete` event to `.factory/events.jsonl`.
+
+## Post-conditions
+- All tests pass.
+- `.factory/test_report.md` exists.
+- Ready for `/fba:review`.
+
+> Note: Full test generation and execution is implemented in M3.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,11 +83,40 @@ def test_init_creates_agents_yaml(runner, temp_project):
 
 
 def test_init_creates_slash_commands(runner, temp_project):
-    """Verify fba init creates slash command files."""
+    """Verify fba init creates all slash command files."""
     result = runner.invoke(main, ["init", "-d", str(temp_project)])
 
     assert result.exit_code == 0
-    assert (temp_project / ".opencode" / "commands" / "fba:init.md").is_file()
+
+    commands_dir = temp_project / ".opencode" / "commands"
+    expected_commands = [
+        "fba:init.md",
+        "fba:elicit.md",
+        "fba:specify.md",
+        "fba:plan.md",
+        "fba:tasks.md",
+        "fba:build.md",
+        "fba:test.md",
+        "fba:review.md",
+        "fba:ship.md",
+    ]
+    for cmd in expected_commands:
+        assert (commands_dir / cmd).is_file(), f"Missing command: {cmd}"
+
+
+def test_init_orchestrator_yaml_content(runner, temp_project):
+    """Verify the orchestrator.yaml has correct phase definitions."""
+    result = runner.invoke(main, ["init", "-d", str(temp_project)])
+    assert result.exit_code == 0
+
+    import yaml
+    orchestrator = yaml.safe_load(
+        (temp_project / ".opencode" / "agents" / "orchestrator.yaml").read_text()
+    )
+    assert orchestrator["name"] == "orchestrator"
+    assert orchestrator["methodology"] == "BABOK"
+    assert len(orchestrator["phases"]) == 9
+    assert "valid_transitions" in orchestrator
 
 
 def test_init_creates_github_workflow(runner, temp_project):


### PR DESCRIPTION
## Summary
- Improved `fba:init.md` — now includes pre/post conditions, actionable steps
- Added 7 new slash command definitions: elicit, specify, plan, tasks, build, test, review, ship
- Enhanced `orchestrator.yaml` — added valid_transitions, command reference, improved prompt
- Added test for orchestrator YAML content validation
- Updated slash command test to verify all 9 commands are copied

Closes #6