### PR TITLE
feat(#37): crear schema SDD con validacion completa y tests

### DIFF
--- a/schemas/sdd.schema.json
+++ b/schemas/sdd.schema.json
@@ -1,0 +1,487 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://opencode.ai/fba/schemas/sdd.schema.json",
+  "title": "Software Design Document",
+  "description": "Schema for FBA-generated Software Design Document (SDD). Validates the machine-readable sdd.json artifact for Odoo v18 modules.",
+  "type": "object",
+  "required": [
+    "module_name",
+    "module_display_name",
+    "version",
+    "architecture",
+    "models",
+    "views",
+    "security",
+    "dependencies",
+    "file_structure",
+    "traceability_matrix"
+  ],
+  "properties": {
+    "module_name": {
+      "type": "string",
+      "minLength": 3,
+      "description": "Technical module name (e.g., vehicle_registry)."
+    },
+    "module_display_name": {
+      "type": "string",
+      "minLength": 3,
+      "description": "Human-readable module name (e.g., Vehicle Registry)."
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+.*$",
+      "description": "Odoo module version (e.g., 18.0.1.0.0)."
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 10,
+      "description": "Brief description of the module."
+    },
+    "architecture": {
+      "type": "object",
+      "required": ["description"],
+      "properties": {
+        "description": {
+          "type": "string",
+          "minLength": 10,
+          "description": "High-level architecture description."
+        },
+        "diagram_notes": {
+          "type": "string",
+          "description": "Key architectural decisions and design patterns."
+        }
+      },
+      "additionalProperties": false
+    },
+    "models": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Odoo models defined in this module.",
+      "items": {
+        "type": "object",
+        "required": ["name", "display_name", "description", "fields", "traceability"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 3,
+            "pattern": "^[a-z0-9_.]+$",
+            "description": "Technical model name (e.g., vehicle.registry)."
+          },
+          "display_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Human-readable model name."
+          },
+          "description": {
+            "type": "string",
+            "minLength": 5,
+            "description": "Description of the model's purpose."
+          },
+          "inherit": {
+            "type": ["string", "null"],
+            "description": "Parent model name if inherited, or null."
+          },
+          "fields": {
+            "type": "array",
+            "minItems": 1,
+            "description": "Fields defined in this model.",
+            "items": {
+              "type": "object",
+              "required": ["name", "type", "display_name", "description", "traceability"],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "pattern": "^[a-z][a-z0-9_]*$",
+                  "description": "Field technical name."
+                },
+                "type": {
+                  "type": "string",
+                  "enum": ["char", "text", "integer", "float", "boolean", "date", "datetime", "binary", "selection", "many2one", "one2many", "many2many", "html", "monetary"],
+                  "description": "Odoo field type."
+                },
+                "display_name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Human-readable field label."
+                },
+                "required": {
+                  "type": "boolean",
+                  "description": "Whether this field is required."
+                },
+                "unique": {
+                  "type": "boolean",
+                  "description": "Whether this field must be unique."
+                },
+                "size": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Max size for char fields."
+                },
+                "compute": {
+                  "type": "string",
+                  "description": "Compute method name if field is computed."
+                },
+                "selection": {
+                  "type": "array",
+                  "description": "Selection options for selection fields.",
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": {"type": "string"}
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "minLength": 5,
+                  "description": "Description of the field's purpose."
+                },
+                "traceability": {
+                  "type": "array",
+                  "minItems": 1,
+                  "description": "PRD requirement IDs this field implements.",
+                  "items": {
+                    "type": "string",
+                    "pattern": "^RF-\\d{2,}$"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "relations": {
+            "type": "array",
+            "description": "Relational fields linking to other models.",
+            "items": {
+              "type": "object",
+              "required": ["type", "model", "field", "description"],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["Many2one", "One2many", "Many2many"],
+                  "description": "Type of relation."
+                },
+                "model": {
+                  "type": "string",
+                  "minLength": 3,
+                  "description": "Target model technical name."
+                },
+                "field": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Relation field name."
+                },
+                "description": {
+                  "type": "string",
+                  "minLength": 5,
+                  "description": "Description of the relationship."
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "traceability": {
+            "type": "array",
+            "minItems": 1,
+            "description": "PRD requirement IDs this model implements.",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "views": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Odoo views defined for this module.",
+      "items": {
+        "type": "object",
+        "required": ["model", "type", "name", "description", "fields", "traceability"],
+        "properties": {
+          "model": {
+            "type": "string",
+            "minLength": 3,
+            "description": "Model technical name this view belongs to."
+          },
+          "type": {
+            "type": "string",
+            "enum": ["form", "tree", "search", "kanban", "calendar", "graph", "pivot", "activity", "qweb"],
+            "description": "Odoo view type."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 3,
+            "description": "XML view ID."
+          },
+          "description": {
+            "type": "string",
+            "minLength": 5,
+            "description": "Description of the view's purpose."
+          },
+          "fields": {
+            "type": "array",
+            "minItems": 1,
+            "description": "Main fields displayed in this view.",
+            "items": {"type": "string", "minLength": 1}
+          },
+          "filters": {
+            "type": "array",
+            "description": "Search filters for search views.",
+            "items": {
+              "type": "object",
+              "required": ["name", "domain_type"],
+              "properties": {
+                "name": {"type": "string", "minLength": 1},
+                "domain_type": {"type": "string", "enum": ["field", "group_by", "filter"]},
+                "field_name": {"type": "string"},
+                "description": {"type": "string"}
+              },
+              "additionalProperties": false
+            }
+          },
+          "traceability": {
+            "type": "array",
+            "minItems": 1,
+            "description": "PRD requirement IDs this view implements.",
+            "items": {"type": "string"}
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "security": {
+      "type": "object",
+      "required": ["groups", "access_rights"],
+      "properties": {
+        "groups": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Security groups for this module.",
+          "items": {
+            "type": "object",
+            "required": ["name", "display_name", "description"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^[a-z][a-z0-9_]*$",
+                "description": "Group XML ID."
+              },
+              "display_name": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Human-readable group name."
+              },
+              "description": {
+                "type": "string",
+                "minLength": 5,
+                "description": "What this group can do."
+              },
+              "implied_ids": {
+                "type": "array",
+                "description": "Inherited group IDs.",
+                "items": {"type": "string"}
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "access_rights": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Access control rules per model per group.",
+          "items": {
+            "type": "object",
+            "required": ["model", "group", "perm_read", "perm_write", "perm_create", "perm_unlink"],
+            "properties": {
+              "model": {
+                "type": "string",
+                "minLength": 3,
+                "description": "Model technical name."
+              },
+              "group": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Group XML ID."
+              },
+              "perm_read": {"type": "boolean"},
+              "perm_write": {"type": "boolean"},
+              "perm_create": {"type": "boolean"},
+              "perm_unlink": {"type": "boolean"}
+            },
+            "additionalProperties": false
+          }
+        },
+        "record_rules": {
+          "type": "array",
+          "description": "Record-level security rules.",
+          "items": {
+            "type": "object",
+            "required": ["name", "model", "domain", "description"],
+            "properties": {
+              "name": {"type": "string", "minLength": 1},
+              "model": {"type": "string", "minLength": 3},
+              "domain": {"type": "string", "minLength": 1},
+              "description": {"type": "string", "minLength": 5},
+              "groups": {
+                "type": "array",
+                "items": {"type": "string"}
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "dependencies": {
+      "type": "object",
+      "required": ["required"],
+      "properties": {
+        "required": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Required Odoo addon dependencies.",
+          "items": {"type": "string", "minLength": 2}
+        },
+        "optional": {
+          "type": "array",
+          "description": "Optional Odoo addon dependencies.",
+          "items": {"type": "string", "minLength": 2}
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 10,
+          "description": "Explanation of why each dependency is needed."
+        }
+      },
+      "additionalProperties": false
+    },
+    "workflows": {
+      "type": "array",
+      "description": "Workflows and state machines.",
+      "items": {
+        "type": "object",
+        "required": ["name", "model", "description", "traceability"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Workflow name."
+          },
+          "model": {
+            "type": "string",
+            "minLength": 3,
+            "description": "Model this workflow applies to."
+          },
+          "states": {
+            "type": "array",
+            "minItems": 2,
+            "description": "States in the workflow.",
+            "items": {"type": "string", "minLength": 1}
+          },
+          "description": {
+            "type": "string",
+            "minLength": 5,
+            "description": "Description of the workflow."
+          },
+          "traceability": {
+            "type": "array",
+            "minItems": 1,
+            "description": "PRD requirement IDs this workflow implements.",
+            "items": {"type": "string"}
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "reporting": {
+      "type": "array",
+      "description": "Report definitions.",
+      "items": {
+        "type": "object",
+        "required": ["name", "type", "model", "description"],
+        "properties": {
+          "name": {"type": "string", "minLength": 1},
+          "type": {
+            "type": "string",
+            "enum": ["pdf", "excel", "dashboard", "qweb"]
+          },
+          "model": {"type": "string", "minLength": 3},
+          "description": {"type": "string", "minLength": 5},
+          "traceability": {
+            "type": "array",
+            "items": {"type": "string"}
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "file_structure": {
+      "type": "object",
+      "required": ["module", "files"],
+      "properties": {
+        "module": {
+          "type": "string",
+          "minLength": 3,
+          "description": "Module directory name."
+        },
+        "files": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Files in the module.",
+          "items": {
+            "type": "string",
+            "minLength": 3,
+            "pattern": "^[a-zA-Z0-9_/.]+$"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "traceability_matrix": {
+      "type": "object",
+      "required": ["mappings"],
+      "properties": {
+        "description": {
+          "type": "string",
+          "minLength": 10,
+          "description": "Description of the traceability mapping."
+        },
+        "mappings": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Maps each PRD requirement to SDD components.",
+          "items": {
+            "type": "object",
+            "required": ["requirement", "sdD_components", "description"],
+            "properties": {
+              "requirement": {
+                "type": "string",
+                "minLength": 2,
+                "description": "PRD requirement ID (RF-NN or RNF-NN)."
+              },
+              "sdD_components": {
+                "type": "array",
+                "minItems": 1,
+                "description": "SDD component names this requirement maps to.",
+                "items": {"type": "string", "minLength": 1}
+              },
+              "description": {
+                "type": "string",
+                "minLength": 5,
+                "description": "How this requirement maps to these SDD components."
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -210,8 +210,9 @@ def test_init_creates_schemas(runner, temp_project):
     schemas_dir = temp_project / ".factory" / "schemas"
     assert schemas_dir.is_dir()
     schema_files = list(schemas_dir.glob("*.schema.json"))
-    assert len(schema_files) >= 1
+    assert len(schema_files) >= 2
     assert (schemas_dir / "prd.schema.json").is_file()
+    assert (schemas_dir / "sdd.schema.json").is_file()
 
 
 class TestStatusCommand:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -259,6 +259,93 @@ class TestFullElicitationFlow:
         assert result.exit_code == 1
         assert "validation failed" in result.output
 
+    def test_sdd_validation_via_cli(self, runner, project):
+        """Validate an SDD artifact via fba validate sdd."""
+        runner.invoke(main, ["init", "-d", str(project)])
+
+        sdd = {
+            "module_name": "vehicle_registry",
+            "module_display_name": "Vehicle Registry",
+            "version": "18.0.1.0.0",
+            "summary": "Vehicle management module for Odoo v18",
+            "architecture": {
+                "description": "Simple module with one model, basic views, and security for vehicle management"
+            },
+            "models": [
+                {
+                    "name": "vehicle.registry",
+                    "display_name": "Vehicle",
+                    "description": "Main vehicle registry model for storing vehicle data",
+                    "fields": [
+                        {
+                            "name": "plate",
+                            "type": "char",
+                            "display_name": "License Plate",
+                            "required": True,
+                            "unique": True,
+                            "size": 20,
+                            "description": "Unique vehicle license plate number",
+                            "traceability": ["RF-01"]
+                        }
+                    ],
+                    "traceability": ["RF-01"]
+                }
+            ],
+            "views": [
+                {
+                    "model": "vehicle.registry",
+                    "type": "form",
+                    "name": "vehicle.registry.form",
+                    "description": "Main vehicle form view",
+                    "fields": ["plate"],
+                    "traceability": ["RF-01"]
+                }
+            ],
+            "security": {
+                "groups": [
+                    {
+                        "name": "vehicle_user",
+                        "display_name": "Vehicle User",
+                        "description": "Can view and create vehicles"
+                    }
+                ],
+                "access_rights": [
+                    {
+                        "model": "vehicle.registry",
+                        "group": "vehicle_user",
+                        "perm_read": True,
+                        "perm_write": True,
+                        "perm_create": True,
+                        "perm_unlink": False
+                    }
+                ]
+            },
+            "dependencies": {
+                "required": ["base"],
+                "reason": "base module is required for all Odoo addons"
+            },
+            "file_structure": {
+                "module": "vehicle_registry",
+                "files": ["__manifest__.py", "__init__.py", "models/vehicle_registry.py"]
+            },
+            "traceability_matrix": {
+                "mappings": [
+                    {
+                        "requirement": "RF-01",
+                        "sdD_components": ["vehicle.registry model", "vehicle.registry.form view"],
+                        "description": "CRUD operations for vehicle records"
+                    }
+                ]
+            }
+        }
+        (project / ".factory" / "sdd.json").write_text(
+            json.dumps(sdd, indent=2, ensure_ascii=False)
+        )
+
+        result = runner.invoke(main, ["validate", "sdd", "-d", str(project)])
+        assert result.exit_code == 0
+        assert "valid" in result.output
+
     def test_complete_m1_flow(self, runner, project):
         """End-to-end simulation of the M1 flow: elicit -> specify."""
         _create_elicitation_context(project)

--- a/tests/test_sdd_schema.py
+++ b/tests/test_sdd_schema.py
@@ -1,0 +1,508 @@
+"""Tests for SDD schema validation."""
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "schemas" / "sdd.schema.json"
+
+
+@pytest.fixture
+def sdd_schema():
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+def _valid_sdd():
+    return {
+        "module_name": "vehicle_registry",
+        "module_display_name": "Vehicle Registry",
+        "version": "18.0.1.0.0",
+        "summary": "Module for managing vehicle records in Odoo v18",
+        "architecture": {
+            "description": "The module uses a single model with basic CRUD views and security groups for access control.",
+            "diagram_notes": "Standard Odoo v18 module architecture with MVC separation."
+        },
+        "models": [
+            {
+                "name": "vehicle.registry",
+                "display_name": "Vehicle",
+                "description": "Main vehicle registry model for storing vehicle data",
+                "inherit": None,
+                "fields": [
+                    {
+                        "name": "plate",
+                        "type": "char",
+                        "display_name": "License Plate",
+                        "required": True,
+                        "unique": True,
+                        "size": 20,
+                        "description": "Unique vehicle license plate number",
+                        "traceability": ["RF-01"]
+                    },
+                    {
+                        "name": "brand",
+                        "type": "char",
+                        "display_name": "Brand",
+                        "required": True,
+                        "description": "Vehicle manufacturer brand",
+                        "traceability": ["RF-01"]
+                    },
+                ],
+                "relations": [
+                    {
+                        "type": "Many2one",
+                        "model": "res.partner",
+                        "field": "owner_id",
+                        "description": "Vehicle owner contact"
+                    }
+                ],
+                "traceability": ["RF-01", "RF-02"]
+            }
+        ],
+        "views": [
+            {
+                "model": "vehicle.registry",
+                "type": "form",
+                "name": "vehicle.registry.form",
+                "description": "Main vehicle form view",
+                "fields": ["plate", "brand"],
+                "traceability": ["RF-01"]
+            },
+            {
+                "model": "vehicle.registry",
+                "type": "tree",
+                "name": "vehicle.registry.tree",
+                "description": "Vehicle list view",
+                "fields": ["plate", "brand"],
+                "traceability": ["RF-01"]
+            },
+            {
+                "model": "vehicle.registry",
+                "type": "search",
+                "name": "vehicle.registry.search",
+                "description": "Vehicle search view",
+                "fields": ["plate", "brand"],
+                "traceability": ["RF-03"]
+            }
+        ],
+        "security": {
+            "groups": [
+                {
+                    "name": "vehicle_user",
+                    "display_name": "Vehicle User",
+                    "description": "Can view and create vehicles",
+                    "implied_ids": ["base.group_user"]
+                }
+            ],
+            "access_rights": [
+                {
+                    "model": "vehicle.registry",
+                    "group": "vehicle_user",
+                    "perm_read": True,
+                    "perm_write": True,
+                    "perm_create": True,
+                    "perm_unlink": False
+                }
+            ],
+            "record_rules": []
+        },
+        "dependencies": {
+            "required": ["base"],
+            "optional": ["mail"],
+            "reason": "base is required for all Odoo modules, mail for activity tracking"
+        },
+        "workflows": [
+            {
+                "name": "vehicle_status",
+                "model": "vehicle.registry",
+                "states": ["draft", "active", "inactive"],
+                "description": "Vehicle lifecycle status workflow",
+                "traceability": ["RF-04"]
+            }
+        ],
+        "reporting": [],
+        "file_structure": {
+            "module": "vehicle_registry",
+            "files": [
+                "__manifest__.py",
+                "__init__.py",
+                "models/__init__.py",
+                "models/vehicle_registry.py",
+                "views/vehicle_registry_views.xml",
+                "security/ir.model.access.csv"
+            ]
+        },
+        "traceability_matrix": {
+            "description": "Maps PRD requirements to SDD design components for full traceability",
+            "mappings": [
+                {
+                    "requirement": "RF-01",
+                    "sdD_components": ["vehicle.registry model", "vehicle.registry.form view"],
+                    "description": "CRUD operations for vehicle records"
+                },
+                {
+                    "requirement": "RNF-01",
+                    "sdD_components": ["security section"],
+                    "description": "Access control"
+                }
+            ]
+        }
+    }
+
+
+class TestSDDSchemaValid:
+    """Valid SDD documents pass validation."""
+
+    def test_valid_sdd_passes(self, sdd_schema):
+        jsonschema.validate(_valid_sdd(), sdd_schema)
+
+    def test_minimal_sdd_passes(self, sdd_schema):
+        sdd = {
+            "module_name": "test",
+            "module_display_name": "Test Module",
+            "version": "18.0.1.0.0",
+            "architecture": {
+                "description": "Simple test module architecture description here"
+            },
+            "models": [
+                {
+                    "name": "test.model",
+                    "display_name": "Test",
+                    "description": "A test model",
+                    "fields": [
+                        {
+                            "name": "name",
+                            "type": "char",
+                            "display_name": "Name",
+                            "description": "Record name field",
+                            "traceability": ["RF-01"]
+                        }
+                    ],
+                    "traceability": ["RF-01"]
+                }
+            ],
+            "views": [
+                {
+                    "model": "test.model",
+                    "type": "form",
+                    "name": "test.model.form",
+                    "description": "Test form view",
+                    "fields": ["name"],
+                    "traceability": ["RF-01"]
+                }
+            ],
+            "security": {
+                "groups": [
+                    {
+                        "name": "test_user",
+                        "display_name": "Test User",
+                        "description": "Basic user group for testing"
+                    }
+                ],
+                "access_rights": [
+                    {
+                        "model": "test.model",
+                        "group": "test_user",
+                        "perm_read": True,
+                        "perm_write": False,
+                        "perm_create": False,
+                        "perm_unlink": False
+                    }
+                ]
+            },
+            "dependencies": {
+                "required": ["base"]
+            },
+            "file_structure": {
+                "module": "test",
+                "files": ["__manifest__.py"]
+            },
+            "traceability_matrix": {
+                "mappings": [
+                    {
+                        "requirement": "RF-01",
+                        "sdD_components": ["test.model"],
+                        "description": "Basic model mapping"
+                    }
+                ]
+            }
+        }
+        jsonschema.validate(sdd, sdd_schema)
+
+    def test_sdd_with_optional_fields_passes(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["workflows"] = [
+            {
+                "name": "state_flow",
+                "model": "vehicle.registry",
+                "states": ["draft", "done"],
+                "description": "Simple state flow for testing",
+                "traceability": ["RF-01"]
+            }
+        ]
+        sdd["reporting"] = [
+            {
+                "name": "vehicle_report",
+                "type": "pdf",
+                "model": "vehicle.registry",
+                "description": "Vehicle record PDF report"
+            }
+        ]
+        jsonschema.validate(sdd, sdd_schema)
+
+
+class TestSDDSchemaRequiredFields:
+    """Missing required fields fail validation."""
+
+    def test_missing_module_name_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        del sdd["module_name"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_missing_models_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        del sdd["models"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_missing_views_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        del sdd["views"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_missing_security_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        del sdd["security"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_missing_dependencies_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        del sdd["dependencies"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_missing_file_structure_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        del sdd["file_structure"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_missing_traceability_matrix_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        del sdd["traceability_matrix"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_missing_architecture_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        del sdd["architecture"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_missing_display_name_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        del sdd["module_display_name"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+
+class TestSDDSchemaEmptyArrays:
+    """Empty required arrays fail validation."""
+
+    def test_empty_models_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["models"] = []
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_empty_views_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["views"] = []
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_empty_security_groups_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["security"]["groups"] = []
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_empty_access_rights_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["security"]["access_rights"] = []
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_empty_dependencies_required_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["dependencies"]["required"] = []
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_empty_file_structure_files_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["file_structure"]["files"] = []
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_empty_traceability_mappings_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["traceability_matrix"]["mappings"] = []
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+
+class TestSDDSchemaInvalidTypes:
+    """Invalid field types fail validation."""
+
+    def test_invalid_model_field_type_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["models"][0]["fields"][0]["type"] = "invalid_type"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_invalid_view_type_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["views"][0]["type"] = "invalid_type"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_invalid_relation_type_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["models"][0]["relations"][0]["type"] = "InvalidRel"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_invalid_version_format_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["version"] = "abc"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+
+class TestSDDSchemaTraceability:
+    """Traceability requirements fail correctly."""
+
+    def test_model_without_traceability_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        del sdd["models"][0]["traceability"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_field_without_traceability_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        del sdd["models"][0]["fields"][0]["traceability"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_view_without_traceability_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        del sdd["views"][0]["traceability"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_workflow_without_traceability_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        del sdd["workflows"][0]["traceability"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_traceability_mapping_missing_sdd_components_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        del sdd["traceability_matrix"]["mappings"][0]["sdD_components"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+
+class TestSDDSchemaMinLength:
+    """String fields must meet minimum length requirements."""
+
+    def test_module_name_too_short_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["module_name"] = "ab"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_architecture_description_too_short_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["architecture"]["description"] = "Short"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_model_description_too_short_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["models"][0]["description"] = "Sho"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_field_description_too_short_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["models"][0]["fields"][0]["description"] = "Sh"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_view_description_too_short_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["views"][0]["description"] = "Sho"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_traceability_description_too_short_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["traceability_matrix"]["description"] = "Short"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+
+class TestSDDSchemaPatterns:
+    """Pattern validations work correctly."""
+
+    def test_invalid_model_name_pattern_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["models"][0]["name"] = "Invalid Model Name!"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_invalid_field_name_pattern_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["models"][0]["fields"][0]["name"] = "1invalid"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_traceability_rf_pattern_fails_with_invalid_id(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["models"][0]["fields"][0]["traceability"] = ["RF-1"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_valid_traceability_with_rnf_passes(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["traceability_matrix"]["mappings"][0]["requirement"] = "RNF-01"
+        jsonschema.validate(sdd, sdd_schema)
+
+
+class TestSDDAdditionalProperties:
+    """Additional properties are rejected."""
+
+    def test_sdd_extra_property_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["extra_field"] = "not allowed"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_model_extra_property_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["models"][0]["extra"] = "not allowed"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)
+
+    def test_security_extra_property_fails(self, sdd_schema):
+        sdd = _valid_sdd()
+        sdd["security"]["extra"] = "not allowed"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(sdd, sdd_schema)


### PR DESCRIPTION
## Summary
- Crea `schemas/sdd.schema.json` con validacion completa de todos los componentes SDD
- Valida: modelos, campos, vistas, seguridad, dependencias, workflows, file_structure, traceability_matrix
- 41 tests unitarios de schema + 1 test de integracion (fba validate sdd)
- Schema copiado automaticamente por `fba init` a `.factory/schemas/`
- Total: 169 tests pasando
- Closes #37