### PR TITLE
feat(#54): Validacion semantica de artefactos en sistema de gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,16 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/).
   - Slash commands `fba:specify` y `fba:plan` actualizados con paso `fba gate` antes de transicion (#51)
   - 43 tests unitarios e integracion del sistema de gates (#52)
   - `docs/testing/m4-gates.md` con 11 pasos de verificacion manual (#53)
-  - Total: 218 tests
+  - Validacion semantica de artefactos: nueva regla `semantic_check` en gates (#54)
+    - `src/fba/gate.py`: `_check_semantic()` empaqueta datos para evaluacion LLM con `requires_agent: true`
+    - `RuleResult.requires_agent` y `GateResult.pending_agent_checks` para detectar reglas que requieren agente
+    - `state.schema.json`: nuevo tipo `semantic_check` con `source_path`, `target_path`, `dimensions`
+    - CLI `fba gate`: output con `⏳` para reglas pending y contador de `pending agent evaluation(s)`
+    - Agente `validador_semantico.md`: evalua 5 dimensiones (dominio, objetivos, terminologia, stakeholders, requisitos)
+    - Slash command `/fba:semantic-check` con ciclo de correccion en sesiones nuevas
+    - Orquestador y Revisor de Artefactos detectan `pending_agent_checks` y delegan al validador
+    - Correcciones delegadas al agente dueno en sesion fresca sin task_id
+  - Total: 231 tests
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -164,7 +164,7 @@ El sistema de gates es declarativo: las reglas de validacion se definen en
 ### Tareas
 
 - [x] Modulo `src/fba/gate.py`: GateRunner con definiciones de gates declarativas
-  - Gate por fase: schema, content, traceability, cross-artifact
+  - Gate por fase: schema, content, traceability, cross-artifact, semantic_check
   - Resultado estructurado con mensajes de error descriptivos
   - Carga de reglas desde `state.json`
 - [x] Integrar gates en `StateManager.transition_to()`: bloquea transicion si gate falla
@@ -174,11 +174,15 @@ El sistema de gates es declarativo: las reglas de validacion se definen en
   - Verifica coherencia cross-artifact (ej. trazabilidad PRD→SDD)
   - Genera reporte de validacion
   - Soporta ciclo: generar → validar → fallo → corregir → revalidar
-- [x] Slash command `/fba:gate`
-- [x] Actualizar orquestador: flujo incluye validacion de gates en cada transicion
+- [x] Sub-agente Validador Semantico (`validador_semantico.md`)
+  - Valida alineacion semantica de artefactos contra la solicitud original
+  - Evalua 5 dimensiones: dominio, objetivos, terminologia, stakeholders, requisitos
+  - Correcciones delegadas al agente dueno en sesion fresca (sin task_id)
+- [x] Slash commands `/fba:gate` y `/fba:semantic-check`
+- [x] Actualizar orquestador: flujo incluye validacion de gates + semantica en cada transicion
 - [x] Actualizar slash commands existentes: cada comando ejecuta `fba validate` + gate check
-- [x] Actualizar `state.schema.json` con seccion `gates`
-- [x] Tests unitarios + integracion de gates
+- [x] Actualizar `state.schema.json` con seccion `gates` y rule types `semantic_check`
+- [x] Tests unitarios + integracion de gates (incluyendo semantic_check)
 - [x] Guia de testing: `docs/testing/m4-gates.md`
 
 ### Verificacion
@@ -207,6 +211,7 @@ Orquestador (fase actual, validacion, transiciones)
 ├── Documentador (PRD + SDD)
 ├── Planificador (arquitectura Odoo)
 ├── Revisor de Artefactos (gates + validacion cross-artifact)
+├── Validador Semantico (alineacion semantica contra solicitud original)
 ├── Constructor (generacion de codigo)
 ├── Tester/QA (pruebas)
 ├── Revisor de Codigo (calidad + seguridad)

--- a/docs/testing/m4-gates.md
+++ b/docs/testing/m4-gates.md
@@ -39,8 +39,8 @@ Debe mostrar:
 ```
 Gates defined: ['elicitation', 'documentation', 'planning']
   elicitation: 2 rules, owner=elicitador
-  documentation: 3 rules, owner=documentador
-  planning: 4 rules, owner=planificador
+  documentation: 4 rules, owner=documentador
+  planning: 5 rules, owner=planificador
 ```
 
 ### 2. Verificar que `fba gate` diagnostica fase actual
@@ -129,9 +129,80 @@ fba gate -d /tmp/test-m4
    ✅ elicitation_content_minimum: All content checks passed
 ```
 
-### 6. Transicion con `--force`
+Nota: La fase `elicitation` no tiene reglas `semantic_check`, por lo que no muestra `⏳ pending`.
 
-**Objetivo**: `--force` permite saltar el gate.
+### 6. Verificar gate de documentacion con PRD (incluye semantic_check)
+
+**Objetivo**: Verificar que el gate `documentation` incluye la regla `semantic_check` como pending.
+
+**Comandos**:
+```bash
+# Crear un PRD valido para pasar los gates estructurales
+cat > /tmp/test-m4/.factory/prd.json << 'EOF'
+{
+  "vision": "Sistema de gestion de inventario en bodega",
+  "stakeholders": [{"name": "Admin", "role": "Administrador", "interest": "Gestion total"}],
+  "objectives": ["Control de stock en tiempo real"],
+  "functional_requirements": [
+    {"id": "RF-01", "description": "CRUD de productos con stock", "priority": "high",
+     "acceptance_criteria": ["Crear producto en < 1 min"]}
+  ],
+  "non_functional_requirements": [
+    {"id": "RNF-01", "description": "Tiempo de respuesta < 2 segundos", "category": "performance", "priority": "high"}
+  ],
+  "acceptance_criteria": [{"id": "CA-01", "criterion": "Usuario crea producto en < 1 min", "related_requirements": ["RF-01"]}],
+  "glossary": [{"term": "SKU", "definition": "Stock Keeping Unit"}]
+}
+EOF
+
+cat > /tmp/test-m4/.factory/prd.md << 'EOF'
+# PRD - Sistema de Inventario
+EOF
+
+fba transition documentation -d /tmp/test-m4 --force
+fba gate documentation -d /tmp/test-m4
+```
+
+**Resultado esperado**:
+```
+✅ Gate: documentation
+   Validates that PRD is complete and schema-valid
+   ✅ prd_json_exists: Artifact exists: .factory/prd.json
+   ✅ prd_md_exists: Artifact exists: .factory/prd.md
+   ✅ prd_schema_valid: Schema validation passed: .factory/prd.json
+   ⏳ prd_semantic_relevance: Semantic check pending: comparing .factory/context/elicitation.json → .factory/prd.json across 5 dimensions — requires agent evaluation
+   ⏳ 1 pending agent evaluation(s)
+```
+
+### 7. Verificar agente Validador Semantico
+
+**Objetivo**: El agente validador_semantico existe en las plantillas.
+
+**Comando**:
+```bash
+ls /tmp/test-m4/.opencode/agents/validador_semantico.md
+```
+
+**Resultado esperado**: El archivo existe.
+
+### 8. Verificar slash command `/fba:semantic-check`
+
+**Objetivo**: El comando slash existe en las plantillas.
+
+**Comando**:
+```bash
+head -5 /tmp/test-m4/.opencode/commands/fba:semantic-check.md
+```
+
+**Resultado esperado**:
+```
+---
+description: Run semantic validation on project artifacts to verify relevance against original request
+agent: validador_semantico
+---
+```
+
+### 9. Transicion con `--force`
 
 **Comandos**:
 ```bash
@@ -148,9 +219,9 @@ Transitioned to 'documentation'
 ⚠️  Gate validation was skipped (--force)
 ```
 
-### 7. Verificar gate de documentacion
+### 10. Verificar gate de documentacion (sin PRD)
 
-**Objetivo**: El gate `documentation` valida PRD.
+**Objetivo**: El gate `documentation` valida PRD cuando no hay PRD generado.
 
 **Comandos**:
 ```bash
@@ -165,7 +236,7 @@ fba gate documentation -d /tmp/test-m4
    ...
 ```
 
-### 8. Verificar `fba gate --all`
+### 11. Verificar `fba gate --all`
 
 **Objetivo**: El flag `--all` muestra todos los gates definidos.
 
@@ -176,7 +247,7 @@ fba gate --all -d /tmp/test-m4
 
 **Resultado esperado**: Muestra gates de `elicitation`, `documentation`, y `planning` con sus estados.
 
-### 9. Verificar agente Revisor de Artefactos
+### 12. Verificar agente Revisor de Artefactos
 
 **Objetivo**: El agente existe en las plantillas.
 
@@ -187,7 +258,7 @@ ls /tmp/test-m4/.opencode/agents/revisor_artefactos.md
 
 **Resultado esperado**: El archivo existe.
 
-### 10. Verificar slash command `/fba:gate`
+### 13. Verificar slash command `/fba:gate`
 
 **Objetivo**: El comando slash existe en las plantillas.
 
@@ -204,7 +275,7 @@ agent: revisor_artefactos
 ---
 ```
 
-### 11. Limits
+### 14. Limpieza
 
 **Objetivo**: Limpiar.
 
@@ -233,6 +304,15 @@ Ejecutar `fba update` en el proyecto para copiar las plantillas mas recientes:
 ```bash
 fba update -d <project-dir>
 ```
+
+### `fba gate` muestra ⏳ pending pero no se ejecuta la validacion semantica
+
+El simbolo `⏳` indica que la regla `semantic_check` requiere evaluacion LLM
+desde un agente. No se resuelve desde la CLI — el orquestador o el Revisor de
+Artefactos deben invocar al `validador_semantico` via `task` tool.
+
+Para probar manualmente que la regla existe, verificar que `state.json` contiene
+reglas de tipo `semantic_check` en los gates de `documentation` y `planning`:
 
 ### Tests fallan en test_gate.py
 

--- a/schemas/state.schema.json
+++ b/schemas/state.schema.json
@@ -143,7 +143,7 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["schema", "artifact_exists", "traceability", "content_check"],
+                  "enum": ["schema", "artifact_exists", "traceability", "content_check", "semantic_check"],
                   "description": "Rule evaluation type"
                 },
                 "rule_name": {
@@ -170,6 +170,19 @@
                   "type": "object",
                   "description": "Content checks mapping (for content_check rule type)",
                   "additionalProperties": {"type": "integer"}
+                },
+                "source_path": {
+                  "type": "string",
+                  "description": "Path to the source artifact for comparison (for semantic_check rule type)"
+                },
+                "target_path": {
+                  "type": "string",
+                  "description": "Path to the target artifact to validate (for semantic_check rule type)"
+                },
+                "dimensions": {
+                  "type": "array",
+                  "description": "Semantic dimensions to evaluate (for semantic_check rule type)",
+                  "items": {"type": "string"}
                 }
               }
             }

--- a/src/fba/cli.py
+++ b/src/fba/cli.py
@@ -191,6 +191,19 @@ def _init_factory_state(target: Path):
                         "schema": "prd.schema.json",
                         "path": ".factory/prd.json",
                     },
+                    {
+                        "type": "semantic_check",
+                        "rule_name": "prd_semantic_relevance",
+                        "source_path": ".factory/context/elicitation.json",
+                        "target_path": ".factory/prd.json",
+                        "dimensions": [
+                            "domain_consistency",
+                            "objective_alignment",
+                            "terminology_match",
+                            "stakeholder_relevance",
+                            "requirement_relevance",
+                        ],
+                    },
                 ],
             },
             "planning": {
@@ -218,6 +231,19 @@ def _init_factory_state(target: Path):
                         "rule_name": "prd_sdd_traceability",
                         "prd_path": ".factory/prd.json",
                         "sdd_path": ".factory/sdd.json",
+                    },
+                    {
+                        "type": "semantic_check",
+                        "rule_name": "sdd_semantic_relevance",
+                        "source_path": ".factory/context/elicitation.json",
+                        "target_path": ".factory/sdd.json",
+                        "dimensions": [
+                            "domain_consistency",
+                            "objective_alignment",
+                            "terminology_match",
+                            "stakeholder_relevance",
+                            "requirement_relevance",
+                        ],
                     },
                 ],
             },
@@ -359,13 +385,19 @@ def gate(phase, all_gates, project_dir):
             click.echo("   (no rules defined)")
 
         for r in result.results:
-            rs = "✅" if r.passed else "❌"
+            if r.requires_agent:
+                rs = "⏳"
+            else:
+                rs = "✅" if r.passed else "❌"
             click.echo(f"   {rs} {r.rule}: {r.message}")
 
         if result.failures:
             click.echo(f"   Owner agent: {result.owner_agent}")
             click.echo(f"   {result.error_count} failure(s)")
             all_passed = False
+
+        if result.pending_agent_checks:
+            click.echo(f"   ⏳ {len(result.pending_agent_checks)} pending agent evaluation(s)")
         click.echo("")
 
     if not all_passed:

--- a/src/fba/gate.py
+++ b/src/fba/gate.py
@@ -9,6 +9,7 @@ class RuleResult:
     rule: str
     message: str = ""
     details: dict = field(default_factory=dict)
+    requires_agent: bool = False
 
     def to_dict(self):
         return {
@@ -16,6 +17,7 @@ class RuleResult:
             "rule": self.rule,
             "message": self.message,
             "details": self.details,
+            "requires_agent": self.requires_agent,
         }
 
 
@@ -35,6 +37,10 @@ class GateResult:
     def error_count(self):
         return len(self.failures)
 
+    @property
+    def pending_agent_checks(self):
+        return [r for r in self.results if r.requires_agent]
+
     def to_dict(self):
         return {
             "passed": self.passed,
@@ -43,6 +49,7 @@ class GateResult:
             "owner_agent": self.owner_agent,
             "results": [r.to_dict() for r in self.results],
             "error_count": self.error_count,
+            "pending_agent_checks": len(self.pending_agent_checks),
         }
 
 
@@ -115,6 +122,8 @@ class GateRunner:
             return self._check_traceability(rule)
         elif rule_type == "content_check":
             return self._check_content(rule)
+        elif rule_type == "semantic_check":
+            return self._check_semantic(rule)
         else:
             return RuleResult(
                 passed=False,
@@ -345,6 +354,120 @@ class GateRunner:
             rule=rule_name,
             message="All content checks passed",
             details={"path": path_str, "checks_passed": len(checks)},
+        )
+
+    def _check_semantic(self, rule: dict) -> RuleResult:
+        rule_name = rule.get("rule_name", "semantic_check")
+        source_path_str = rule.get("source_path", "")
+        target_path_str = rule.get("target_path", "")
+        dimensions = rule.get("dimensions", [
+            "domain_consistency",
+            "objective_alignment",
+            "terminology_match",
+            "stakeholder_relevance",
+            "requirement_relevance",
+        ])
+
+        source_path = self._resolve_path(source_path_str)
+        if not source_path.exists():
+            return RuleResult(
+                passed=True,
+                rule=rule_name,
+                message=f"Semantic check deferred: source artifact not found ({source_path_str})",
+                details={"source_path": source_path_str, "target_path": target_path_str},
+                requires_agent=False,
+            )
+
+        target_path = self._resolve_path(target_path_str)
+        if not target_path.exists():
+            return RuleResult(
+                passed=True,
+                rule=rule_name,
+                message=f"Semantic check deferred: target artifact not found ({target_path_str})",
+                details={"source_path": source_path_str, "target_path": target_path_str},
+                requires_agent=False,
+            )
+
+        try:
+            source_data = json.loads(source_path.read_text())
+        except json.JSONDecodeError as e:
+            return RuleResult(
+                passed=True,
+                rule=rule_name,
+                message=f"Semantic check deferred: invalid JSON in source ({source_path_str}): {e}",
+                details={"source_path": source_path_str, "target_path": target_path_str},
+                requires_agent=False,
+            )
+
+        try:
+            target_data = json.loads(target_path.read_text())
+        except json.JSONDecodeError as e:
+            return RuleResult(
+                passed=True,
+                rule=rule_name,
+                message=f"Semantic check deferred: invalid JSON in target ({target_path_str}): {e}",
+                details={"source_path": source_path_str, "target_path": target_path_str},
+                requires_agent=False,
+            )
+
+        eval_data = {
+            "source_path": source_path_str,
+            "target_path": target_path_str,
+            "dimensions": dimensions,
+            "source_snapshot": {
+                "initial_description": source_data.get("initial_description", ""),
+                "business_context": source_data.get("business_context", ""),
+                "objectives": source_data.get("objectives", [])[:10],
+                "stakeholders": [
+                    {"name": s.get("name", ""), "role": s.get("role", ""), "interest": s.get("interest", "")}
+                    for s in source_data.get("stakeholders", [])[:10]
+                ],
+                "functional_requirements": [
+                    {"id": r["id"], "description": r.get("description", "")}
+                    for r in source_data.get("functional_requirements", [])[:20]
+                ],
+                "non_functional_requirements": [
+                    {"id": r["id"], "description": r.get("description", ""), "category": r.get("category", "")}
+                    for r in source_data.get("non_functional_requirements", [])[:10]
+                ],
+                "glossary": [
+                    {"term": g.get("term", ""), "definition": g.get("definition", "")}
+                    for g in source_data.get("glossary", [])[:10]
+                ],
+            },
+            "target_snapshot": {
+                "vision": target_data.get("vision", ""),
+                "module_name": target_data.get("module_name", ""),
+                "module_display_name": target_data.get("module_display_name", ""),
+                "summary": target_data.get("summary", ""),
+                "objectives": target_data.get("objectives", [])[:10],
+                "stakeholders": [
+                    {"name": s.get("name", ""), "role": s.get("role", ""), "interest": s.get("interest", "")}
+                    for s in target_data.get("stakeholders", [])[:10]
+                ],
+                "functional_requirements": [
+                    {"id": r["id"], "description": r.get("description", ""), "priority": r.get("priority", "")}
+                    for r in target_data.get("functional_requirements", [])[:20]
+                ],
+                "non_functional_requirements": [
+                    {"id": r["id"], "description": r.get("description", ""), "category": r.get("category", "")}
+                    for r in target_data.get("non_functional_requirements", [])[:10]
+                ],
+                "glossary": [
+                    {"term": g.get("term", ""), "definition": g.get("definition", "")}
+                    for g in target_data.get("glossary", [])[:10]
+                ],
+                "constraints": target_data.get("constraints", [])[:10],
+                "dependencies": target_data.get("dependencies", {}) if isinstance(target_data.get("dependencies"), dict) else target_data.get("dependencies", [])[:10],
+            },
+        }
+
+        return RuleResult(
+            passed=True,
+            rule=rule_name,
+            message=f"Semantic check pending: comparing {source_path_str} → {target_path_str} across {len(dimensions)} dimensions — requires agent evaluation",
+            details={"eval_data": eval_data},
+            requires_agent=True,
         )
 
     def _find_schema(self, schema_name: str) -> Path | None:

--- a/templates/.opencode/agents/orchestrator.md
+++ b/templates/.opencode/agents/orchestrator.md
@@ -21,15 +21,22 @@ the development lifecycle of an Odoo v18 module.
 
 ## Phase Flow
 ```
-/fba:init --> /fba:elicit --> /fba:gate --> /fba:specify --> /fba:gate
-                                                                     |
-/fba:plan --> /fba:gate --> /fba:tasks --> /fba:gate --> /fba:build   |
-                                                                      |
-/fba:ship <-- /fba:review <-- /fba:test <-- /fba:gate <--------------+
+/fba:init --> /fba:elicit --> /fba:gate --> /fba:semantic-check
+                                              |                |
+                                              v                v
+                                        /fba:specify --> /fba:gate --> /fba:semantic-check
+                                                                              |
+                                                                              v
+/fba:plan --> /fba:gate --> /fba:semantic-check --> /fba:tasks --> /fba:gate
+                                                                              |
+                                                                              v
+/fba:build --> /fba:gate --> /fba:test --> /fba:review --> /fba:ship
 ```
 
 Each phase transition is gated: artifacts must pass `fba gate` before the
-next phase can begin.
+next phase can begin. For phases that produce semantic content (documentation,
+planning), gate validation includes semantic checks that must be resolved
+by the validador_semantico agent.
 
 ## Phases Reference
 
@@ -40,6 +47,7 @@ next phase can begin.
 | documentation | documentador | /fba:specify | context/elicitation.json | prd.json, prd.md | documentation |
 | planning | planificador | /fba:plan | prd.md | sdd.md, plan.md | planning |
 | gate | revisor_artefactos | /fba:gate | current artifacts | gate_report.json | - |
+| semantic | validador_semantico | /fba:semantic-check | elicitation.json, prd.json or sdd.json | semantic_report.json | - |
 | tasks | planificador | /fba:tasks | sdd.md, plan.md | tasks.md | tasks |
 | construction | constructor | /fba:build | sdd.md, tasks.md | odoo_module/ | construction |
 | testing | tester | /fba:test | odoo_module/ | test_report.md | testing |
@@ -129,11 +137,27 @@ After completing any phase (except `ci_cd`), you MUST follow this protocol:
    ```bash
    fba gate
    ```
-   - If gates pass: proceed to step 3.
-   - If gates fail: invoke the Revisor de Artefactos sub-agent via
-     `/fba:gate` to diagnose and offer the correction cycle.
+   - If gates pass AND `pending_agent_checks` is 0: proceed to step 3.
+   - If gates fail (structural): invoke the Revisor de Artefactos sub-agent
+     via `/fba:gate` to diagnose and offer the correction cycle.
      Do NOT offer progression until all gates pass or the user
      explicitly authorizes `--force`.
+   - If gates pass BUT `pending_agent_checks` > 0: semantic checks are
+     pending. Invoke the Validador Semantico sub-agent:
+     ```
+     task(
+       description="Validacion semantica para <phase>",
+       prompt="Run /fba:semantic-check for the current phase <phase>. Read
+         .factory/state.json to find the semantic_check rule, read the
+         source and target artifacts, evaluate all dimensions, generate
+         semantic_report.json, and present results with correction options.",
+       subagent_type="general"
+     )
+     ```
+     DO NOT pass task_id — this must be a fresh session.
+     After the validador completes, re-check: if semantic passes,
+     proceed to step 3; if fails, the validador will handle the
+     correction cycle with the owning agent (also in fresh sessions).
 
 3. **Ask the user** using the `question` tool:
    - Header: `"Fase completada: <phase_name>"`
@@ -147,7 +171,8 @@ After completing any phase (except `ci_cd`), you MUST follow this protocol:
    - Read the next slash command from `.opencode/commands/` to get the
      agent name and instructions.
    - Invoke the appropriate sub-agent using the `task` tool with the
-     command's instructions as the task prompt.
+     command's instructions as the task prompt. **Do NOT pass task_id**
+     — each sub-agent invocation must be a fresh session.
    - Display the sub-agent's result to the user.
    - After the sub-agent completes, repeat this protocol for the new phase.
 
@@ -173,6 +198,7 @@ See `.opencode/commands/` for full documentation of each slash command.
 - `/fba:init` -- Initialize project structure
 - `/fba:elicit` -- Elicit requirements (interactive, uses question tool)
 - `/fba:gate` -- Run gate validation and diagnostics
+- `/fba:semantic-check` -- Run LLM-based semantic validation on artifacts
 - `/fba:specify` -- Generate PRD
 - `/fba:plan` -- Generate SDD and technical plan
 - `/fba:tasks` -- Create task list

--- a/templates/.opencode/agents/revisor_artefactos.md
+++ b/templates/.opencode/agents/revisor_artefactos.md
@@ -55,6 +55,9 @@ least one SDD component in the traceability matrix.
 Read `.factory/state.json` to identify the current phase.
 - If a specific phase is requested, validate that phase's gates.
 - Otherwise, validate gates for the current phase.
+- If the gate definition includes `semantic_check` rules, semantic
+  validation will be needed. After structural validation passes,
+  the validador_semantico agent must be invoked in a fresh session.
 
 ### 2. Run Gate Validation
 Execute the gate system for the relevant phase:
@@ -63,6 +66,30 @@ fba gate <phase>
 ```
 
 Parse the output to identify which rules passed or failed.
+
+If any rule has `requires_agent: true` (semantic_check), the structural
+validation passed but semantic validation is pending. Skip to Step 2b.
+
+### 2b. Handle Semantic Checks
+
+If the gate results include `pending_agent_checks > 0`:
+
+1. The validador_semantico agent must evaluate the semantic alignment.
+2. Invoke it using the `task` tool **without task_id** (fresh session):
+   ```
+   task(
+     description="Validacion semantica para <phase>",
+     prompt="Run /fba:semantic-check for phase <phase>. Read state.json
+       to find the semantic_check rule, read elicitation.json and the
+       target artifact, evaluate all dimensions, generate
+       semantic_report.json, and present results with correction options
+       following the validador_semantico agent procedure.",
+     subagent_type="general"
+   )
+   ```
+3. After completion, check the result. If the semantic check passed,
+   proceed normally. If it failed, the validador's correction cycle
+   handles re-invoking the owning agent (also in fresh sessions).
 
 ### 3. Run Schema Validation
 ```bash
@@ -136,9 +163,12 @@ If the user selects **C**:
 ## Important Rules
 
 1. Always run `fba gate` BEFORE `fba validate` to get structured gate results.
-2. Never modify artifacts directly — delegate corrections to the owning sub-agent.
-3. Always present results with clear pass/fail indicators per rule.
-4. When invoking a sub-agent for correction, pass the full list of validation
+2. If gate results include `pending_agent_checks > 0`, delegate semantic
+   validation to the validador_semantico agent in a fresh session (no task_id).
+3. Never modify artifacts directly — delegate corrections to the owning sub-agent
+   in a FRESH session (no task_id).
+4. Always present results with clear pass/fail indicators per rule.
+5. When invoking a sub-agent for correction, pass the full list of validation
    errors as context so the sub-agent knows exactly what needs fixing.
-5. After correction, re-run ALL validation steps to ensure no new issues
+6. After correction, re-run ALL validation steps to ensure no new issues
    were introduced.

--- a/templates/.opencode/agents/validador_semantico.md
+++ b/templates/.opencode/agents/validador_semantico.md
@@ -1,0 +1,208 @@
+---
+description: Validates generated artifacts (PRD, SDD) for semantic relevance against the original module request using LLM-based evaluation. Checks domain consistency, objective alignment, terminology, stakeholder relevance, and requirement relevance.
+mode: subagent
+permission:
+  read: allow
+  bash: allow
+  glob: allow
+  grep: allow
+  question: allow
+---
+
+You are the FBA Validador Semantico. Your role is to validate that generated
+artifacts (PRD, SDD) are semantically relevant to the original module
+request — not just structurally correct.
+
+## Mission
+
+Verify that the content of generated artifacts (vision, objectives,
+requirements, stakeholders, glossary) corresponds to the business domain
+and intent captured during elicitation. Structural artifacts can pass
+schema validation while describing a completely different module. You
+prevent that.
+
+## Input
+
+- `.factory/state.json` — current phase and gate definitions (find the
+  `semantic_check` rule for the current phase)
+- `.factory/context/elicitation.json` — original module request (ground truth)
+- `.factory/prd.json` or `.factory/sdd.json` — generated artifact to validate
+
+## Output
+
+- `.factory/semantic_report.json` — structured validation report
+
+## Procedure
+
+### 1. Identify the Semantic Check Rule
+
+Read `.factory/state.json` and locate the `semantic_check` rule for the
+current phase. Extract:
+- `source_path`: the elicitation artifact (ground truth)
+- `target_path`: the artifact to validate (prd.json or sdd.json)
+- `dimensions`: which semantic dimensions to evaluate
+
+### 2. Read Source and Target Artifacts
+
+Read both files to understand:
+- **Source** (elicitation.json): initial_description, business_context,
+  objectives, stakeholders, functional_requirements, non_functional_requirements,
+  glossary
+- **Target** (prd.json or sdd.json): vision, objectives, stakeholders,
+  functional_requirements, non_functional_requirements, glossary, module_name,
+  summary
+
+### 3. Evaluate Each Dimension
+
+For each dimension in the rule's `dimensions` list, evaluate semantic
+alignment between source and target:
+
+#### domain_consistency
+Does the target describe the same Odoo business domain as the source?
+- Compare `initial_description` + `business_context` (source) against
+  `vision` + `module_name` + `summary` (target)
+- Classify the domain from source: inventory, sales, HR, fleet, accounting,
+  project, quality, maintenance, etc.
+- Classify the domain from target: do they match?
+- If the target describes fleet when source describes inventory → FAIL
+
+#### objective_alignment
+Do the target objectives address the source's business context and objectives?
+- Compare `objectives` arrays between source and target
+- Each source objective should have at least one corresponding target
+  objective that addresses it
+- Objectives don't need to be identical, but the intent must align
+
+#### terminology_match
+Does the target glossary use terminology consistent with the domain?
+- Compare `glossary` terms between source and target
+- Target should not introduce glossary terms from a different domain
+- If source glossary has "SKU, stock, warehouse" and target has
+  "vehicle, plate, driver" → FAIL
+
+#### stakeholder_relevance
+Are the target stakeholders appropriate for the described domain?
+- Compare `stakeholders` between source and target
+- Target stakeholders should map to source stakeholder roles
+- If source describes warehouse operators and target lists drivers → FAIL
+
+#### requirement_relevance
+Do the target functional/non-functional requirements address the problem?
+- Compare `functional_requirements` and `non_functional_requirements`
+  between source and target
+- Each RF/RNF in the target should plausibly relate to at least one
+  source requirement or objective
+- Target should not introduce requirements from an entirely different domain
+
+### 4. Generate the Report
+
+Create `.factory/semantic_report.json`:
+
+```json
+{
+  "phase": "<current_phase>",
+  "timestamp": "<ISO8601>",
+  "source": ".factory/context/elicitation.json",
+  "target": ".factory/prd.json",
+  "overall_passed": true,
+  "dimensions": [
+    {
+      "name": "domain_consistency",
+      "passed": true,
+      "explanation": "Both source and target describe inventory management domain"
+    },
+    {
+      "name": "objective_alignment",
+      "passed": true,
+      "explanation": "Target objectives cover stock control and traceability from source"
+    }
+  ],
+  "summary": "5/5 dimensions passed. Target artifact is semantically aligned with source.",
+  "recommendations": []
+}
+```
+
+If any dimension fails, `overall_passed` is `false`. The `summary` should
+state clearly what failed and why. `recommendations` should provide
+actionable correction guidance.
+
+### 5. Present Results
+
+Display results using the `question` tool:
+
+- **Header**: `"Validacion Semantica: <phase>"`
+- **Question**: `"Resultado: <X>/<Y> dimensiones pasaron. ¿Como procedemos?"`
+- **Options**:
+  - A) "Corregir artefacto (re-invocar agente dueno)" (Recommended if failures)
+  - B) "Revisar reporte detallado"
+  - C) "Continuar sin corregir (usar --force)"
+
+### 6. Handle Correction
+
+If the user selects **A**:
+
+1. Read the `owner_agent` from the gate definition in `state.json["gates"][<phase>]`
+2. Read the agent definition from `.opencode/agents/<owner_agent>.md`
+3. Read the slash command from `.opencode/commands/fba:<command>.md`
+4. Prepare a task prompt that includes:
+   - The agent's original instructions
+   - The source data (elicitation.json content)
+   - The specific failing dimensions and explanations from the semantic report
+   - The exact files that need correction
+5. Invoke the owning sub-agent using the `task` tool —
+   **DO NOT pass task_id** — this starts a fresh session with clean context:
+   ```
+   task(
+     description="Corregir <artifact> para alineacion semantica",
+     prompt="<detailed correction instructions>",
+     subagent_type="general"
+   )
+   ```
+6. After the sub-agent completes, re-run the gate validation:
+   ```bash
+   fba gate <phase>
+   ```
+7. Re-run yourself (read the new target artifact and re-evaluate dimensions)
+8. Present updated results
+
+If the user selects **B**:
+- Display the full contents of `.factory/semantic_report.json`
+- Ask again
+
+If the user selects **C**:
+- Warn: "Saltar validacion semantica puede causar que el modulo generado
+  no corresponda a lo solicitado"
+- If user confirms, record the bypass:
+  ```bash
+  fba record semantic_bypassed --data '{"phase":"<phase>","reason":"user_requested"}'
+  ```
+
+## Correction Cycle
+
+```
+┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+│  generate    │────▶│  validate    │────▶│  report      │
+│  (sub-agent) │     │  (gate)      │     │  (diagnose)  │
+└──────────────┘     └──────────────┘     └──────────────┘
+       ▲                                        │
+       │              ┌──────────────┐          │ fail
+       └──────────────│  correct     │◀─────────┘
+                      │  (owner agent│
+                      │   fresh sess)│
+                      └──────────────┘
+```
+
+## Important Rules
+
+1. Always run `fba gate <phase>` before starting to get structured gate results.
+2. Focus on semantic meaning, not structural validity — the schema gate
+   already handles structure.
+3. Use domain classification explicitly: state what domain the source
+   describes and what domain the target describes.
+4. Corrections are always delegated to the owning agent in a FRESH session
+   (no task_id) — never modify artifacts yourself.
+5. After correction, re-run ALL validation steps to confirm no new issues.
+6. Record the semantic validation result as an event:
+   ```bash
+   fba record semantic_validation --data '{"phase":"<phase>","passed":true,"dimensions":<N>}'
+   ```

--- a/templates/.opencode/commands/fba:gate.md
+++ b/templates/.opencode/commands/fba:gate.md
@@ -36,6 +36,27 @@ Or to check all defined gates:
 fba gate --all
 ```
 
+### 2b. Check for Pending Semantic Validation
+
+After running gate validation, check the output for `⏳` rules.
+These are `semantic_check` rules that require LLM-based evaluation
+by the validador_semantico agent.
+
+If `pending agent evaluation(s)` appears in the output, invoke the
+validador_semantico agent in a FRESH session (no task_id):
+```
+task(
+  description="Validacion semantica para <phase>",
+  prompt="Run /fba:semantic-check for phase <phase>. The validador_semantico
+    agent will read elicitation.json and the target artifact, evaluate all
+    semantic dimensions, generate semantic_report.json, and present results.",
+  subagent_type="general"
+)
+```
+
+After semantic validation completes, re-run `fba gate` to confirm all
+checks pass (both structural and semantic).
+
 ### 3. Run Schema Validation
 Execute full artifact schema validation:
 ```bash
@@ -45,7 +66,8 @@ fba validate
 ### 4. Diagnose Failures
 For each failed rule, identify:
 - Which artifact has the issue
-- What the issue is (missing field, invalid format, missing traceability)
+- What the issue is (missing field, invalid format, missing traceability,
+  semantic misalignment)
 - Which agent should fix it (`owner_agent` from the gate definition)
 
 ### 5. Generate Validation Report
@@ -65,6 +87,7 @@ Create `.factory/gate_report.json` with:
     "prd": {"passed": true, "errors": []},
     "sdd": {"passed": true, "errors": []}
   },
+  "semantic_pending": true/false,
   "recommendations": [
     "actionable suggestion 1",
     "actionable suggestion 2"
@@ -74,26 +97,30 @@ Create `.factory/gate_report.json` with:
 
 ### 6. Present Results and Offer Correction
 Follow the **Procedure** from `.opencode/agents/revisor_artefactos.md`
-(Step 6: Present results and offer correction cycle).
+(Step 2b for semantic checks, Step 6 for structural correction).
 
 Display a summary:
 - Phase validated
-- Number of gates checked
+- Number of gates checked (structural + semantic pending)
 - Number passed / failed
 - Each failure with its message and owning agent
+- If semantic checks are pending, indicate `⏳` and invoke validador_semantico
 
 Then present the options (correct / review / skip) using the
 revisor_artefactos agent's correction cycle protocol.
 
 ### 7. Handle Correction
 If the user chooses to correct:
-- Extract validation errors
-- Invoke the owning sub-agent with the errors as context
+- **Structural failures**: extract validation errors, invoke the owning
+  sub-agent with the errors as context in a FRESH session (no task_id).
+- **Semantic failures**: the validador_semantico handles this — it reads
+  the semantic errors from semantic_report.json, invokes the owning agent
+  in a fresh session to correct the artifact, and re-runs validation.
 - After correction completes, re-run `fba gate` and `fba validate`
 - Present updated results
 
-If all gates pass, report success and suggest transitioning to the
-next phase.
+If all gates pass (structural + semantic), report success and suggest
+transitioning to the next phase.
 
 ## Post-conditions
 - `.factory/gate_report.json` exists with current validation results.
@@ -102,6 +129,8 @@ next phase.
 - The project is ready for phase transition (if all gates passed).
 
 ## Example Output
+
+All gates passing (structural only, no semantic checks pending):
 
 ```
 🔍 Gate Validation: documentation
@@ -119,6 +148,22 @@ next phase.
 > - A) Continuar a la siguiente fase (planning)
 > - B) Revisar reporte detallado
 > - C) Quiero hacer cambios en esta fase
+```
+
+All passing with pending semantic check:
+
+```
+🔍 Gate Validation: documentation
+   ✅ prd_json_exists: Artifact exists: .factory/prd.json
+   ✅ prd_md_exists: Artifact exists: .factory/prd.md
+   ✅ prd_schema_valid: Schema validation passed: .factory/prd.json
+   ⏳ prd_semantic_relevance: Semantic check pending: comparing .factory/context/elicitation.json → .factory/prd.json across 5 dimensions — requires agent evaluation
+
+   Result: 3/3 structural passed
+   ⏳ 1 pending agent evaluation(s)
+   Owner agent: documentador
+
+> [Invokes validador_semantico in fresh session via task tool]
 ```
 
 If gates fail:

--- a/templates/.opencode/commands/fba:semantic-check.md
+++ b/templates/.opencode/commands/fba:semantic-check.md
@@ -1,0 +1,134 @@
+---
+description: Run semantic validation on project artifacts to verify relevance against original request
+agent: validador_semantico
+---
+
+# fba:semantic-check
+
+Run LLM-based semantic validation to verify that generated artifacts (PRD, SDD)
+correspond to the original module request, not just structurally correct.
+
+## Pre-conditions
+- `.factory/state.json` must exist with a valid current phase.
+- `.factory/context/elicitation.json` must exist (the ground truth).
+- The current phase must have a `semantic_check` gate rule defined in
+  `state.json["gates"]`.
+- The target artifact (prd.json or sdd.json) must exist.
+
+## Steps
+
+### 1. Identify the Semantic Check Context
+Read `.factory/state.json` to determine:
+- `current_phase`: documentation, planning, or any phase with semantic_check
+- `gates[<phase>].rules`: find the `semantic_check` rule with source_path and target_path
+
+### 2. Read Artifacts
+- Read `.factory/context/elicitation.json` (source of truth)
+- Read the target artifact (`.factory/prd.json` or `.factory/sdd.json`)
+
+### 3. Evaluate Semantic Dimensions
+For each dimension in the rule's `dimensions` array, assess whether the target
+artifact is semantically aligned with the source:
+
+| Dimension | What it checks |
+|-----------|---------------|
+| `domain_consistency` | Does the target describe the same Odoo domain? |
+| `objective_alignment` | Do objectives address the business context? |
+| `terminology_match` | Is glossary terminology consistent with domain? |
+| `stakeholder_relevance` | Are stakeholders appropriate for the domain? |
+| `requirement_relevance` | Do requirements address the requested problem? |
+
+### 4. Generate semantic_report.json
+Create `.factory/semantic_report.json` with structured results:
+```json
+{
+  "phase": "<current_phase>",
+  "timestamp": "<ISO8601>",
+  "source": ".factory/context/elicitation.json",
+  "target": ".factory/prd.json",
+  "overall_passed": true,
+  "dimensions": [
+    {
+      "name": "domain_consistency",
+      "passed": true,
+      "explanation": "..."
+    }
+  ],
+  "summary": "...",
+  "recommendations": []
+}
+```
+
+### 5. Present Results
+Follow the **Procedure** from `.opencode/agents/validador_semantico.md`
+(Step 5: Present results and offer correction).
+
+Display a summary:
+- Phase validated
+- Number of dimensions checked
+- Number passed / failed
+- Each failure with its dimension and explanation
+
+Then present options using the `question` tool:
+- A) Corregir artefacto (re-invocar agente dueno en sesion nueva)
+- B) Revisar reporte detallado
+- C) Continuar sin corregir (usar --force)
+
+### 6. Handle Correction
+If the user chooses to correct:
+- Read the `owner_agent` from the failing gate definition
+- Prepare a task prompt with the original agent instructions and specific
+  semantic errors as correction context
+- Invoke the owning sub-agent via `task` tool **without task_id** (fresh session)
+- Re-run validation after correction completes
+- Present updated results
+
+## Post-conditions
+- `.factory/semantic_report.json` exists with current validation results.
+- All semantic dimensions are passing, OR the user has acknowledged
+  the failures and chosen to bypass.
+- The project is semantically validated for the current phase.
+
+## Example Output
+
+```
+🔍 Semantic Validation: documentation
+
+   Dimensions evaluated:
+     ✅ domain_consistency: Both source and target describe inventory
+     ✅ objective_alignment: Target objectives cover all source objectives
+     ✅ terminology_match: Glossary terms consistent with inventory domain
+     ✅ stakeholder_relevance: Stakeholders map to warehouse roles
+     ✅ requirement_relevance: All RFs address inventory operations
+
+   Result: 5/5 passed
+
+> [Uses question tool]
+> Header: "Validacion Semantica: documentation"
+> Q: "Resultado: 5/5 dimensiones pasaron. ¿Como procedemos?"
+> - A) Continuar a la siguiente fase
+> - B) Revisar reporte detallado
+> - C) Quiero hacer cambios en esta fase
+```
+
+If validation fails:
+
+```
+🔍 Semantic Validation: documentation
+
+   Dimensions evaluated:
+     ❌ domain_consistency: Source describes inventory, target describes fleet
+     ❌ terminology_match: Target uses "vehicle, driver" instead of "stock, warehouse"
+     ✅ objective_alignment: Objectives are aligned
+     ❌ stakeholder_relevance: Target lists "chofer" instead of warehouse operators
+     ✅ requirement_relevance: Requirements are generic CRUD, applicable
+
+   Result: 2/5 passed — 3 failure(s)
+
+> [Uses question tool]
+> Header: "Validacion Semantica: documentation"
+> Q: "Resultado: 2/5 dimensiones pasaron. ¿Como procedemos?"
+> - A) Corregir artefacto (re-invocar documentador en sesion nueva)
+> - B) Revisar reporte detallado
+> - C) Continuar sin corregir (usar --force)
+```

--- a/tests/test_agent_definitions.py
+++ b/tests/test_agent_definitions.py
@@ -35,7 +35,7 @@ def _load_all_agents():
     return agents
 
 
-EXPECTED_AGENTS = {"elicitador", "documentador", "orchestrator", "planificador", "revisor_artefactos"}
+EXPECTED_AGENTS = {"elicitador", "documentador", "orchestrator", "planificador", "revisor_artefactos", "validador_semantico"}
 
 
 class TestAgentDefinitionsExist:

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -101,6 +101,16 @@ class TestRuleResult:
         for key in ["passed", "rule", "message", "details"]:
             assert key in d
 
+    def test_requires_agent_default_false(self):
+        r = RuleResult(passed=True, rule="test")
+        assert r.requires_agent is False
+        assert r.to_dict()["requires_agent"] is False
+
+    def test_requires_agent_true(self):
+        r = RuleResult(passed=True, rule="semantic", requires_agent=True)
+        assert r.requires_agent is True
+        assert r.to_dict()["requires_agent"] is True
+
 
 class TestGateResult:
     def test_all_passed(self):
@@ -137,6 +147,31 @@ class TestGateResult:
         assert gr.passed is True
         assert gr.error_count == 0
         assert gr.failures == []
+
+    def test_pending_agent_checks_empty(self):
+        results = [
+            RuleResult(passed=True, rule="r1", message="ok"),
+            RuleResult(passed=True, rule="r2", message="ok"),
+        ]
+        gr = GateResult(passed=True, phase="test", results=results)
+        assert gr.pending_agent_checks == []
+
+    def test_pending_agent_checks_with_semantic(self):
+        results = [
+            RuleResult(passed=True, rule="r1", message="ok"),
+            RuleResult(passed=True, rule="semantic", requires_agent=True, message="pending"),
+        ]
+        gr = GateResult(passed=True, phase="test", results=results)
+        assert len(gr.pending_agent_checks) == 1
+        assert gr.pending_agent_checks[0].rule == "semantic"
+
+    def test_to_dict_includes_pending_agent_checks(self):
+        results = [
+            RuleResult(passed=True, rule="semantic", requires_agent=True),
+        ]
+        gr = GateResult(passed=True, phase="test", results=results)
+        d = gr.to_dict()
+        assert d["pending_agent_checks"] == 1
 
 
 class TestGateError:
@@ -602,3 +637,323 @@ class TestGateRunnerMissingFactory:
         result = runner.check_current_phase()
         assert result.passed is True
         assert result.phase == "init"
+
+
+class TestGateRunnerSemanticCheck:
+    def setup_semantic_state(self, tmp_path):
+        factory = tmp_path / ".factory"
+        factory.mkdir(parents=True)
+
+        schemas_dir = factory / "schemas"
+        schemas_dir.mkdir()
+
+        context_dir = factory / "context"
+        context_dir.mkdir()
+
+        state = {
+            "project": "test",
+            "current_phase": "documentation",
+            "methodology": "BABOK",
+            "phases": {
+                "documentation": {"status": "in_progress", "agent": "documentador"},
+            },
+            "valid_transitions": {},
+            "gates": {
+                "documentation": {
+                    "description": "Semantic validation gate",
+                    "owner_agent": "documentador",
+                    "rules": [
+                        {
+                            "type": "semantic_check",
+                            "rule_name": "prd_semantic_check",
+                            "source_path": ".factory/context/elicitation.json",
+                            "target_path": ".factory/prd.json",
+                            "dimensions": [
+                                "domain_consistency",
+                                "objective_alignment",
+                            ],
+                        },
+                    ],
+                },
+            },
+            "artifacts": {},
+        }
+        (factory / "state.json").write_text(json.dumps(state, indent=2))
+        return tmp_path
+
+    def test_semantic_check_does_not_block(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            from pathlib import Path as P
+            d = self.setup_semantic_state(P(tmp))
+
+            elicitation = {
+                "initial_description": "modulo de inventario",
+                "business_context": "gestion de stock",
+                "objectives": ["control de inventario"],
+                "stakeholders": [{"name": "admin", "role": "admin", "interest": "gestión"}],
+                "functional_requirements": [{"id": "RF-01", "description": "CRUD productos"}],
+                "non_functional_requirements": [{"id": "RNF-01", "description": "rendimiento", "category": "performance"}],
+                "glossary": [{"term": "stock", "definition": "inventario"}],
+            }
+            (d / ".factory" / "context" / "elicitation.json").write_text(json.dumps(elicitation))
+
+            prd = {
+                "vision": "gestion de flota vehicular",
+                "objectives": ["registro vehiculos"],
+                "stakeholders": [{"name": "chofer", "role": "conductor", "interest": "gestion flota"}],
+                "functional_requirements": [{"id": "RF-01", "description": "CRUD vehiculos", "priority": "high"}],
+                "non_functional_requirements": [{"id": "RNF-01", "description": "seguridad acceso", "category": "security"}],
+                "glossary": [{"term": "vehiculo", "definition": "unidad de flota"}],
+            }
+            (d / ".factory" / "prd.json").write_text(json.dumps(prd))
+
+            runner = GateRunner(d)
+            result = runner.check_phase("documentation")
+
+            assert result.passed is True
+            assert result.results[0].passed is True
+            assert result.results[0].requires_agent is True
+
+    def test_semantic_check_packages_eval_data(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            from pathlib import Path as P
+            d = self.setup_semantic_state(P(tmp))
+
+            elicitation = {
+                "initial_description": "modulo de inventario",
+                "business_context": "gestion de stock en almacen",
+                "objectives": ["control de inventario", "trazabilidad"],
+                "stakeholders": [
+                    {"name": "admin", "role": "administrador", "interest": "gestion total"},
+                    {"name": "operador", "role": "bodeguero", "interest": "registro entradas"},
+                ],
+                "functional_requirements": [
+                    {"id": "RF-01", "description": "CRUD de productos con stock"},
+                    {"id": "RF-02", "description": "registro de movimientos"},
+                ],
+                "non_functional_requirements": [
+                    {"id": "RNF-01", "description": "tiempo respuesta < 2s", "category": "performance"},
+                ],
+                "glossary": [
+                    {"term": "SKU", "definition": "Stock Keeping Unit"},
+                ],
+            }
+            (d / ".factory" / "context" / "elicitation.json").write_text(json.dumps(elicitation))
+
+            prd = {
+                "vision": "sistema de gestion de inventario",
+                "objectives": ["control stock"],
+                "stakeholders": [{"name": "admin", "role": "admin", "interest": "control"}],
+                "functional_requirements": [{"id": "RF-01", "description": "CRUD productos", "priority": "high"}],
+                "non_functional_requirements": [{"id": "RNF-01", "description": "rendimiento", "category": "performance"}],
+                "glossary": [{"term": "inventario", "definition": "conjunto de productos"}],
+                "constraints": ["solo Odoo Community"],
+                "dependencies": {"required": ["base"], "optional": ["mail"]},
+            }
+            (d / ".factory" / "prd.json").write_text(json.dumps(prd))
+
+            runner = GateRunner(d)
+            result = runner.check_phase("documentation")
+
+            eval_data = result.results[0].details["eval_data"]
+            assert eval_data["source_path"] == ".factory/context/elicitation.json"
+            assert eval_data["target_path"] == ".factory/prd.json"
+            assert eval_data["dimensions"] == ["domain_consistency", "objective_alignment"]
+
+            assert eval_data["source_snapshot"]["initial_description"] == "modulo de inventario"
+            assert eval_data["source_snapshot"]["business_context"] == "gestion de stock en almacen"
+            assert len(eval_data["source_snapshot"]["objectives"]) == 2
+            assert len(eval_data["source_snapshot"]["stakeholders"]) == 2
+
+            assert eval_data["target_snapshot"]["vision"] == "sistema de gestion de inventario"
+            assert len(eval_data["target_snapshot"]["functional_requirements"]) == 1
+            assert eval_data["target_snapshot"]["constraints"] == ["solo Odoo Community"]
+            assert eval_data["target_snapshot"]["dependencies"]["required"] == ["base"]
+
+    def test_semantic_check_missing_source(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            from pathlib import Path as P
+            d = self.setup_semantic_state(P(tmp))
+
+            prd = {"vision": "test", "objectives": ["test"]}
+            (d / ".factory" / "prd.json").write_text(json.dumps(prd))
+
+            runner = GateRunner(d)
+            result = runner.check_phase("documentation")
+
+            assert result.passed is True
+            assert result.results[0].passed is True
+            assert result.results[0].requires_agent is False
+            assert "not found" in result.results[0].message
+
+    def test_semantic_check_missing_target(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            from pathlib import Path as P
+            d = self.setup_semantic_state(P(tmp))
+
+            elicitation = {"initial_description": "modulo X", "business_context": "test"}
+            (d / ".factory" / "context" / "elicitation.json").write_text(json.dumps(elicitation))
+
+            runner = GateRunner(d)
+            result = runner.check_phase("documentation")
+
+            assert result.passed is True
+            assert result.results[0].passed is True
+            assert result.results[0].requires_agent is False
+            assert "not found" in result.results[0].message
+
+    def test_semantic_check_invalid_json(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            from pathlib import Path as P
+            d = self.setup_semantic_state(P(tmp))
+
+            (d / ".factory" / "context" / "elicitation.json").write_text("not valid json")
+            (d / ".factory" / "prd.json").write_text("also not json")
+
+            runner = GateRunner(d)
+            result = runner.check_phase("documentation")
+
+            assert result.passed is True
+            assert result.results[0].passed is True
+            assert result.results[0].requires_agent is False
+            assert "invalid json" in result.results[0].message.lower()
+
+    def test_semantic_check_default_dimensions(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            from pathlib import Path as P
+            d = P(tmp)
+            factory = d / ".factory"
+            factory.mkdir(parents=True)
+
+            context_dir = factory / "context"
+            context_dir.mkdir()
+
+            elicitation = {
+                "initial_description": "modulo de prueba",
+                "business_context": "testing",
+            }
+            (context_dir / "elicitation.json").write_text(json.dumps(elicitation))
+
+            prd = {"vision": "test"}
+            (factory / "prd.json").write_text(json.dumps(prd))
+
+            state = {
+                "project": "test",
+                "current_phase": "docs",
+                "methodology": "BABOK",
+                "phases": {},
+                "valid_transitions": {},
+                "gates": {
+                    "docs": {
+                        "description": "t",
+                        "owner_agent": "d",
+                        "rules": [{
+                            "type": "semantic_check",
+                            "rule_name": "check",
+                            "source_path": ".factory/context/elicitation.json",
+                            "target_path": ".factory/prd.json",
+                        }],
+                    },
+                },
+                "artifacts": {},
+            }
+            (factory / "state.json").write_text(json.dumps(state))
+
+            runner = GateRunner(d)
+            result = runner.check_phase("docs")
+
+            eval_data = result.results[0].details["eval_data"]
+            assert len(eval_data["dimensions"]) == 5
+            assert "domain_consistency" in eval_data["dimensions"]
+
+
+class TestCLIGateSemanticCheck:
+    def setup_semantic_cli_state(self, tmp_path):
+        factory = tmp_path / ".factory"
+        factory.mkdir(parents=True)
+
+        context_dir = factory / "context"
+        context_dir.mkdir()
+
+        elicitation = {
+            "initial_description": "modulo de inventario",
+            "business_context": "gestion stock",
+            "objectives": ["control inventario"],
+            "stakeholders": [{"name": "admin", "role": "admin", "interest": "gestion"}],
+            "functional_requirements": [{"id": "RF-01", "description": "CRUD productos"}],
+            "non_functional_requirements": [{"id": "RNF-01", "description": "rendimiento", "category": "performance"}],
+            "glossary": [{"term": "SKU", "definition": "codigo producto"}],
+        }
+        (context_dir / "elicitation.json").write_text(json.dumps(elicitation))
+
+        prd = {
+            "vision": "gestion inventario",
+            "objectives": ["control stock"],
+            "stakeholders": [{"name": "admin", "role": "admin", "interest": "control"}],
+            "functional_requirements": [{"id": "RF-01", "description": "CRUD productos", "priority": "high"}],
+            "non_functional_requirements": [{"id": "RNF-01", "description": "rendimiento", "category": "performance"}],
+            "glossary": [{"term": "inventario", "definition": "conjunto productos"}],
+        }
+        (factory / "prd.json").write_text(json.dumps(prd))
+
+        state = {
+            "project": "test",
+            "current_phase": "documentation",
+            "methodology": "BABOK",
+            "phases": {
+                "documentation": {"status": "in_progress", "agent": "documentador"},
+            },
+            "valid_transitions": {},
+            "gates": {
+                "documentation": {
+                    "description": "Documentation gate with semantic check",
+                    "owner_agent": "documentador",
+                    "rules": [
+                        {"type": "artifact_exists", "rule_name": "prd_exists", "path": ".factory/prd.json"},
+                        {
+                            "type": "semantic_check",
+                            "rule_name": "prd_semantic",
+                            "source_path": ".factory/context/elicitation.json",
+                            "target_path": ".factory/prd.json",
+                            "dimensions": ["domain_consistency"],
+                        },
+                    ],
+                },
+            },
+            "artifacts": {},
+        }
+        (factory / "state.json").write_text(json.dumps(state, indent=2))
+        return tmp_path
+
+    def test_cli_gate_shows_pending_semantic(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            from pathlib import Path as P
+            d = self.setup_semantic_cli_state(P(tmp))
+
+            runner_cli = CliRunner()
+            result = runner_cli.invoke(main, ["gate", "documentation", "-d", str(d)])
+
+            assert result.exit_code == 0
+            assert "⏳" in result.output
+            assert "prd_semantic" in result.output
+            assert "pending agent evaluation" in result.output
+
+    def test_cli_gate_semantic_does_not_fail_passed_gate(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            from pathlib import Path as P
+            d = self.setup_semantic_cli_state(P(tmp))
+
+            runner_cli = CliRunner()
+            result = runner_cli.invoke(main, ["gate", "documentation", "-d", str(d)])
+
+            assert result.exit_code == 0
+            assert "✅ Gate:" in result.output
+            assert "pending" in result.output


### PR DESCRIPTION
## Summary

- Nueva regla `semantic_check` en el sistema de gates: empaqueta datos de elicitation.json y target para evaluacion LLM
- `RuleResult.requires_agent` y `GateResult.pending_agent_checks` para detectar reglas que requieren agente
- Agente `validador_semantico`: evalua 5 dimensiones semanticas (dominio, objetivos, terminologia, stakeholders, requisitos)
- Slash command `/fba:semantic-check` con ciclo de correccion en sesiones nuevas sin task_id
- Orchestrator y Revisor de Artefactos actualizados: detectan `pending_agent_checks`, delegan al validador
- 14 tests nuevos + 235 totales pasando
- Docs actualizados: CHANGELOG, ROADMAP, docs/testing/m4-gates.md

Closes #54