### PR TITLE
feat(#19): State module y comandos CLI

### DIFF
--- a/schemas/state.schema.json
+++ b/schemas/state.schema.json
@@ -31,6 +31,13 @@
       "type": "object",
       "description": "Status of each phase",
       "properties": {
+        "init": {
+          "type": "object",
+          "properties": {
+            "status": {"type": "string", "enum": ["pending", "in_progress", "complete", "failed"]},
+            "agent": {"type": "string"}
+          }
+        },
         "elicitation": {
           "type": "object",
           "properties": {

--- a/src/fba/cli.py
+++ b/src/fba/cli.py
@@ -6,8 +6,23 @@ from pathlib import Path
 import click
 
 from fba import __version__
+from fba.state import StateManager
 
 TEMPLATES_DIR = Path(__file__).resolve().parent.parent.parent / "templates"
+SCHEMAS_DIR = Path(__file__).resolve().parent.parent.parent / "schemas"
+
+PROJECT_DIR_OPTION = click.option(
+    "--project-dir", "-d", default=None,
+    help="Target project directory (default: current directory)"
+)
+
+
+def _resolve_project_dir(project_dir):
+    target = Path(project_dir).resolve() if project_dir else Path.cwd()
+    if not (target / ".factory").exists():
+        click.echo(f"Error: No .factory/ found in {target}. Run 'fba init' first.")
+        raise SystemExit(1)
+    return target
 
 
 @click.group()
@@ -33,6 +48,7 @@ def init(project_dir):
         raise SystemExit(1)
 
     _copy_templates(target)
+    _copy_schemas(target)
     _init_factory_state(target)
     _init_events_log(target)
 
@@ -52,6 +68,20 @@ def _copy_templates(target: Path):
     shutil.copytree(templates_src, target, dirs_exist_ok=True)
 
 
+def _copy_schemas(target: Path):
+    schemas_src = SCHEMAS_DIR
+    if not schemas_src.exists():
+        return
+
+    factory_schemas = target / ".factory" / "schemas"
+    factory_schemas.mkdir(parents=True, exist_ok=True)
+
+    for schema_file in schemas_src.glob("*.schema.json"):
+        dest = factory_schemas / schema_file.name
+        if not dest.exists():
+            shutil.copy2(schema_file, dest)
+
+
 def _init_factory_state(target: Path):
     factory_dir = target / ".factory"
     factory_dir.mkdir(parents=True, exist_ok=True)
@@ -63,6 +93,7 @@ def _init_factory_state(target: Path):
         "current_phase": "init",
         "methodology": "BABOK",
         "phases": {
+            "init": {"status": "in_progress", "agent": "orchestrator"},
             "elicitation": {"status": "pending", "agent": "elicitador"},
             "documentation": {"status": "pending", "agent": "documentador"},
             "planning": {"status": "pending", "agent": "planificador"},
@@ -92,3 +123,154 @@ def _init_events_log(target: Path):
     }
 
     events_path.write_text(json.dumps(init_event, ensure_ascii=False) + "\n")
+
+
+@main.command()
+@PROJECT_DIR_OPTION
+def status(project_dir):
+    """Show the current state of the Factory Build Agent project."""
+    target = _resolve_project_dir(project_dir)
+    state_mgr = StateManager(target)
+    state = state_mgr.load()
+
+    click.echo(f"Project: {state['project']}")
+    click.echo(f"Version: {state.get('framework_version', 'unknown')}")
+    click.echo(f"Methodology: {state['methodology']}")
+    click.echo(f"Current phase: {state['current_phase']}")
+    click.echo("")
+
+    click.echo("Phases:")
+    for phase_name, phase_info in state.get("phases", {}).items():
+        symbol = {
+            "pending": "⬜",
+            "in_progress": "🔄",
+            "complete": "✅",
+            "failed": "❌",
+        }.get(phase_info.get("status", "pending"), "⬜")
+        click.echo(f"  {symbol} {phase_name}: {phase_info['status']}")
+
+    click.echo("")
+    click.echo("Artifacts:")
+    artifacts = state.get("artifacts", {})
+    if artifacts:
+        for name, info in artifacts.items():
+            click.echo(f"  📄 {name}: {info['status']} (v{info.get('version', 1)})")
+    else:
+        click.echo("  (none)")
+
+
+@main.command()
+@click.argument("phase")
+@PROJECT_DIR_OPTION
+def transition(phase, project_dir):
+    """Transition the project to a new development phase."""
+    target = _resolve_project_dir(project_dir)
+    state_mgr = StateManager(target)
+
+    try:
+        state = state_mgr.transition_to(phase)
+        click.echo(f"Transitioned from '{state['current_phase']}' to '{phase}'")
+    except ValueError as e:
+        click.echo(f"Error: {e}")
+        raise SystemExit(1)
+
+
+@main.command()
+@click.argument("event_type")
+@click.option("--data", default=None, help="JSON string with event data")
+@PROJECT_DIR_OPTION
+def record(event_type, data, project_dir):
+    """Record an event in the append-only event log."""
+    target = _resolve_project_dir(project_dir)
+    state_mgr = StateManager(target)
+
+    parsed_data = None
+    if data:
+        parsed_data = json.loads(data)
+
+    state_mgr.record_event(event_type, parsed_data)
+    click.echo(f"Event '{event_type}' recorded.")
+
+
+@main.command()
+@click.argument("artifact", required=False)
+@PROJECT_DIR_OPTION
+def validate(artifact, project_dir):
+    """Validate project artifacts against their JSON schemas.
+
+    If no artifact is specified, validates all artifacts found in state.json.
+    """
+    target = _resolve_project_dir(project_dir)
+
+    schemas_available = _list_schemas(target)
+    if not schemas_available:
+        click.echo("No schemas found for validation.")
+        return
+
+    artifacts_to_validate = []
+    if artifact:
+        schema_name = f"{artifact}.schema.json"
+        if schema_name not in schemas_available:
+            click.echo(f"No schema found for artifact '{artifact}'.")
+            click.echo("Available schemas: " + ", ".join(
+                s.replace(".schema.json", "") for s in schemas_available
+            ))
+            raise SystemExit(1)
+        artifacts_to_validate = [artifact]
+    else:
+        artifacts_to_validate = [
+            s.replace(".schema.json", "") for s in schemas_available
+        ]
+
+    import jsonschema
+
+    all_valid = True
+    for art_name in artifacts_to_validate:
+        art_path = target / ".factory" / f"{art_name}.json"
+        if not art_path.exists():
+            click.echo(f"Skipping '{art_name}': artifact file not found ({art_path})")
+            continue
+
+        schema_path = _find_schema(target, f"{art_name}.schema.json")
+        if not schema_path:
+            click.echo(f"Skipping '{art_name}': schema not found")
+            continue
+
+        try:
+            artifact_data = json.loads(art_path.read_text())
+            schema = json.loads(schema_path.read_text())
+            jsonschema.validate(artifact_data, schema)
+            click.echo(f"✅ {art_name}: valid")
+        except jsonschema.ValidationError as e:
+            click.echo(f"❌ {art_name}: validation failed - {e.message}")
+            all_valid = False
+        except json.JSONDecodeError as e:
+            click.echo(f"❌ {art_name}: invalid JSON - {e}")
+            all_valid = False
+
+    if not all_valid:
+        raise SystemExit(1)
+
+
+def _list_schemas(target: Path) -> list:
+    schemas = []
+    project_schemas = target / ".factory" / "schemas"
+    if project_schemas.is_dir():
+        schemas.extend(
+            f.name for f in project_schemas.glob("*.schema.json")
+        )
+    if SCHEMAS_DIR.is_dir():
+        for f in SCHEMAS_DIR.glob("*.schema.json"):
+            if f.name not in schemas:
+                schemas.append(f.name)
+    return sorted(schemas)
+
+
+def _find_schema(target: Path, schema_name: str) -> Path | None:
+    project_schema = target / ".factory" / "schemas" / schema_name
+    if project_schema.exists():
+        return project_schema
+    framework_schema = SCHEMAS_DIR / schema_name
+    if framework_schema.exists():
+        return framework_schema
+    return None

--- a/src/fba/state.py
+++ b/src/fba/state.py
@@ -1,0 +1,109 @@
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+
+class StateManager:
+    """Manages the Factory Build Agent state machine for a project."""
+
+    def __init__(self, project_dir: Path):
+        self.project_dir = Path(project_dir).resolve()
+        self._factory_dir = self.project_dir / ".factory"
+        self._opencode_dir = self.project_dir / ".opencode"
+
+    @property
+    def state_path(self) -> Path:
+        return self._factory_dir / "state.json"
+
+    @property
+    def events_path(self) -> Path:
+        return self._factory_dir / "events.jsonl"
+
+    @property
+    def orchestrator_path(self) -> Path:
+        return self._opencode_dir / "agents" / "orchestrator.yaml"
+
+    @property
+    def current_phase(self) -> str:
+        state = self.load()
+        return state["current_phase"]
+
+    def load(self) -> dict:
+        if not self.state_path.exists():
+            raise FileNotFoundError(
+                f"State file not found: {self.state_path}. Run 'fba init' first."
+            )
+        return json.loads(self.state_path.read_text())
+
+    def save(self, state: dict) -> None:
+        self._factory_dir.mkdir(parents=True, exist_ok=True)
+        self.state_path.write_text(json.dumps(state, indent=2, ensure_ascii=False))
+
+    def transition_to(self, phase: str) -> dict:
+        state = self.load()
+        current = state["current_phase"]
+        valid = self._get_valid_transitions()
+
+        if current not in valid:
+            raise ValueError(f"No transitions defined from phase '{current}'")
+        if phase not in valid[current]:
+            allowed = ", ".join(valid[current])
+            raise ValueError(
+                f"Invalid transition: '{current}' -> '{phase}'."
+                f" Allowed: {allowed}"
+            )
+
+        if current in state["phases"]:
+            state["phases"][current]["status"] = "complete"
+
+        state["current_phase"] = phase
+        if phase in state["phases"]:
+            state["phases"][phase]["status"] = "in_progress"
+        self.save(state)
+
+        self.record_event(
+            "phase_transition",
+            {"from": current, "to": phase},
+        )
+
+        return state
+
+    def record_event(self, event_type: str, data: dict = None) -> None:
+        event = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "type": event_type,
+        }
+        if data:
+            event["data"] = data
+
+        self._factory_dir.mkdir(parents=True, exist_ok=True)
+        with open(self.events_path, "a") as f:
+            f.write(json.dumps(event, ensure_ascii=False) + "\n")
+
+    def mark_phase(self, phase: str, status: str) -> None:
+        state = self.load()
+        if phase not in state["phases"]:
+            raise ValueError(f"Unknown phase: {phase}")
+        state["phases"][phase]["status"] = status
+        self.save(state)
+
+    def add_artifact(self, name: str, status: str = "draft") -> None:
+        state = self.load()
+        state["artifacts"][name] = {"status": status, "version": 1}
+        self.save(state)
+
+    def add_artifact_version(self, name: str) -> None:
+        state = self.load()
+        if name not in state["artifacts"]:
+            raise ValueError(f"Unknown artifact: {name}")
+        current = state["artifacts"][name].get("version", 0)
+        state["artifacts"][name]["version"] = current + 1
+        self.save(state)
+
+    def _get_valid_transitions(self) -> dict:
+        if not self.orchestrator_path.exists():
+            return {}
+        orchestrator = yaml.safe_load(self.orchestrator_path.read_text())
+        return orchestrator.get("valid_transitions", {})

--- a/templates/.opencode/agents/orchestrator.yaml
+++ b/templates/.opencode/agents/orchestrator.yaml
@@ -26,6 +26,7 @@ phases:
     input_artifacts: ["prd.md"]
     output_artifacts: ["prd.md"]
     description: Generate structured PRD document
+    phase_key: documentation
   - name: planning
     agent: planificador
     command: /fba:plan
@@ -65,8 +66,8 @@ phases:
 
 valid_transitions:
   init: [elicitation]
-  elicitation: [specification]
-  specification: [planning]
+  elicitation: [documentation]
+  documentation: [planning]
   planning: [tasks]
   tasks: [construction]
   construction: [testing]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -164,3 +164,130 @@ def test_state_schema_validation(runner, temp_project):
     schema = json.loads(schema_path.read_text())
 
     jsonschema.validate(state, schema)
+
+
+def test_init_creates_schemas(runner, temp_project):
+    """Verify fba init copies schemas to .factory/schemas/."""
+    result = runner.invoke(main, ["init", "-d", str(temp_project)])
+    assert result.exit_code == 0
+
+    schemas_dir = temp_project / ".factory" / "schemas"
+    assert schemas_dir.is_dir()
+    schema_files = list(schemas_dir.glob("*.schema.json"))
+    assert len(schema_files) >= 1
+    assert (schemas_dir / "prd.schema.json").is_file()
+
+
+class TestStatusCommand:
+    def test_status_shows_project_info(self, runner, temp_project):
+        runner.invoke(main, ["init", "-d", str(temp_project)])
+        result = runner.invoke(main, ["status", "-d", str(temp_project)])
+        assert result.exit_code == 0
+        assert "Current phase: init" in result.output
+        assert "Methodology: BABOK" in result.output
+
+    def test_status_requires_factory(self, runner, temp_project):
+        result = runner.invoke(main, ["status", "-d", str(temp_project)])
+        assert result.exit_code == 1
+        assert "No .factory/ found" in result.output
+
+
+class TestTransitionCommand:
+    def test_valid_transition(self, runner, temp_project):
+        runner.invoke(main, ["init", "-d", str(temp_project)])
+        result = runner.invoke(main, ["transition", "elicitation", "-d", str(temp_project)])
+        assert result.exit_code == 0
+        assert "Transitioned" in result.output
+
+        state = json.loads((temp_project / ".factory" / "state.json").read_text())
+        assert state["current_phase"] == "elicitation"
+
+    def test_invalid_transition(self, runner, temp_project):
+        runner.invoke(main, ["init", "-d", str(temp_project)])
+        result = runner.invoke(main, ["transition", "construction", "-d", str(temp_project)])
+        assert result.exit_code == 1
+        assert "Invalid transition" in result.output
+
+
+class TestRecordCommand:
+    def test_record_event(self, runner, temp_project):
+        runner.invoke(main, ["init", "-d", str(temp_project)])
+        result = runner.invoke(
+            main,
+            ["record", "elicitation_start", "--data", '{"stakeholders": 3}', "-d", str(temp_project)],
+        )
+        assert result.exit_code == 0
+        assert "Event 'elicitation_start' recorded" in result.output
+
+        events_path = temp_project / ".factory" / "events.jsonl"
+        lines = events_path.read_text().strip().split("\n")
+        assert len(lines) == 2
+
+        event = json.loads(lines[1])
+        assert event["type"] == "elicitation_start"
+        assert event["data"]["stakeholders"] == 3
+
+
+class TestValidateCommand:
+    def test_validate_valid_prd(self, runner, temp_project):
+        runner.invoke(main, ["init", "-d", str(temp_project)])
+
+        valid_prd = {
+            "vision": "A vehicle registration module for Odoo v18.",
+            "stakeholders": [
+                {"name": "Admin", "role": "User", "interest": "Track vehicles"}
+            ],
+            "objectives": ["Automate vehicle registration"],
+            "functional_requirements": [
+                {
+                    "id": "RF-01",
+                    "description": "CRUD operations for vehicles",
+                    "priority": "high",
+                }
+            ],
+            "non_functional_requirements": [
+                {
+                    "id": "RNF-01",
+                    "description": "Must respond under 2 seconds",
+                    "category": "performance",
+                    "priority": "medium",
+                }
+            ],
+            "acceptance_criteria": [
+                {
+                    "id": "CA-01",
+                    "criterion": "User can create a vehicle with required fields",
+                }
+            ],
+            "glossary": [
+                {"term": "CRUD", "definition": "Create, Read, Update, Delete operations"}
+            ],
+        }
+        art_path = temp_project / ".factory" / "prd.json"
+        art_path.write_text(json.dumps(valid_prd))
+
+        result = runner.invoke(main, ["validate", "prd", "-d", str(temp_project)])
+        assert result.exit_code == 0
+        assert "valid" in result.output
+
+    def test_validate_invalid_prd(self, runner, temp_project):
+        runner.invoke(main, ["init", "-d", str(temp_project)])
+
+        invalid_prd = {"vision": "Too short"}  # missing required fields
+        art_path = temp_project / ".factory" / "prd.json"
+        art_path.write_text(json.dumps(invalid_prd))
+
+        result = runner.invoke(main, ["validate", "prd", "-d", str(temp_project)])
+        assert result.exit_code == 1
+        assert "validation failed" in result.output
+
+    def test_validate_missing_artifact(self, runner, temp_project):
+        runner.invoke(main, ["init", "-d", str(temp_project)])
+        result = runner.invoke(main, ["validate", "prd", "-d", str(temp_project)])
+        assert "artifact file not found" in result.output
+
+    def test_validate_unknown_artifact(self, runner, temp_project):
+        runner.invoke(main, ["init", "-d", str(temp_project)])
+        result = runner.invoke(main, ["validate", "nonexistent", "-d", str(temp_project)])
+        assert result.exit_code == 1
+        assert "No schema found" in result.output

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,190 @@
+"""Tests for the StateManager module."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from fba.state import StateManager
+
+
+@pytest.fixture
+def project_dir(tmp_path):
+    factory_dir = tmp_path / ".factory"
+    factory_dir.mkdir()
+
+    opencode_agents = tmp_path / ".opencode" / "agents"
+    opencode_agents.mkdir(parents=True)
+
+    state = {
+        "project": tmp_path.name,
+        "framework_version": "0.1.0",
+        "init_at": "2026-05-02T00:00:00+00:00",
+        "current_phase": "init",
+        "methodology": "BABOK",
+        "phases": {
+            "init": {"status": "in_progress", "agent": "orchestrator"},
+            "elicitation": {"status": "pending", "agent": "elicitador"},
+            "documentation": {"status": "pending", "agent": "documentador"},
+            "planning": {"status": "pending", "agent": "planificador"},
+            "construction": {"status": "pending", "agent": "constructor"},
+            "testing": {"status": "pending", "agent": "tester"},
+            "review": {"status": "pending", "agent": "revisor"},
+            "ci_cd": {"status": "pending", "agent": "cicd_manager"},
+        },
+        "artifacts": {},
+        "context": {},
+    }
+    (factory_dir / "state.json").write_text(json.dumps(state, indent=2))
+
+    orchestrator = {
+        "name": "orchestrator",
+        "methodology": "BABOK",
+        "valid_transitions": {
+            "init": ["elicitation"],
+            "elicitation": ["documentation"],
+            "documentation": ["planning"],
+            "planning": ["tasks"],
+            "tasks": ["construction"],
+            "construction": ["testing"],
+            "testing": ["review"],
+            "review": ["ci_cd"],
+            "ci_cd": ["complete"],
+        },
+    }
+    import yaml
+    (opencode_agents / "orchestrator.yaml").write_text(yaml.dump(orchestrator))
+
+    return tmp_path
+
+
+@pytest.fixture
+def state_mgr(project_dir):
+    return StateManager(project_dir)
+
+
+class TestStateManagerLoadSave:
+    def test_load_state(self, state_mgr):
+        state = state_mgr.load()
+        assert state["current_phase"] == "init"
+        assert state["methodology"] == "BABOK"
+
+    def test_save_state(self, state_mgr):
+        state = state_mgr.load()
+        state["context"]["key"] = "value"
+        state_mgr.save(state)
+
+        reloaded = state_mgr.load()
+        assert reloaded["context"]["key"] == "value"
+
+    def test_current_phase(self, state_mgr):
+        assert state_mgr.current_phase == "init"
+
+    def test_load_missing_state_file(self, tmp_path):
+        mgr = StateManager(tmp_path / "nonexistent")
+        with pytest.raises(FileNotFoundError, match="Run 'fba init' first"):
+            mgr.load()
+
+
+class TestStateManagerTransitions:
+    def test_valid_transition(self, state_mgr):
+        state = state_mgr.transition_to("elicitation")
+        assert state["current_phase"] == "elicitation"
+        assert state["phases"]["elicitation"]["status"] == "in_progress"
+        assert state["phases"]["init"]["status"] == "complete"
+
+    def test_invalid_transition_raises(self, state_mgr):
+        with pytest.raises(ValueError, match="Invalid transition"):
+            state_mgr.transition_to("construction")
+
+    def test_transition_chain(self, state_mgr):
+        state_mgr.transition_to("elicitation")
+        state_mgr.transition_to("documentation")
+        assert state_mgr.current_phase == "documentation"
+        assert state_mgr.load()["phases"]["elicitation"]["status"] == "complete"
+
+    def test_transition_does_not_mark_init_complete(self, state_mgr):
+        state_mgr.transition_to("elicitation")
+        assert state_mgr.load()["phases"]["init"]["status"] == "complete"
+
+    def test_transition_records_event(self, state_mgr):
+        events_before = _count_events(state_mgr.events_path)
+        state_mgr.transition_to("elicitation")
+        events_after = _count_events(state_mgr.events_path)
+        assert events_after == events_before + 1
+
+        last_event = _read_last_event(state_mgr.events_path)
+        assert last_event["type"] == "phase_transition"
+        assert last_event["data"]["from"] == "init"
+        assert last_event["data"]["to"] == "elicitation"
+
+
+class TestStateManagerEvents:
+    def test_record_event(self, state_mgr):
+        state_mgr.record_event("elicitation_start", {"stakeholders": 3})
+        events = _read_events(state_mgr.events_path)
+        assert len(events) == 1
+        assert events[0]["type"] == "elicitation_start"
+        assert events[0]["data"]["stakeholders"] == 3
+
+    def test_record_event_no_data(self, state_mgr):
+        state_mgr.record_event("ping")
+        event = _read_last_event(state_mgr.events_path)
+        assert event["type"] == "ping"
+        assert "data" not in event
+
+    def test_record_event_appends(self, state_mgr):
+        state_mgr.record_event("first")
+        state_mgr.record_event("second")
+        events = _read_events(state_mgr.events_path)
+        assert len(events) == 2
+        assert events[0]["type"] == "first"
+        assert events[1]["type"] == "second"
+
+
+class TestStateManagerPhases:
+    def test_mark_phase(self, state_mgr):
+        state_mgr.mark_phase("elicitation", "in_progress")
+        state = state_mgr.load()
+        assert state["phases"]["elicitation"]["status"] == "in_progress"
+
+    def test_mark_unknown_phase_raises(self, state_mgr):
+        with pytest.raises(ValueError, match="Unknown phase"):
+            state_mgr.mark_phase("nonexistent", "complete")
+
+
+class TestStateManagerArtifacts:
+    def test_add_artifact(self, state_mgr):
+        state_mgr.add_artifact("prd")
+        state = state_mgr.load()
+        assert "prd" in state["artifacts"]
+        assert state["artifacts"]["prd"]["status"] == "draft"
+        assert state["artifacts"]["prd"]["version"] == 1
+
+    def test_add_artifact_with_status(self, state_mgr):
+        state_mgr.add_artifact("prd", "valid")
+        assert state_mgr.load()["artifacts"]["prd"]["status"] == "valid"
+
+    def test_add_artifact_version(self, state_mgr):
+        state_mgr.add_artifact("prd")
+        state_mgr.add_artifact_version("prd")
+        assert state_mgr.load()["artifacts"]["prd"]["version"] == 2
+
+    def test_add_artifact_version_unknown_raises(self, state_mgr):
+        with pytest.raises(ValueError, match="Unknown artifact"):
+            state_mgr.add_artifact_version("nonexistent")
+
+
+def _read_events(path: Path) -> list:
+    if not path.exists():
+        return []
+    lines = path.read_text().strip().split("\n")
+    return [json.loads(line) for line in lines if line]
+
+
+def _read_last_event(path: Path) -> dict:
+    return _read_events(path)[-1]
+
+
+def _count_events(path: Path) -> int:
+    return len(_read_events(path))


### PR DESCRIPTION
## Summary
- StateManager con gestion de fases, transiciones, eventos y artefactos
- Nuevos CLI: `fba status`, `fba transition`, `fba record`, `fba validate`  
- Schemas copiados automaticamente con `fba init`
- Consistencia phase names: `specification` → `documentation`

## Tests
69/69 pasan (30 PRD schema + 18 state + 21 CLI)

Closes #19