### PR TITLE
feat(#14): release automatico al mergear PR a main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag exists
+        id: check_tag
+        run: |
+          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${{ steps.version.outputs.tag }} already exists, skipping release"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build package
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Extract changelog
+        if: steps.check_tag.outputs.exists == 'false'
+        id: changelog
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          NOTES=$(python -c "
+          import os, re
+          content = open('CHANGELOG.md').read()
+          version = os.environ['RELEASE_VERSION']
+          pattern = rf'## \[{re.escape(version)}\].*?(?=## \[|\Z)'
+          match = re.search(pattern, content, re.DOTALL)
+          if match:
+              print(match.group().strip())
+          else:
+              print(os.environ['RELEASE_TAG'])
+          ")
+          {
+            echo "notes<<EOF"
+            echo "$NOTES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create tag
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Create GitHub Release
+        if: steps.check_tag.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
+          body: ${{ steps.changelog.outputs.notes }}
+          files: |
+            dist/*.whl
+            dist/*.tar.gz

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,9 @@
 
 ## Reglas Fundamentales
 
+> ⛔ **main es SOLO-LECTURA. Cero commits directos. Cero excepciones.**
+> Toda modificacion al codigo se hace en branches y entra a main exclusivamente via Pull Request mergeado.
+
 1. **NUNCA hacer commit directo a `main`**. Solo se mergea via Pull Request.
 2. **Siempre crear un GitHub Issue antes de escribir codigo**. Nada se desarrolla sin issue.
 3. **Usar la convencion de branching** descrita abajo.

--- a/src/fba/cli.py
+++ b/src/fba/cli.py
@@ -5,11 +5,13 @@ from pathlib import Path
 
 import click
 
+from fba import __version__
+
 TEMPLATES_DIR = Path(__file__).resolve().parent.parent.parent / "templates"
 
 
 @click.group()
-@click.version_option(version="0.1.0")
+@click.version_option(version=__version__)
 def main():
     """Factory Build Agent - Multi-agent framework for Odoo v18 module development."""
 
@@ -56,7 +58,7 @@ def _init_factory_state(target: Path):
 
     state = {
         "project": target.name,
-        "framework_version": "0.1.0",
+        "framework_version": __version__,
         "init_at": datetime.now(timezone.utc).isoformat(),
         "current_phase": "init",
         "methodology": "BABOK",
@@ -85,7 +87,7 @@ def _init_events_log(target: Path):
         "ts": datetime.now(timezone.utc).isoformat(),
         "type": "init",
         "agent": "fba_cli",
-        "framework_version": "0.1.0",
+        "framework_version": __version__,
         "project": target.name,
     }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from fba import __version__
 from fba.cli import main
 
 
@@ -24,7 +25,7 @@ def test_cli_version(runner):
     """Verify the CLI shows version."""
     result = runner.invoke(main, ["--version"])
     assert result.exit_code == 0
-    assert "0.1.0" in result.output
+    assert __version__ in result.output
 
 
 def test_init_creates_directories(runner, temp_project):


### PR DESCRIPTION
Closes #14

## Cambios

- **`.github/workflows/release.yml`** (nuevo): workflow que se dispara en `push` a `main`. Extrae version de `pyproject.toml`, verifica si el tag ya existe, build wheel + sdist, extrae la seccion correspondiente del `CHANGELOG.md`, crea git tag `vX.Y.Z` y genera un GitHub Release con changelog + build artifacts.
- **`src/fba/cli.py`**: version dinamica desde `fba.__version__` en `@click.version_option()` y en `framework_version` de state/events.
- **`tests/test_cli.py`**: test de version usa `__version__` importado en vez de string hardcodeado.