### PR TITLE
feat(#38): trazabilidad PRD -> SDD con verificacion automatica en fba validate

### DIFF
--- a/src/fba/cli.py
+++ b/src/fba/cli.py
@@ -286,6 +286,11 @@ def validate(artifact, project_dir):
             schema = json.loads(schema_path.read_text())
             jsonschema.validate(artifact_data, schema)
             click.echo(f"✅ {art_name}: valid")
+
+            if art_name == "sdd":
+                if not _check_traceability(target, artifact_data):
+                    all_valid = False
+
         except jsonschema.ValidationError as e:
             click.echo(f"❌ {art_name}: validation failed - {e.message}")
             all_valid = False
@@ -295,6 +300,48 @@ def validate(artifact, project_dir):
 
     if not all_valid:
         raise SystemExit(1)
+
+
+def _check_traceability(target: Path, sdd: dict) -> bool:
+    """Verify PRD→SDD traceability completeness.
+
+    Returns True if all PRD requirements are mapped in the SDD.
+    """
+    prd_path = target / ".factory" / "prd.json"
+    if not prd_path.exists():
+        click.echo("ℹ️  prd.json not found, skipping traceability check")
+        return True
+
+    try:
+        prd = json.loads(prd_path.read_text())
+    except json.JSONDecodeError:
+        click.echo("⚠️  prd.json is invalid JSON, skipping traceability check")
+        return True
+
+    prd_rfs = {rf["id"] for rf in prd.get("functional_requirements", [])}
+    prd_rnfs = {rnf["id"] for rnf in prd.get("non_functional_requirements", [])}
+    all_requirements = prd_rfs | prd_rnfs
+
+    if not all_requirements:
+        click.echo("ℹ️  No requirements found in PRD, skipping traceability check")
+        return True
+
+    mappings = sdd.get("traceability_matrix", {}).get("mappings", [])
+    mapped_requirements = set()
+    for mapping in mappings:
+        req = mapping.get("requirement", "")
+        if req:
+            mapped_requirements.add(req)
+
+    unmapped = all_requirements - mapped_requirements
+    if unmapped:
+        for req in sorted(unmapped):
+            click.echo(f"❌ traceability: PRD requirement '{req}' not mapped to any SDD component")
+        click.echo(f"   {len(unmapped)} unmapped requirement(s)")
+        return False
+
+    click.echo(f"✅ traceability: {len(all_requirements)} requirements mapped to SDD components")
+    return True
 
 
 def _list_schemas(target: Path) -> list:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -346,6 +346,169 @@ class TestFullElicitationFlow:
         assert result.exit_code == 0
         assert "valid" in result.output
 
+    def test_sdd_traceability_verification_passes(self, runner, project):
+        """Validate SDD with complete PRD→SDD traceability passes."""
+        runner.invoke(main, ["init", "-d", str(project)])
+
+        prd = {
+            "vision": "Vehicle management module for Odoo v18.",
+            "stakeholders": [
+                {"name": "Admin", "role": "Manager", "interest": "Vehicle tracking"}
+            ],
+            "objectives": ["Track vehicles"],
+            "functional_requirements": [
+                {"id": "RF-01", "description": "CRUD vehicle records", "priority": "high"},
+                {"id": "RF-02", "description": "Search by plate", "priority": "medium"},
+            ],
+            "non_functional_requirements": [
+                {"id": "RNF-01", "description": "Search under 2 seconds", "category": "performance", "priority": "high"},
+            ],
+            "acceptance_criteria": [
+                {"id": "CA-01", "criterion": "User creates vehicle in under 1 minute", "related_requirements": ["RF-01"]}
+            ],
+            "glossary": [{"term": "CRUD", "definition": "Create Read Update Delete"}]
+        }
+        (project / ".factory" / "prd.json").write_text(json.dumps(prd, indent=2))
+
+        sdd = {
+            "module_name": "vehicle_registry",
+            "module_display_name": "Vehicle Registry",
+            "version": "18.0.1.0.0",
+            "architecture": {"description": "Simple vehicle management module"},
+            "models": [{
+                "name": "vehicle.registry",
+                "display_name": "Vehicle",
+                "description": "Main vehicle model",
+                "fields": [{
+                    "name": "plate", "type": "char", "display_name": "Plate",
+                    "description": "License plate number",
+                    "traceability": ["RF-01"]
+                }],
+                "traceability": ["RF-01", "RF-02"]
+            }],
+            "views": [{
+                "model": "vehicle.registry", "type": "form", "name": "vehicle.form",
+                "description": "Vehicle form view", "fields": ["plate"],
+                "traceability": ["RF-01"]
+            }],
+            "security": {
+                "groups": [{
+                    "name": "vehicle_user", "display_name": "Vehicle User",
+                    "description": "Basic vehicle access"
+                }],
+                "access_rights": [{
+                    "model": "vehicle.registry", "group": "vehicle_user",
+                    "perm_read": True, "perm_write": True,
+                    "perm_create": True, "perm_unlink": False
+                }]
+            },
+            "dependencies": {"required": ["base"]},
+            "file_structure": {
+                "module": "vehicle_registry",
+                "files": ["__manifest__.py"]
+            },
+            "traceability_matrix": {
+                "mappings": [
+                    {
+                        "requirement": "RF-01",
+                        "sdD_components": ["vehicle.registry model", "vehicle.form view"],
+                        "description": "CRUD vehicle records"
+                    },
+                    {
+                        "requirement": "RF-02",
+                        "sdD_components": ["vehicle.registry model"],
+                        "description": "Search by plate"
+                    },
+                    {
+                        "requirement": "RNF-01",
+                        "sdD_components": ["security section"],
+                        "description": "Performance requirement"
+                    }
+                ]
+            }
+        }
+        (project / ".factory" / "sdd.json").write_text(json.dumps(sdd, indent=2))
+
+        result = runner.invoke(main, ["validate", "sdd", "-d", str(project)])
+        assert result.exit_code == 0
+        assert "3 requirements mapped" in result.output
+
+    def test_sdd_traceability_verification_fails_on_unmapped(self, runner, project):
+        """Validate SDD fails traceability check when requirements not mapped."""
+        runner.invoke(main, ["init", "-d", str(project)])
+
+        prd = {
+            "vision": "Vehicle management module for Odoo v18.",
+            "stakeholders": [
+                {"name": "Admin", "role": "Manager", "interest": "Vehicle tracking"}
+            ],
+            "objectives": ["Track vehicles"],
+            "functional_requirements": [
+                {"id": "RF-01", "description": "CRUD vehicle records", "priority": "high"},
+                {"id": "RF-02", "description": "Search by plate", "priority": "medium"},
+            ],
+            "non_functional_requirements": [],
+            "acceptance_criteria": [
+                {"id": "CA-01", "criterion": "User creates vehicle", "related_requirements": ["RF-01"]}
+            ],
+            "glossary": [{"term": "CRUD", "definition": "Create Read Update Delete"}]
+        }
+        (project / ".factory" / "prd.json").write_text(json.dumps(prd, indent=2))
+
+        sdd = {
+            "module_name": "vehicle_registry",
+            "module_display_name": "Vehicle Registry",
+            "version": "18.0.1.0.0",
+            "architecture": {"description": "Simple vehicle management module"},
+            "models": [{
+                "name": "vehicle.registry",
+                "display_name": "Vehicle",
+                "description": "Main vehicle model",
+                "fields": [{
+                    "name": "plate", "type": "char", "display_name": "Plate",
+                    "description": "License plate number",
+                    "traceability": ["RF-01"]
+                }],
+                "traceability": ["RF-01"]
+            }],
+            "views": [{
+                "model": "vehicle.registry", "type": "form", "name": "vehicle.form",
+                "description": "Vehicle form view", "fields": ["plate"],
+                "traceability": ["RF-01"]
+            }],
+            "security": {
+                "groups": [{
+                    "name": "vehicle_user", "display_name": "Vehicle User",
+                    "description": "Basic vehicle access"
+                }],
+                "access_rights": [{
+                    "model": "vehicle.registry", "group": "vehicle_user",
+                    "perm_read": True, "perm_write": True,
+                    "perm_create": True, "perm_unlink": False
+                }]
+            },
+            "dependencies": {"required": ["base"]},
+            "file_structure": {
+                "module": "vehicle_registry",
+                "files": ["__manifest__.py"]
+            },
+            "traceability_matrix": {
+                "mappings": [
+                    {
+                        "requirement": "RF-01",
+                        "sdD_components": ["vehicle.registry model"],
+                        "description": "CRUD vehicle records"
+                    }
+                ]
+            }
+        }
+        (project / ".factory" / "sdd.json").write_text(json.dumps(sdd, indent=2))
+
+        result = runner.invoke(main, ["validate", "sdd", "-d", str(project)])
+        assert result.exit_code == 1
+        assert "not mapped" in result.output
+        assert "RF-02" in result.output
+
     def test_complete_m1_flow(self, runner, project):
         """End-to-end simulation of the M1 flow: elicit -> specify."""
         _create_elicitation_context(project)


### PR DESCRIPTION
## Summary
- Agrega `_check_traceability()` que verifica que todos los RFs y RNFs del PRD estan mapeados en la traceability_matrix del SDD
- Se ejecuta automaticamente al correr `fba validate sdd` si `prd.json` existe
- Reporta requisitos no mapeados con IDs especificos (ej: "RF-02 no mapeado")
- 2 tests de integracion: traceability completa (pasa) y traceability incompleta (falla)
- Total: 171 tests pasando
- Closes #38