### PR TITLE
chore(#57): bump pyproject.toml version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fba"
-version = "0.1.0"
+version = "0.4.0"
 description = "Factory Build Agent - Multi-agent development framework for Odoo v18 modules"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml` version from `0.1.0` to `0.4.0` to match CHANGELOG

Closes #57