### PR TITLE
feat(#35): expandir slash command fba:plan con flujo completo de planificacion

### DIFF
--- a/templates/.opencode/commands/fba:plan.md
+++ b/templates/.opencode/commands/fba:plan.md
@@ -1,38 +1,155 @@
 ---
-description: Generate technical plan and Software Design Document (SDD.md) from PRD
+description: Generate a Software Design Document (SDD) and technical plan for Odoo v18 from validated PRD
 agent: planificador
 ---
 
 # fba:plan
 
-Generate a Software Design Document and technical plan specific to Odoo v18
-architecture, with full traceability to the PRD.
+Generate an Odoo v18 Software Design Document (SDD) and technical plan from
+a validated PRD, with full traceability from requirements to design components.
 
 ## Pre-conditions
 - `.factory/state.json` must have `current_phase: "documentation"`.
-- `.factory/prd.md` exists and is valid.
+- `.factory/prd.json` must exist and pass schema validation.
+- `.factory/prd.md` must exist (human-readable version).
 
 ## Steps
 
-1. Read `.factory/prd.md` to understand requirements.
-2. Generate `sdd.md` in `.factory/` with:
-   - Odoo v18 architecture (modules, models, views)
-   - Security design (groups, ACLs, access rights)
-   - Module dependencies
-   - File structure for the Odoo module
-3. Generate `plan.md` in `.factory/` with:
-   - Implementation sequence
-   - Technology stack
-   - Identified risks
-   - Estimates
-4. Ensure traceability: each PRD requirement maps to an SDD component.
-5. Update `.factory/state.json`: set `current_phase` to `"planning"`,
-   mark `phases.planning.status` as `"complete"`.
-6. Append a `plan_complete` event to `.factory/events.jsonl`.
+### 1. Validate Pre-conditions
+Read `.factory/state.json` to confirm the project is in the `documentation` phase.
+Verify `.factory/prd.json` exists. If not found, instruct the user to
+run `/fba:specify` first.
+
+### 2. Load PRD
+Read `.factory/prd.json` to understand:
+- Module vision and objectives
+- Functional requirements (RFs)
+- Non-functional requirements (RNFs)
+- Stakeholders
+- Constraints and dependencies
+- Acceptance criteria
+
+Also read `.factory/prd.md` for human-readable context.
+
+### 3. Generate SDD and Plan
+Follow the planificador agent instructions in `.opencode/agents/planificador.md`:
+
+#### 3a. Generate `.factory/sdd.json`
+Create the machine-readable SDD conforming to the SDD JSON schema
+(`schemas/sdd.schema.json`). This file describes the complete Odoo v18
+module architecture:
+- **module_name**: Technical module name (e.g., `vehicle_registry`)
+- **architecture**: High-level design description
+- **models**: All Odoo models with fields, types, relations, and traceability
+- **views**: Form, tree, search views for each model
+- **security**: Groups, access rights, record rules
+- **dependencies**: Required and optional Odoo addons
+- **workflows**: State machines and automation flows
+- **reporting**: Report definitions if applicable
+- **file_structure**: Complete module file tree
+- **traceability_matrix**: Maps every RF/RNF to its SDD components
+
+#### 3b. Generate `.factory/sdd.md`
+Render the SDD as a human-readable Markdown document with all sections
+properly formatted:
+- Architecture Overview
+- Models (detailed per model with field tables)
+- Views (table per view type)
+- Security Design (groups + access rights)
+- Dependencies
+- Workflows
+- Reporting
+- File Structure (tree)
+- Traceability Matrix (global mapping table)
+
+#### 3c. Generate `.factory/plan.md`
+Create a technical plan with:
+- Technology Stack (Odoo v18, Python 3.11+, Odoo ORM, etc.)
+- Implementation Phases (Foundation → Views → Security → Logic → Polish)
+- Risks and Mitigations table
+- Estimates per phase with complexity ratings
+
+### 4. Validate SDD
+Run schema validation on the generated `sdd.json`:
+```bash
+fba validate sdd
+```
+
+If validation fails:
+- Read the error message
+- Fix the identified issue in `sdd.json`
+- Re-run `fba validate sdd`
+- Repeat until validation passes
+
+### 5. Verify Traceability
+Check that the traceability matrix is complete:
+- Every RF from the PRD must appear in at least one mapping
+- Every RNF from the PRD must appear in at least one mapping
+- All SDD components must have traceability tags
+
+### 6. Update State and Record Events
+After successful validation:
+1. Record the event:
+   ```bash
+   fba record plan_complete \
+     --data '{"artifacts":["sdd.json","sdd.md","plan.md"],"traceability_complete":true}'
+   ```
+2. Add artifacts to state:
+   ```bash
+   fba add-artifact sdd
+   ```
+3. Transition phase:
+   ```bash
+   fba transition planning
+   ```
+
+### 7. Report Summary and Ask to Proceed
+Display a summary of the generated SDD:
+- Module name
+- Number of models designed
+- Number of fields across all models
+- Number of views (form, tree, search)
+- Security groups and access rights
+- Dependencies
+- Traceability coverage (RFs mapped / total RFs)
+- Validation status: passed
+
+Then follow the **Phase Progression Protocol** from the orchestrator agent
+definition. If the user approves progression, instruct the user on the
+next slash command for task breakdown.
 
 ## Post-conditions
-- `.factory/sdd.md` and `.factory/plan.md` exist.
-- Traceability matrix PRD -> SDD is documented.
-- Ready for `/fba:tasks`.
+- `.factory/sdd.json` exists and passes schema validation.
+- `.factory/sdd.md` exists with human-readable SDD.
+- `.factory/plan.md` exists with technical plan.
+- `.factory/state.json` has `current_phase: "planning"`.
+- `.factory/events.jsonl` contains the `plan_complete` event.
+- Ready for the next phase: tasks.
 
-> Note: Full SDD generation with traceability is implemented in M2.
+## Example Output
+
+```
+✅ SDD y plan tecnico generados y validados
+
+📄 .factory/sdd.json — valid
+📄 .factory/sdd.md — documentacion de diseno legible
+📄 .factory/plan.md — plan tecnico
+
+Resumen:
+  - Modulo: vehicle_registry (Vehicle Registry)
+  - 1 modelo disenado (vehicle.registry)
+  - 7 campos, 2 relaciones
+  - 3 vistas (form, tree, search)
+  - 1 grupo de seguridad, 1 regla de acceso
+  - Dependencias: base (required), mail (optional)
+  - Trazabilidad: 5/5 RFs mapeados, 3/3 RNFs mapeados
+
+Fase actual: planning
+
+> [Uses question tool]
+> Header: "Fase completada: planning"
+> Q: "¿Como procedemos?"
+> - A) Continuar a la siguiente fase (tasks)
+> - B) Quiero revisar los artefactos generados primero
+> - C) Quiero hacer cambios en esta fase
+```

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,6 +148,36 @@ def test_init_creates_project_agents_md(runner, temp_project):
     assert "/fba:build" in content
 
 
+def test_plan_command_has_frontmatter_and_body(runner, temp_project):
+    """Verify the fba:plan.md command has proper frontmatter and detailed body."""
+    import yaml
+
+    plan_cmd_path = (
+        Path(__file__).resolve().parent.parent
+        / "templates" / ".opencode" / "commands" / "fba:plan.md"
+    )
+    text = plan_cmd_path.read_text()
+    parts = text.split("---", 2)
+
+    assert len(parts) >= 3
+    frontmatter = yaml.safe_load(parts[1])
+    body = parts[2].strip()
+
+    assert frontmatter.get("agent") == "planificador"
+    assert "Generate" in frontmatter.get("description", "")
+
+    assert "# fba:plan" in body
+    assert "Pre-conditions" in body
+    assert "documentation" in body
+    assert ".factory/prd.json" in body
+    assert "sdd.json" in body
+    assert "sdd.md" in body
+    assert "plan.md" in body
+    assert "traceability" in body.lower()
+    assert "fba validate sdd" in body
+    assert "fba transition planning" in body
+
+
 def test_init_fails_if_factory_exists(runner, temp_project):
     """Verify init fails if .factory/ already exists."""
     (temp_project / ".factory").mkdir()


### PR DESCRIPTION
## Summary
- Expande el slash command `/fba:plan` de stub a documentacion completa con 7 pasos
- Incluye pre-condiciones, pasos detallados, validacion SDD, verificacion de trazabilidad
- Agrega Phase Progression Protocol y ejemplo de output
- Agrega test que verifica frontmatter y body del comando
- Total: 127 tests pasando
- Closes #35