### PR TITLE
feat(#64): Rediseño del sistema de tasks — archivos separados por task

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -112,7 +112,7 @@ especifico para Odoo v18 con trazabilidad completa.
 construccion -> pruebas -> revision -> CI/CD, produciendo un modulo Odoo v18
 instalable y funcional de "Registro de Vehiculos" (CRUD con modelo + vistas).
 
-M3 se divide en 4 sub-milestones secuenciales para facilitar la implementacion
+M3 se divide en 5 sub-milestones secuenciales para facilitar la implementacion
 incremental. Cada sub-milestone es un deliverable independiente y demostrable.
 
 ### Branching
@@ -120,13 +120,32 @@ incremental. Cada sub-milestone es un deliverable independiente y demostrable.
 ```
 main
   └── milestone/3.0-construccion-mvp        ← creado desde main
+        ├── feat/3.0a-task-files            ← desde milestone/3.0 (sistema de tasks rediseñado)
         ├── feat/3.1-constructor-core        ← desde milestone/3.0
         ├── feat/3.2-constructor-completo    ← desde milestone/3.0 (mergea M3.1 a M3.0 primero)
         ├── feat/3.3-tester-reviewer         ← desde milestone/3.0 (mergea M3.2 a M3.0 primero)
         └── feat/3.4-cicd-e2e               ← desde milestone/3.0 (mergea M3.3 a M3.0 primero)
 ```
 
-Flujo: `feat/3.1 → PR → merge a milestone/3.0 → feat/3.2 → PR → merge a milestone/3.0 → ...`
+Flujo: `feat/3.0a → PR → merge a milestone/3.0 → feat/3.1 → PR → merge a milestone/3.0 → ...`
+
+---
+
+### M3.0a: Task System Redesign — Archivos por Task
+**Objetivo**: Rediseñar el sistema de tasks para generar un archivo por task
+en lugar de un solo `tasks.md`, permitiendo construccion iterativa con commits
+por task.
+
+**Entregables**:
+- [x] Schema `task_index.schema.json` y `task_item.schema.json`
+- [x] Gate `tasks` con rule type `task_files_exist`
+- [x] Comando `/fba:tasks` actualizado: genera `index.json` + `T*.json`
+- [x] Comando `/fba:build` rediseñado: flujo iterativo task-por-task con sesiones frescas
+- [x] Orquestador actualizado con nueva tabla de fases
+- [x] Tests unitarios del nuevo sistema de tasks
+- [x] Documentacion de testing: `docs/testing/m3-tasks-files.md`
+
+**Depende de**: M2 (SDD + plan)
 
 ---
 
@@ -142,7 +161,7 @@ Odoo v18 funcionales con campos y relaciones.
 - [ ] Tests unitarios del constructor y del gate construction
 - [ ] Prueba manual: modulo minimo instalable en Odoo v18
 
-**Depende de**: SDD valido + tasks.md (fase `tasks`)
+**Depende de**: SDD valido + tasks/index.json (fase `tasks`)
 
 ---
 

--- a/docs/testing/m3-tasks-files.md
+++ b/docs/testing/m3-tasks-files.md
@@ -1,0 +1,290 @@
+# Testing - M3.0a: Task System Redesign (Archivos por Task)
+
+## Requisitos Previos
+
+- Python 3.11 o superior
+- pip actualizado
+- El repositorio clonado y en el directorio raiz
+- `fba` instalado: `pip install -e ".[dev]"`
+
+## Pasos para Probar
+
+### 1. Verificar que `fba init` incluye el gate `tasks`
+
+**Objetivo**: Confirmar que el estado inicial contiene el nuevo gate `tasks` con 4 reglas.
+
+**Comando**:
+```bash
+mkdir -p /tmp/test-m3a && fba init -d /tmp/test-m3a
+python3 -c "
+import json
+state = json.load(open('/tmp/test-m3a/.factory/state.json'))
+gate = state['gates']['tasks']
+print(f'Owner: {gate[\"owner_agent\"]}')
+print(f'Rules: {len(gate[\"rules\"])}')
+for r in gate['rules']:
+    print(f'  - {r[\"type\"]}: {r[\"rule_name\"]}')
+"
+```
+
+**Resultado esperado**:
+```
+Owner: planificador
+Rules: 4
+  - artifact_exists: task_index_exists
+  - schema: task_index_schema_valid
+  - content_check: task_index_content_minimum
+  - task_files_exist: all_task_files_exist
+```
+
+---
+
+### 2. Validar schemas de tasks
+
+**Objetivo**: Probar que los schemas `task_index.schema.json` y `task_item.schema.json` son validos y detectan errores.
+
+**Comando**:
+```bash
+python3 -c "
+import json, jsonschema
+from pathlib import Path
+
+schemas_dir = Path('schemas')
+
+# Valid index
+index_schema = json.loads((schemas_dir / 'task_index.schema.json').read_text())
+valid_index = {
+    'module_name': 'test_module',
+    'total_tasks': 1,
+    'tasks': [{
+        'id': 'T001', 'name': 'Test', 'file': 'T001-test.json',
+        'dependencies': [], 'order': 1, 'estimated_effort': 'low',
+        'sdd_components': ['models.test']
+    }]
+}
+jsonschema.validate(valid_index, index_schema)
+print('✅ Valid index passes')
+
+# Invalid index: bad ID pattern
+try:
+    invalid = json.loads(json.dumps(valid_index))
+    invalid['tasks'][0]['id'] = '1'
+    jsonschema.validate(invalid, index_schema)
+    print('❌ Should have failed')
+except jsonschema.ValidationError:
+    print('✅ Invalid ID pattern caught')
+
+# Valid task item
+item_schema = json.loads((schemas_dir / 'task_item.schema.json').read_text())
+valid_item = {
+    'id': 'T001', 'name': 'Test', 'description': 'Generate test code.',
+    'components': [{
+        'type': 'model', 'name': 'test.model',
+        'description': 'Test model', 'sdd_reference': 'models.test'
+    }],
+    'files_to_generate': ['models/test.py'],
+    'dependencies': []
+}
+jsonschema.validate(valid_item, item_schema)
+print('✅ Valid item passes')
+"
+```
+
+**Resultado esperado**:
+```
+✅ Valid index passes
+✅ Invalid ID pattern caught
+✅ Valid item passes
+```
+
+---
+
+### 3. Probar el gate `tasks` con archivos validos
+
+**Objetivo**: Verificar que el gate `tasks` pasa cuando todos los archivos existen.
+
+**Comando**:
+```bash
+# Crear archivos de task validos
+mkdir -p /tmp/test-m3a/.factory/tasks
+
+cat > /tmp/test-m3a/.factory/tasks/index.json << 'EOF'
+{
+  "module_name": "test",
+  "total_tasks": 2,
+  "tasks": [
+    {
+      "id": "T001", "name": "Modelos", "file": "T001-modelos.json",
+      "dependencies": [], "order": 1, "estimated_effort": "high",
+      "sdd_components": ["models.test"]
+    },
+    {
+      "id": "T002", "name": "Vistas", "file": "T002-vistas.json",
+      "dependencies": ["T001"], "order": 2, "estimated_effort": "medium",
+      "sdd_components": ["views.form"]
+    }
+  ]
+}
+EOF
+
+cat > /tmp/test-m3a/.factory/tasks/T001-modelos.json << 'EOF'
+{
+  "id": "T001", "name": "Modelos",
+  "description": "Generar modelos Odoo para modulo de prueba.",
+  "components": [{
+    "type": "model", "name": "test.model",
+    "description": "Modelo de prueba", "sdd_reference": "models.test"
+  }],
+  "files_to_generate": ["models/__init__.py", "models/test_model.py"],
+  "dependencies": []
+}
+EOF
+
+cat > /tmp/test-m3a/.factory/tasks/T002-vistas.json << 'EOF'
+{
+  "id": "T002", "name": "Vistas",
+  "description": "Generar vistas XML para modulo de prueba.",
+  "components": [{
+    "type": "view", "name": "test.form",
+    "description": "Formulario de prueba", "view_type": "form",
+    "model": "test.model", "view_fields": ["name"],
+    "sdd_reference": "views.form"
+  }],
+  "files_to_generate": ["views/test_views.xml"],
+  "dependencies": ["T001"]
+}
+EOF
+
+# Actualizar state.json al phase tasks
+python3 -c "
+import json
+state = json.load(open('/tmp/test-m3a/.factory/state.json'))
+state['current_phase'] = 'tasks'
+state['phases']['tasks']['status'] = 'in_progress'
+json.dump(state, open('/tmp/test-m3a/.factory/state.json', 'w'), indent=2)
+"
+
+# Ejecutar gate
+fba gate tasks -d /tmp/test-m3a
+```
+
+**Resultado esperado**:
+```
+✅ Gate: tasks
+   Validates task index and individual task files
+   ✅ task_index_exists: Artifact exists: .factory/tasks/index.json
+   ✅ task_index_schema_valid: Schema validation passed: .factory/tasks/index.json
+   ✅ task_index_content_minimum: All content checks passed
+   ✅ all_task_files_exist: All 2 task files exist and are valid
+```
+
+---
+
+### 4. Probar que el gate bloquea sin archivos
+
+**Objetivo**: Confirmar que `fba transition construction` falla sin los archivos de tasks.
+
+**Comando**:
+```bash
+# En un proyecto sin tasks
+mkdir -p /tmp/test-m3a-block && fba init -d /tmp/test-m3a-block
+
+python3 -c "
+import json
+state = json.load(open('/tmp/test-m3a-block/.factory/state.json'))
+state['current_phase'] = 'tasks'
+state['phases']['tasks']['status'] = 'in_progress'
+json.dump(state, open('/tmp/test-m3a-block/.factory/state.json', 'w'), indent=2)
+"
+
+fba transition construction -d /tmp/test-m3a-block
+echo "Exit code: $?"
+```
+
+**Resultado esperado**:
+```
+❌ Gate 'tasks' failed:
+   - Artifact not found: .factory/tasks/index.json
+Exit code: 1
+```
+
+---
+
+### 5. Probar transicion exitosa con tasks validos
+
+**Objetivo**: Confirmar que la transicion `tasks → construction` funciona cuando los archivos son validos.
+
+**Comando**:
+```bash
+fba transition construction -d /tmp/test-m3a
+cat /tmp/test-m3a/.factory/state.json | python3 -c "import json,sys; s=json.load(sys.stdin); print(f'Current: {s[\"current_phase\"]}'); print(f'Tasks status: {s[\"phases\"][\"tasks\"][\"status\"]}'); print(f'Construction status: {s[\"phases\"][\"construction\"][\"status\"]}')"
+```
+
+**Resultado esperado**:
+```
+Transitioned to 'construction'
+Current: construction
+Tasks status: complete
+Construction status: in_progress
+```
+
+---
+
+### 6. Verificar fba:build.md tiene contenido iterativo
+
+**Objetivo**: Confirmar que el comando build referencia el nuevo flujo.
+
+**Comando**:
+```bash
+grep -E "index.json|Iterative|fresh|git commit" templates/.opencode/commands/fba:build.md
+```
+
+**Resultado esperado**:
+```
+- `.factory/tasks/index.json` exists with a valid task index.
+### 3. Iterative Task Execution
+   Do NOT pass `task_id` — each task must be a fresh session.
+   git add <module_name>/ && git commit -m "feat(#XX): task <id> <name>"
+## Iterative Protocol Rules
+```
+
+---
+
+### 7. Verificar fba:tasks.md genera archivos separados
+
+**Objetivo**: Confirmar que el comando tasks referencia index.json y T*.json.
+
+**Comando**:
+```bash
+grep -E "index.json|T\*\.json|task_index.schema|task_item.schema" templates/.opencode/commands/fba:tasks.md
+```
+
+**Resultado esperado**:
+```
+3. Generate `.factory/tasks/index.json` with:
+4. For each task in the index, generate `.factory/tasks/<file>` as a structured JSON file conforming to `task_item.schema.json`:
+- `.factory/tasks/index.json` exists and is valid against `task_index.schema.json`.
+- All individual `T*.json` task files exist and are valid against `task_item.schema.json`.
+```
+
+---
+
+## Troubleshooting
+
+### `jsonschema.exceptions.ValidationError` en el gate tasks
+
+Si el gate `tasks` falla con errores de schema, verifica que:
+- `task_index.schema.json` y `task_item.schema.json` existen en `.factory/schemas/`
+- `fba init` se ejecuto con la version actualizada del framework
+
+### `Artifact not found` para un archivo T*.json
+
+El gate valida que TODOS los archivos listados en `index.json` (`tasks[].file`) existen en `.factory/tasks/`. Revisa que no haya errores de tipeo en los nombres de archivo.
+
+### Archivos T*.json vacios o JSON invalido
+
+El gate `task_files_exist` valida que cada archivo de task:
+1. Existe
+2. No esta vacio
+3. Es JSON valido
+4. Pasa la validacion del schema `task_item.schema.json`

--- a/schemas/state.schema.json
+++ b/schemas/state.schema.json
@@ -143,7 +143,7 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["schema", "artifact_exists", "traceability", "content_check", "semantic_check"],
+                  "enum": ["schema", "artifact_exists", "traceability", "content_check", "semantic_check", "task_files_exist"],
                   "description": "Rule evaluation type"
                 },
                 "rule_name": {
@@ -183,6 +183,10 @@
                   "type": "array",
                   "description": "Semantic dimensions to evaluate (for semantic_check rule type)",
                   "items": {"type": "string"}
+                },
+                "index_path": {
+                  "type": "string",
+                  "description": "Path to the task index JSON (for task_files_exist rule type)"
                 }
               }
             }

--- a/schemas/task_index.schema.json
+++ b/schemas/task_index.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://opencode.ai/fba/schemas/task_index.schema.json",
+  "title": "Task Index",
+  "description": "Schema for the task index manifest (tasks/index.json). Lists all implementation tasks with metadata and ordering.",
+  "type": "object",
+  "required": [
+    "module_name",
+    "total_tasks",
+    "tasks"
+  ],
+  "properties": {
+    "module_name": {
+      "type": "string",
+      "minLength": 3,
+      "description": "Technical module name this task list applies to."
+    },
+    "total_tasks": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Total number of tasks defined."
+    },
+    "tasks": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Ordered list of implementation tasks.",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "file", "dependencies", "order", "estimated_effort", "sdd_components"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^T\\d{3,}$",
+            "description": "Task identifier (e.g., T001, T002)."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 3,
+            "description": "Short human-readable task name."
+          },
+          "file": {
+            "type": "string",
+            "minLength": 5,
+            "pattern": "^T\\d{3,}-[a-z0-9_-]+\\.json$",
+            "description": "Filename of the individual task definition (e.g., T001-modelos.json)."
+          },
+          "dependencies": {
+            "type": "array",
+            "description": "Task IDs this task depends on.",
+            "items": {
+              "type": "string",
+              "pattern": "^T\\d{3,}$"
+            }
+          },
+          "order": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Execution order (1-based)."
+          },
+          "estimated_effort": {
+            "type": "string",
+            "enum": ["low", "medium", "high"],
+            "description": "Estimated effort level for this task."
+          },
+          "sdd_components": {
+            "type": "array",
+            "minItems": 1,
+            "description": "SDD component references this task implements (e.g., models.vehicle, views.form).",
+            "items": {
+              "type": "string",
+              "minLength": 3
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/task_item.schema.json
+++ b/schemas/task_item.schema.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://opencode.ai/fba/schemas/task_item.schema.json",
+  "title": "Task Item",
+  "description": "Schema for an individual implementation task file (tasks/T*.json). Defines what code to generate for a single task.",
+  "type": "object",
+  "required": [
+    "id",
+    "name",
+    "description",
+    "components",
+    "files_to_generate",
+    "dependencies"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^T\\d{3,}$",
+      "description": "Task identifier matching the index entry (e.g., T001)."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 3,
+      "description": "Short human-readable task name."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 10,
+      "description": "Detailed description of what this task implements."
+    },
+    "components": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Software components to implement in this task.",
+      "items": {
+        "type": "object",
+        "required": ["type", "name", "description", "sdd_reference"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["model", "view", "security_group", "access_right", "record_rule", "data", "report", "workflow", "wizard", "controller"],
+            "description": "Type of Odoo component."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 3,
+            "description": "Technical name of the component (e.g., vehicle.vehicle)."
+          },
+          "description": {
+            "type": "string",
+            "minLength": 5,
+            "description": "Description of the component."
+          },
+          "fields": {
+            "type": "array",
+            "description": "Fields to implement (for models).",
+            "items": {
+              "type": "object",
+              "required": ["name", "type", "label"],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "pattern": "^[a-z][a-z0-9_]*$",
+                  "description": "Field technical name."
+                },
+                "type": {
+                  "type": "string",
+                  "enum": ["Char", "Text", "Integer", "Float", "Boolean", "Date", "Datetime", "Binary", "Selection", "Many2one", "One2many", "Many2many", "Html", "Monetary"],
+                  "description": "Odoo field type."
+                },
+                "label": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Human-readable field label."
+                },
+                "required": {
+                  "type": "boolean",
+                  "description": "Whether this field is required."
+                },
+                "unique": {
+                  "type": "boolean",
+                  "description": "Whether this field must be unique."
+                },
+                "size": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Max size for char fields."
+                },
+                "selection": {
+                  "type": "array",
+                  "description": "Selection options for Selection fields.",
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": {"type": "string"}
+                  }
+                },
+                "relation": {
+                  "type": "string",
+                  "description": "Related model for relational fields."
+                },
+                "compute": {
+                  "type": "string",
+                  "description": "Compute method name for computed fields."
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "view_type": {
+            "type": "string",
+            "enum": ["form", "tree", "search", "kanban", "calendar", "graph", "pivot", "activity"],
+            "description": "Odoo view type (for view components)."
+          },
+          "model": {
+            "type": "string",
+            "minLength": 3,
+            "description": "Target model (for views, security, data)."
+          },
+          "view_fields": {
+            "type": "array",
+            "description": "Fields to display in the view.",
+            "items": {"type": "string", "minLength": 1}
+          },
+          "permissions": {
+            "type": "object",
+            "description": "CRUD permissions (for access rights).",
+            "properties": {
+              "read": {"type": "boolean"},
+              "write": {"type": "boolean"},
+              "create": {"type": "boolean"},
+              "unlink": {"type": "boolean"}
+            },
+            "additionalProperties": false
+          },
+          "sdd_reference": {
+            "type": "string",
+            "minLength": 3,
+            "description": "Reference to the SDD component this implements (e.g., models.vehicle)."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "files_to_generate": {
+      "type": "array",
+      "minItems": 1,
+      "description": "File paths (relative to module root) to generate in this task.",
+      "items": {
+        "type": "string",
+        "minLength": 3,
+        "pattern": "^[a-zA-Z0-9_/.]+$"
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "description": "Task IDs this task depends on (same as in index.json).",
+      "items": {
+        "type": "string",
+        "pattern": "^T\\d{3,}$"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/fba/cli.py
+++ b/src/fba/cli.py
@@ -247,6 +247,34 @@ def _init_factory_state(target: Path):
                     },
                 ],
             },
+            "tasks": {
+                "description": "Validates task index and individual task files",
+                "owner_agent": "planificador",
+                "rules": [
+                    {
+                        "type": "artifact_exists",
+                        "rule_name": "task_index_exists",
+                        "path": ".factory/tasks/index.json",
+                    },
+                    {
+                        "type": "schema",
+                        "rule_name": "task_index_schema_valid",
+                        "schema": "task_index.schema.json",
+                        "path": ".factory/tasks/index.json",
+                    },
+                    {
+                        "type": "content_check",
+                        "rule_name": "task_index_content_minimum",
+                        "path": ".factory/tasks/index.json",
+                        "checks": {"min_tasks": 1},
+                    },
+                    {
+                        "type": "task_files_exist",
+                        "rule_name": "all_task_files_exist",
+                        "index_path": ".factory/tasks/index.json",
+                    },
+                ],
+            },
         },
         "artifacts": {},
         "context": {},

--- a/src/fba/gate.py
+++ b/src/fba/gate.py
@@ -124,6 +124,8 @@ class GateRunner:
             return self._check_content(rule)
         elif rule_type == "semantic_check":
             return self._check_semantic(rule)
+        elif rule_type == "task_files_exist":
+            return self._check_task_files_exist(rule)
         else:
             return RuleResult(
                 passed=False,
@@ -468,6 +470,114 @@ class GateRunner:
             message=f"Semantic check pending: comparing {source_path_str} → {target_path_str} across {len(dimensions)} dimensions — requires agent evaluation",
             details={"eval_data": eval_data},
             requires_agent=True,
+        )
+
+    def _check_task_files_exist(self, rule: dict) -> RuleResult:
+        import jsonschema
+
+        rule_name = rule.get("rule_name", "task_files_exist")
+        index_path_str = rule.get("index_path", "")
+
+        index_path = self._resolve_path(index_path_str)
+        if not index_path.exists():
+            return RuleResult(
+                passed=False,
+                rule=rule_name,
+                message=f"Task index not found: {index_path_str}",
+                details={"index_path": index_path_str},
+            )
+
+        try:
+            index_data = json.loads(index_path.read_text())
+        except json.JSONDecodeError as e:
+            return RuleResult(
+                passed=False,
+                rule=rule_name,
+                message=f"Task index is invalid JSON: {index_path_str} - {e}",
+                details={"index_path": index_path_str},
+            )
+
+        tasks = index_data.get("tasks", [])
+        if not tasks:
+            return RuleResult(
+                passed=False,
+                rule=rule_name,
+                message=f"Task index has no tasks defined: {index_path_str}",
+                details={"index_path": index_path_str},
+            )
+
+        task_item_schema = self._find_schema("task_item.schema.json")
+        missing_files = []
+        invalid_json = []
+        empty_files = []
+        schema_failures = []
+
+        for task_entry in tasks:
+            file_name = task_entry.get("file", "")
+            if not file_name:
+                missing_files.append(f"(no file field for task {task_entry.get('id', 'unknown')})")
+                continue
+
+            task_path = self._factory_dir / "tasks" / file_name
+            if not task_path.exists():
+                missing_files.append(file_name)
+                continue
+
+            try:
+                task_content = task_path.read_text()
+            except Exception as e:
+                missing_files.append(f"{file_name} (read error: {e})")
+                continue
+
+            if not task_content.strip():
+                empty_files.append(file_name)
+                continue
+
+            try:
+                task_data = json.loads(task_content)
+            except json.JSONDecodeError as e:
+                invalid_json.append(f"{file_name}: {e}")
+                continue
+
+            if task_item_schema:
+                try:
+                    schema = json.loads(task_item_schema.read_text())
+                    jsonschema.validate(task_data, schema)
+                except jsonschema.ValidationError as e:
+                    schema_failures.append(f"{file_name}: {e.message}")
+
+        failures = []
+        details = {
+            "index_path": index_path_str,
+            "total_tasks": len(tasks),
+            "missing_files": missing_files,
+            "invalid_json": invalid_json,
+            "empty_files": empty_files,
+            "schema_failures": schema_failures,
+        }
+
+        if missing_files:
+            failures.append(f"Missing task files: {', '.join(missing_files[:5])}")
+        if invalid_json:
+            failures.append(f"Invalid JSON: {', '.join(invalid_json[:5])}")
+        if empty_files:
+            failures.append(f"Empty task files: {', '.join(empty_files[:5])}")
+        if schema_failures:
+            failures.append(f"Schema validation failed: {', '.join(schema_failures[:5])}")
+
+        if failures:
+            return RuleResult(
+                passed=False,
+                rule=rule_name,
+                message="; ".join(failures),
+                details=details,
+            )
+
+        return RuleResult(
+            passed=True,
+            rule=rule_name,
+            message=f"All {len(tasks)} task files exist and are valid",
+            details=details,
         )
 
     def _find_schema(self, schema_name: str) -> Path | None:

--- a/templates/.opencode/agents/orchestrator.md
+++ b/templates/.opencode/agents/orchestrator.md
@@ -48,8 +48,8 @@ by the validador_semantico agent.
 | planning | planificador | /fba:plan | prd.md | sdd.md, plan.md | planning |
 | gate | revisor_artefactos | /fba:gate | current artifacts | gate_report.json | - |
 | semantic | validador_semantico | /fba:semantic-check | elicitation.json, prd.json or sdd.json | semantic_report.json | - |
-| tasks | planificador | /fba:tasks | sdd.md, plan.md | tasks.md | tasks |
-| construction | constructor | /fba:build | sdd.md, tasks.md | odoo_module/ | construction |
+| tasks | planificador | /fba:tasks | sdd.md, plan.md | tasks/index.json, tasks/T*.json | tasks |
+| construction | constructor | /fba:build | sdd.md, tasks/index.json, tasks/T*.json | odoo_module/ | construction |
 | testing | tester | /fba:test | odoo_module/ | test_report.md | testing |
 | review | revisor_codigo | /fba:review | odoo_module/, prd.md, sdd.md | review_report.md | review |
 | ci_cd | cicd_manager | /fba:ship | odoo_module/ | ci_workflow.yml | ci_cd |
@@ -114,7 +114,7 @@ interactive question-asker.
 ## Context Injection
 - When invoking a sub-agent, include relevant context from current artifacts.
 - Include PRD when moving to planning.
-- Include SDD and tasks when moving to construction.
+- Include SDD and tasks/index.json when moving to construction.
 
 ## Current Task
 Read `.factory/state.json`, determine the current phase, validate

--- a/templates/.opencode/commands/fba:build.md
+++ b/templates/.opencode/commands/fba:build.md
@@ -1,31 +1,94 @@
 ---
-description: Generate Odoo v18 module code from SDD and task list
+description: Generate Odoo v18 module code from SDD and individual task files
 agent: constructor
 ---
 
 # fba:build
 
-Generate complete Odoo v18 module source code following the SDD and task list.
+Generate complete Odoo v18 module source code by processing each task
+incrementally. Each task runs in a fresh sub-agent session with a dedicated
+git commit.
 
 ## Pre-conditions
-- `.factory/state.json` must have `current_phase: "tasks"` (or `"planning"`).
-- `.factory/sdd.md` and `.factory/tasks.md` exist.
+- `.factory/state.json` must have `current_phase: "construction"`.
+- `.factory/sdd.md` exists.
+- `.factory/tasks/index.json` exists with a valid task index.
+- All individual task files `.factory/tasks/T*.json` exist.
+- The project has a git repository initialized.
 
 ## Steps
 
-1. Read `.factory/sdd.md` and `.factory/tasks.md`.
-2. Generate the Odoo v18 module directory with:
-   - `__manifest__.py` — module metadata and dependencies
-   - `models/` — Python model classes with fields and methods
-   - `views/` — XML view definitions (tree, form, search, kanban)
-   - `security/` — `ir.model.access.csv` for access control
-   - `data/` — demo data and initial configuration
-3. Update `.factory/state.json`: set `current_phase` to `"construction"`,
-   mark `phases.construction.status` as `"complete"`.
-4. Append a `build_complete` event to `.factory/events.jsonl`.
+### 1. Load Context
+Read `.factory/sdd.md` and `.factory/tasks/index.json`.
+
+### 2. Determine Output Directory
+The Odoo module is created in the project root, named `<module_name>` from
+the SDD. Initialize the module skeleton if it does not already exist:
+- Create `<module_name>/__init__.py`
+- Create `<module_name>/__manifest__.py` based on SDD metadata
+
+### 3. Iterative Task Execution
+For each task in `index.json`, ordered by `order`:
+
+a. **Read the task file** `.factory/tasks/<file>` to get:
+   - `files_to_generate[]` — exact files to create/modify
+   - `components[]` — component specifications (models, views, security, data)
+   - `dependencies[]` — task IDs already completed
+
+b. **Read relevant SDD sections** for this task's `sdd_components[]`.
+   Include only the SDD content relevant to the current task to keep context focused.
+
+c. **Read already-generated code** from the module directory — include a
+   brief summary of existing files and their key structures (models defined,
+   views created, security groups registered). Only include files that are
+   dependencies of the current task.
+
+d. **Invoke a fresh sub-agent session** using the `task` tool:
+   ```
+   task(
+     description="Build task TXXX: <name>",
+     prompt="You are building Odoo v18 module code for task TXXX.
+
+   Context:
+   - Task specification: <summarize task JSON>
+   - SDD sections: <relevant SDD excerpts>
+   - Existing code summary: <brief summary of already-generated files>
+
+   Generate the files listed in files_to_generate[] following Odoo v18
+   conventions. Return which files you created/modified and a brief summary.",
+     subagent_type="general"
+   )
+   ```
+   Do NOT pass `task_id` — each task must be a fresh session.
+
+e. **Commit the generated code**:
+   ```bash
+   git add <module_name>/ && git commit -m "feat(#XX): task <id> <name>"
+   ```
+   Replace `<id>` with the task ID (e.g., T001) and `<name>` with the task name.
+
+f. **Log progress** — append an event to `.factory/events.jsonl`:
+   ```json
+   {"type": "task_built", "data": {"task_id": "<id>", "files_generated": [...], "status": "complete"}}
+   ```
+
+### 4. Finalize
+After all tasks complete:
+- Update `.factory/state.json`: set `phases.construction.status` to `"complete"`.
+  DO NOT change `current_phase` — the orchestrator handles transitions.
+- Append a `build_complete` event to `.factory/events.jsonl`.
+
+## Iterative Protocol Rules
+
+1. **One session per task** — never reuse `task_id` between tasks.
+2. **Context isolation** — each session only receives SDD sections relevant
+   to its task, plus a brief summary of existing code (not full files).
+3. **Ordered execution** — tasks must be processed in `order` sequence.
+   A task with unmet dependencies must wait.
+4. **Per-task commits** — each task gets its own git commit with `feat(#XX): task <id> <name>`.
 
 ## Post-conditions
-- A valid Odoo v18 module directory exists with all required files.
+- A valid Odoo v18 module directory exists with all files from `files_to_generate[]`.
+- One git commit per task in the project repository.
+- `phases.construction.status` is `"complete"`.
 - Ready for `/fba:test`.
-
-> Note: Full code generation is implemented in M3.

--- a/templates/.opencode/commands/fba:tasks.md
+++ b/templates/.opencode/commands/fba:tasks.md
@@ -5,25 +5,48 @@ agent: planificador
 
 # fba:tasks
 
-Decompose the SDD and technical plan into a sequenced list of implementable
-tasks for the construction phase.
+Decompose the SDD and technical plan into a sequenced list of individual
+implementation tasks, each in its own structured JSON file under `.factory/tasks/`.
 
 ## Pre-conditions
-- `.factory/state.json` must have `current_phase: "planning"`.
+- `.factory/state.json` must have `current_phase: "tasks"`.
 - `.factory/sdd.md` and `.factory/plan.md` exist.
 
 ## Steps
 
 1. Read `.factory/sdd.md` and `.factory/plan.md`.
-2. Generate `tasks.md` in `.factory/` with:
-   - Sequenced task list with dependencies
-   - Each task references the SDD component it implements
-   - Estimated effort per task
-3. Update `.factory/state.json`: set `current_phase` to `"tasks"`.
-4. Append a `tasks_complete` event to `.factory/events.jsonl`.
+2. Create `.factory/tasks/` directory.
+3. Generate `.factory/tasks/index.json` with:
+   - `module_name` — from SDD
+   - `total_tasks` — count of tasks
+   - `tasks[]` — ordered list with `id`, `name`, `file`, `dependencies[]`, `order`, `estimated_effort`, `sdd_components[]`
+4. For each task in the index, generate `.factory/tasks/<file>` as a structured JSON file conforming to `task_item.schema.json`:
+   - `id`, `name`, `description`
+   - `components[]` — each with `type`, `name`, `description`, model/view/security-specific fields, `sdd_reference`
+   - `files_to_generate[]` — concrete file paths relative to the Odoo module
+   - `dependencies[]` — task IDs this task depends on
+5. Update `.factory/state.json`: set `phases.tasks.status` to `"complete"`.
+   DO NOT change `current_phase` — the orchestrator handles transitions.
+6. Append a `tasks_complete` event to `.factory/events.jsonl` with:
+   ```json
+   {"type": "tasks_complete", "data": {"total_tasks": <N>, "index": ".factory/tasks/index.json"}}
+   ```
+
+## Output Structure
+
+```
+.factory/tasks/
+├── index.json              # Manifest: task metadata and ordering
+├── T001-modelos.json        # Task: Odoo models
+├── T002-vistas.json         # Task: XML views
+├── T003-seguridad.json      # Task: security (groups, ACL, record rules)
+└── T004-datos-demo.json     # Task: demo data
+```
 
 ## Post-conditions
-- `.factory/tasks.md` exists with a complete implementation sequence.
+- `.factory/tasks/index.json` exists and is valid against `task_index.schema.json`.
+- All individual `T*.json` task files exist and are valid against `task_item.schema.json`.
+- `phases.tasks.status` is `"complete"`.
 - Ready for `/fba:build`.
 
-> Note: Full task decomposition is implemented in M2.
+> Note: The orchestrator runs `fba gate tasks` after this phase to validate the task files.

--- a/tests/test_build_iterative.py
+++ b/tests/test_build_iterative.py
@@ -1,0 +1,265 @@
+"""Tests for the iterative build flow and command files."""
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from fba.cli import main
+from fba.gate import GateError, GateRunner
+from fba.state import StateManager
+
+
+TESTS_DIR = Path(__file__).resolve().parent
+TEMPLATES_DIR = TESTS_DIR.parent / "templates"
+
+
+class TestBuildCommandFrontmatter:
+    def test_build_command_exists(self):
+        cmd_path = TEMPLATES_DIR / ".opencode" / "commands" / "fba:build.md"
+        assert cmd_path.is_file()
+
+    def test_build_command_has_frontmatter(self):
+        import yaml
+        cmd_path = TEMPLATES_DIR / ".opencode" / "commands" / "fba:build.md"
+        text = cmd_path.read_text()
+        parts = text.split("---", 2)
+        assert len(parts) >= 3
+        frontmatter = yaml.safe_load(parts[1])
+        assert frontmatter.get("agent") == "constructor"
+        assert "Generate" in frontmatter.get("description", "")
+
+    def test_build_command_body_has_iterative_content(self):
+        cmd_path = TEMPLATES_DIR / ".opencode" / "commands" / "fba:build.md"
+        text = cmd_path.read_text()
+
+        assert "# fba:build" in text
+        assert "index.json" in text
+        assert "T*.json" in text
+        assert "Iterative" in text
+        assert "fresh" in text
+        assert "task_id" in text
+        assert "git commit" in text
+
+
+class TestTasksCommandFrontmatter:
+    def test_tasks_command_exists(self):
+        cmd_path = TEMPLATES_DIR / ".opencode" / "commands" / "fba:tasks.md"
+        assert cmd_path.is_file()
+
+    def test_tasks_command_has_frontmatter(self):
+        import yaml
+        cmd_path = TEMPLATES_DIR / ".opencode" / "commands" / "fba:tasks.md"
+        text = cmd_path.read_text()
+        parts = text.split("---", 2)
+        assert len(parts) >= 3
+        frontmatter = yaml.safe_load(parts[1])
+        assert frontmatter.get("agent") == "planificador"
+
+    def test_tasks_command_body_references_index_and_files(self):
+        cmd_path = TEMPLATES_DIR / ".opencode" / "commands" / "fba:tasks.md"
+        text = cmd_path.read_text()
+
+        assert "# fba:tasks" in text
+        assert "index.json" in text
+        assert "T*.json" in text
+        assert "task_index.schema.json" in text
+        assert "task_item.schema.json" in text
+        assert "DO NOT change" in text
+
+
+class TestTransitionFromTasksToConstruction:
+    @pytest.fixture
+    def project_with_tasks(self, tmp_path):
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir()
+
+        schemas_dir = factory_dir / "schemas"
+        schemas_dir.mkdir()
+
+        tasks_dir = factory_dir / "tasks"
+        tasks_dir.mkdir()
+
+        tasks_dir_created = tasks_dir
+        schemas_dir_created = schemas_dir
+
+        schemas = TESTS_DIR.parent / "schemas"
+        import shutil
+        for schema_file in ["task_index.schema.json", "task_item.schema.json"]:
+            src = schemas / schema_file
+            if src.exists():
+                shutil.copy2(src, schemas_dir_created / schema_file)
+
+        state = {
+            "project": "test",
+            "current_phase": "tasks",
+            "methodology": "BABOK",
+            "phases": {
+                "planning": {"status": "complete", "agent": "planificador"},
+                "tasks": {"status": "in_progress", "agent": "planificador"},
+                "construction": {"status": "pending", "agent": "constructor"},
+            },
+            "valid_transitions": {
+                "tasks": ["construction"],
+            },
+            "gates": {
+                "tasks": {
+                    "description": "Validates task files",
+                    "owner_agent": "planificador",
+                    "rules": [
+                        {
+                            "type": "artifact_exists",
+                            "rule_name": "task_index_exists",
+                            "path": ".factory/tasks/index.json",
+                        },
+                        {
+                            "type": "content_check",
+                            "rule_name": "min_tasks",
+                            "path": ".factory/tasks/index.json",
+                            "checks": {"min_tasks": 1},
+                        },
+                        {
+                            "type": "task_files_exist",
+                            "rule_name": "all_task_files_exist",
+                            "index_path": ".factory/tasks/index.json",
+                        },
+                    ],
+                },
+            },
+            "artifacts": {},
+        }
+        (factory_dir / "state.json").write_text(json.dumps(state, indent=2))
+        return tmp_path
+
+    def _create_valid_tasks(self, project_path):
+        tasks_dir = project_path / ".factory" / "tasks"
+
+        index = {
+            "module_name": "test_module",
+            "total_tasks": 2,
+            "tasks": [
+                {
+                    "id": "T001",
+                    "name": "Modelos",
+                    "file": "T001-modelos.json",
+                    "dependencies": [],
+                    "order": 1,
+                    "estimated_effort": "high",
+                    "sdd_components": ["models.test"],
+                },
+                {
+                    "id": "T002",
+                    "name": "Vistas",
+                    "file": "T002-vistas.json",
+                    "dependencies": ["T001"],
+                    "order": 2,
+                    "estimated_effort": "medium",
+                    "sdd_components": ["views.form"],
+                },
+            ],
+        }
+        (tasks_dir / "index.json").write_text(json.dumps(index, indent=2))
+
+        for task_file, task_data in [
+            ("T001-modelos.json", {
+                "id": "T001",
+                "name": "Modelos",
+                "description": "Generar modelos Odoo para modulo de prueba.",
+                "components": [{
+                    "type": "model",
+                    "name": "test.model",
+                    "description": "Modelo de prueba",
+                    "sdd_reference": "models.test",
+                }],
+                "files_to_generate": ["models/__init__.py", "models/test_model.py"],
+                "dependencies": [],
+            }),
+            ("T002-vistas.json", {
+                "id": "T002",
+                "name": "Vistas",
+                "description": "Generar vistas XML para modulo de prueba.",
+                "components": [{
+                    "type": "view",
+                    "name": "test.form",
+                    "description": "Formulario de prueba",
+                    "view_type": "form",
+                    "model": "test.model",
+                    "view_fields": ["name"],
+                    "sdd_reference": "views.form",
+                }],
+                "files_to_generate": ["views/test_views.xml"],
+                "dependencies": ["T001"],
+            }),
+        ]:
+            (tasks_dir / task_file).write_text(json.dumps(task_data, indent=2))
+
+    def test_transition_blocked_without_tasks(self, project_with_tasks):
+        sm = StateManager(project_with_tasks)
+        with pytest.raises(GateError) as exc_info:
+            sm.transition_to("construction")
+        assert exc_info.value.gate_result.phase == "tasks"
+        assert exc_info.value.gate_result.error_count > 0
+
+    def test_transition_allowed_with_valid_tasks(self, project_with_tasks):
+        self._create_valid_tasks(project_with_tasks)
+        sm = StateManager(project_with_tasks)
+        state = sm.transition_to("construction")
+        assert state["current_phase"] == "construction"
+        assert state["phases"]["tasks"]["status"] == "complete"
+        assert state["phases"]["construction"]["status"] == "in_progress"
+
+    def test_transition_force_bypasses_tasks_gate(self, project_with_tasks):
+        sm = StateManager(project_with_tasks)
+        state = sm.transition_to("construction", skip_gates=True)
+        assert state["current_phase"] == "construction"
+
+    def test_cli_transition_fails_without_tasks(self, project_with_tasks):
+        runner = CliRunner()
+        result = runner.invoke(main, ["transition", "construction", "-d", str(project_with_tasks)])
+        assert result.exit_code == 1
+        assert "Gate 'tasks' failed" in result.output
+
+    def test_cli_transition_passes_with_valid_tasks(self, project_with_tasks):
+        self._create_valid_tasks(project_with_tasks)
+        runner = CliRunner()
+        result = runner.invoke(main, ["transition", "construction", "-d", str(project_with_tasks)])
+        assert result.exit_code == 0
+        assert "Transitioned" in result.output
+
+        state = json.loads((project_with_tasks / ".factory" / "state.json").read_text())
+        assert state["phases"]["tasks"]["status"] == "complete"
+
+
+class TestOrchestratorPhaseTable:
+    def test_orchestrator_references_task_files(self):
+        orchestrator_path = TEMPLATES_DIR / ".opencode" / "agents" / "orchestrator.md"
+        text = orchestrator_path.read_text()
+
+        assert "tasks/index.json" in text
+        assert "T*.json" in text
+
+    def test_orchestrator_context_injection_updated(self):
+        orchestrator_path = TEMPLATES_DIR / ".opencode" / "agents" / "orchestrator.md"
+        text = orchestrator_path.read_text()
+
+        assert "tasks/index.json" in text
+
+
+class TestInitStateHasTasksGate:
+    def test_init_creates_tasks_gate_in_state(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(main, ["init", "-d", str(tmp_path)])
+        assert result.exit_code == 0
+
+        state = json.loads((tmp_path / ".factory" / "state.json").read_text())
+        assert "tasks" in state["gates"]
+        tasks_gate = state["gates"]["tasks"]
+        assert tasks_gate["owner_agent"] == "planificador"
+        assert len(tasks_gate["rules"]) == 4
+
+        rule_types = [r["type"] for r in tasks_gate["rules"]]
+        assert "artifact_exists" in rule_types
+        assert "schema" in rule_types
+        assert "content_check" in rule_types
+        assert "task_files_exist" in rule_types

--- a/tests/test_task_gate.py
+++ b/tests/test_task_gate.py
@@ -1,0 +1,353 @@
+"""Tests for the task_files_exist gate rule and tasks gate."""
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from fba.cli import main
+from fba.gate import GateRunner
+
+
+@pytest.fixture
+def state_with_tasks_gate(tmp_path):
+    factory_dir = tmp_path / ".factory"
+    factory_dir.mkdir()
+
+    schemas_dir = factory_dir / "schemas"
+    schemas_dir.mkdir()
+
+    tasks_dir = factory_dir / "tasks"
+    tasks_dir.mkdir()
+
+    state = {
+        "project": "test",
+        "current_phase": "tasks",
+        "methodology": "BABOK",
+        "phases": {
+            "tasks": {"status": "in_progress", "agent": "planificador"},
+            "construction": {"status": "pending", "agent": "constructor"},
+        },
+        "valid_transitions": {
+            "tasks": ["construction"],
+        },
+        "gates": {
+            "tasks": {
+                "description": "Validates task index and individual task files",
+                "owner_agent": "planificador",
+                "rules": [
+                    {
+                        "type": "artifact_exists",
+                        "rule_name": "task_index_exists",
+                        "path": ".factory/tasks/index.json",
+                    },
+                    {
+                        "type": "content_check",
+                        "rule_name": "task_index_content_minimum",
+                        "path": ".factory/tasks/index.json",
+                        "checks": {"min_tasks": 1},
+                    },
+                    {
+                        "type": "task_files_exist",
+                        "rule_name": "all_task_files_exist",
+                        "index_path": ".factory/tasks/index.json",
+                    },
+                ],
+            },
+        },
+        "artifacts": {},
+        "context": {},
+    }
+    (factory_dir / "state.json").write_text(json.dumps(state, indent=2))
+    return tmp_path
+
+
+def _create_valid_index_and_tasks(project_path: Path):
+    tasks_dir = project_path / ".factory" / "tasks"
+
+    index = {
+        "module_name": "vehicle_registry",
+        "total_tasks": 2,
+        "tasks": [
+            {
+                "id": "T001",
+                "name": "Modelos",
+                "file": "T001-modelos.json",
+                "dependencies": [],
+                "order": 1,
+                "estimated_effort": "high",
+                "sdd_components": ["models.vehicle"],
+            },
+            {
+                "id": "T002",
+                "name": "Vistas",
+                "file": "T002-vistas.json",
+                "dependencies": ["T001"],
+                "order": 2,
+                "estimated_effort": "medium",
+                "sdd_components": ["views.form"],
+            },
+        ],
+    }
+    (tasks_dir / "index.json").write_text(json.dumps(index, indent=2))
+
+    task1 = {
+        "id": "T001",
+        "name": "Modelos",
+        "description": "Generar los modelos Odoo para el modulo.",
+        "components": [
+            {
+                "type": "model",
+                "name": "vehicle.vehicle",
+                "description": "Modelo principal de vehiculo",
+                "sdd_reference": "models.vehicle",
+            },
+        ],
+        "files_to_generate": ["models/__init__.py", "models/vehicle.py"],
+        "dependencies": [],
+    }
+    (tasks_dir / "T001-modelos.json").write_text(json.dumps(task1, indent=2))
+
+    task2 = {
+        "id": "T002",
+        "name": "Vistas",
+        "description": "Generar las vistas XML para el modulo.",
+        "components": [
+            {
+                "type": "view",
+                "name": "vehicle.form",
+                "description": "Formulario de vehiculo",
+                "view_type": "form",
+                "model": "vehicle.vehicle",
+                "view_fields": ["plate", "brand_id"],
+                "sdd_reference": "views.form",
+            },
+        ],
+        "files_to_generate": ["views/vehicle_views.xml"],
+        "dependencies": ["T001"],
+    }
+    (tasks_dir / "T002-vistas.json").write_text(json.dumps(task2, indent=2))
+
+
+class TestTaskFilesExistRule:
+    def test_all_files_exist_and_valid(self, state_with_tasks_gate):
+        _create_valid_index_and_tasks(state_with_tasks_gate)
+        runner = GateRunner(state_with_tasks_gate)
+        result = runner.check_phase("tasks")
+        assert result.passed is True
+        assert result.error_count == 0
+        for r in result.results:
+            assert r.passed is True
+
+    def test_index_not_found(self, state_with_tasks_gate):
+        runner = GateRunner(state_with_tasks_gate)
+        result = runner.check_phase("tasks")
+
+        task_files_rule = [r for r in result.results if r.rule == "all_task_files_exist"][0]
+        assert task_files_rule.passed is False
+        assert "not found" in task_files_rule.message
+
+    def test_index_invalid_json(self, state_with_tasks_gate):
+        (state_with_tasks_gate / ".factory" / "tasks" / "index.json").write_text("not json")
+        runner = GateRunner(state_with_tasks_gate)
+        result = runner.check_phase("tasks")
+
+        task_files_rule = [r for r in result.results if r.rule == "all_task_files_exist"][0]
+        assert task_files_rule.passed is False
+        assert "invalid json" in task_files_rule.message.lower()
+
+    def test_index_has_no_tasks(self, state_with_tasks_gate):
+        index = {
+            "module_name": "test",
+            "total_tasks": 0,
+            "tasks": [],
+        }
+        (state_with_tasks_gate / ".factory" / "tasks" / "index.json").write_text(json.dumps(index))
+        runner = GateRunner(state_with_tasks_gate)
+        result = runner.check_phase("tasks")
+
+        task_files_rule = [r for r in result.results if r.rule == "all_task_files_exist"][0]
+        assert task_files_rule.passed is False
+        assert "no tasks" in task_files_rule.message.lower()
+
+    def test_task_file_missing(self, state_with_tasks_gate):
+        tasks_dir = state_with_tasks_gate / ".factory" / "tasks"
+        index = {
+            "module_name": "vehicle_registry",
+            "total_tasks": 1,
+            "tasks": [
+                {
+                    "id": "T001",
+                    "name": "Modelos",
+                    "file": "T001-modelos.json",
+                    "dependencies": [],
+                    "order": 1,
+                    "estimated_effort": "high",
+                    "sdd_components": ["models.vehicle"],
+                },
+            ],
+        }
+        (tasks_dir / "index.json").write_text(json.dumps(index))
+        runner = GateRunner(state_with_tasks_gate)
+        result = runner.check_phase("tasks")
+
+        task_files_rule = [r for r in result.results if r.rule == "all_task_files_exist"][0]
+        assert task_files_rule.passed is False
+        assert "Missing task files" in task_files_rule.message
+
+    def test_task_file_empty(self, state_with_tasks_gate):
+        tasks_dir = state_with_tasks_gate / ".factory" / "tasks"
+        index = {
+            "module_name": "vehicle_registry",
+            "total_tasks": 1,
+            "tasks": [
+                {
+                    "id": "T001",
+                    "name": "Modelos",
+                    "file": "T001-modelos.json",
+                    "dependencies": [],
+                    "order": 1,
+                    "estimated_effort": "high",
+                    "sdd_components": ["models.vehicle"],
+                },
+            ],
+        }
+        (tasks_dir / "index.json").write_text(json.dumps(index))
+        (tasks_dir / "T001-modelos.json").write_text("   ")
+        runner = GateRunner(state_with_tasks_gate)
+        result = runner.check_phase("tasks")
+
+        task_files_rule = [r for r in result.results if r.rule == "all_task_files_exist"][0]
+        assert task_files_rule.passed is False
+        assert "Empty task files" in task_files_rule.message
+
+    def test_task_file_invalid_json(self, state_with_tasks_gate):
+        tasks_dir = state_with_tasks_gate / ".factory" / "tasks"
+        index = {
+            "module_name": "vehicle_registry",
+            "total_tasks": 1,
+            "tasks": [
+                {
+                    "id": "T001",
+                    "name": "Modelos",
+                    "file": "T001-modelos.json",
+                    "dependencies": [],
+                    "order": 1,
+                    "estimated_effort": "high",
+                    "sdd_components": ["models.vehicle"],
+                },
+            ],
+        }
+        (tasks_dir / "index.json").write_text(json.dumps(index))
+        (tasks_dir / "T001-modelos.json").write_text("not valid json")
+        runner = GateRunner(state_with_tasks_gate)
+        result = runner.check_phase("tasks")
+
+        task_files_rule = [r for r in result.results if r.rule == "all_task_files_exist"][0]
+        assert task_files_rule.passed is False
+        assert "Invalid JSON" in task_files_rule.message
+
+    def test_task_file_no_file_field(self, state_with_tasks_gate):
+        tasks_dir = state_with_tasks_gate / ".factory" / "tasks"
+        index = {
+            "module_name": "vehicle_registry",
+            "total_tasks": 1,
+            "tasks": [
+                {
+                    "id": "T001",
+                    "name": "Modelos",
+                    "dependencies": [],
+                    "order": 1,
+                    "estimated_effort": "high",
+                    "sdd_components": ["models.vehicle"],
+                },
+            ],
+        }
+        (tasks_dir / "index.json").write_text(json.dumps(index))
+        runner = GateRunner(state_with_tasks_gate)
+        result = runner.check_phase("tasks")
+
+        task_files_rule = [r for r in result.results if r.rule == "all_task_files_exist"][0]
+        assert task_files_rule.passed is False
+        assert "Missing task files" in task_files_rule.message
+
+    def test_task_file_schema_failure(self, state_with_tasks_gate):
+        tasks_dir = state_with_tasks_gate / ".factory" / "tasks"
+        index = {
+            "module_name": "vehicle_registry",
+            "total_tasks": 1,
+            "tasks": [
+                {
+                    "id": "T001",
+                    "name": "Modelos",
+                    "file": "T001-modelos.json",
+                    "dependencies": [],
+                    "order": 1,
+                    "estimated_effort": "high",
+                    "sdd_components": ["models.vehicle"],
+                },
+            ],
+        }
+        (tasks_dir / "index.json").write_text(json.dumps(index))
+        bad_task = {
+            "id": "T001",
+            "name": "X",
+            "description": "too short",
+            "components": [],
+            "files_to_generate": [],
+            "dependencies": [],
+        }
+        (tasks_dir / "T001-modelos.json").write_text(json.dumps(bad_task))
+        runner = GateRunner(state_with_tasks_gate)
+        result = runner.check_phase("tasks")
+
+        task_files_rule = [r for r in result.results if r.rule == "all_task_files_exist"][0]
+        assert task_files_rule.passed is False
+        assert "Schema validation failed" in task_files_rule.message
+
+
+class TestTasksGateIntegration:
+    def test_full_gate_passes(self, state_with_tasks_gate):
+        _create_valid_index_and_tasks(state_with_tasks_gate)
+        runner = GateRunner(state_with_tasks_gate)
+        result = runner.check_phase("tasks")
+        assert result.passed is True
+        assert len(result.results) == 3
+        assert result.error_count == 0
+
+    def test_full_gate_fails_missing_index(self, state_with_tasks_gate):
+        runner = GateRunner(state_with_tasks_gate)
+        result = runner.check_phase("tasks")
+        assert result.passed is False
+        assert result.error_count > 0
+
+    def test_content_check_fails_zero_tasks(self, state_with_tasks_gate):
+        index = {
+            "module_name": "test",
+            "total_tasks": 0,
+            "tasks": [],
+        }
+        (state_with_tasks_gate / ".factory" / "tasks" / "index.json").write_text(json.dumps(index))
+        runner = GateRunner(state_with_tasks_gate)
+        result = runner.check_phase("tasks")
+
+        content_rule = [r for r in result.results if r.rule == "task_index_content_minimum"][0]
+        assert content_rule.passed is False
+        assert "Expected at least" in content_rule.message
+
+
+class TestCLITasksGate:
+    def test_gate_tasks_cli_passes(self, state_with_tasks_gate):
+        _create_valid_index_and_tasks(state_with_tasks_gate)
+        runner_cli = CliRunner()
+        result = runner_cli.invoke(main, ["gate", "tasks", "-d", str(state_with_tasks_gate)])
+        assert result.exit_code == 0
+        assert "✅ Gate:" in result.output
+
+    def test_gate_tasks_cli_fails(self, state_with_tasks_gate):
+        runner_cli = CliRunner()
+        result = runner_cli.invoke(main, ["gate", "tasks", "-d", str(state_with_tasks_gate)])
+        assert result.exit_code == 1
+        assert "❌ Gate:" in result.output
+        assert "task_index_exists" in result.output

--- a/tests/test_task_schema.py
+++ b/tests/test_task_schema.py
@@ -1,0 +1,292 @@
+"""Tests for Task Index and Task Item schema validation."""
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+INDEX_SCHEMA_PATH = Path(__file__).resolve().parent.parent / "schemas" / "task_index.schema.json"
+ITEM_SCHEMA_PATH = Path(__file__).resolve().parent.parent / "schemas" / "task_item.schema.json"
+
+
+@pytest.fixture
+def index_schema():
+    return json.loads(INDEX_SCHEMA_PATH.read_text())
+
+
+@pytest.fixture
+def item_schema():
+    return json.loads(ITEM_SCHEMA_PATH.read_text())
+
+
+def _valid_index():
+    return {
+        "module_name": "vehicle_registry",
+        "total_tasks": 4,
+        "tasks": [
+            {
+                "id": "T001",
+                "name": "Modelos",
+                "file": "T001-modelos.json",
+                "dependencies": [],
+                "order": 1,
+                "estimated_effort": "high",
+                "sdd_components": ["models.vehicle", "models.brand"],
+            },
+            {
+                "id": "T002",
+                "name": "Vistas",
+                "file": "T002-vistas.json",
+                "dependencies": ["T001"],
+                "order": 2,
+                "estimated_effort": "medium",
+                "sdd_components": ["views.form", "views.tree"],
+            },
+            {
+                "id": "T003",
+                "name": "Seguridad",
+                "file": "T003-seguridad.json",
+                "dependencies": ["T001"],
+                "order": 3,
+                "estimated_effort": "medium",
+                "sdd_components": ["security.groups", "security.acl"],
+            },
+            {
+                "id": "T004",
+                "name": "Datos demo",
+                "file": "T004-datos-demo.json",
+                "dependencies": ["T001", "T002", "T003"],
+                "order": 4,
+                "estimated_effort": "low",
+                "sdd_components": ["data.demo"],
+            },
+        ],
+    }
+
+
+def _valid_item():
+    return {
+        "id": "T001",
+        "name": "Modelos",
+        "description": "Generar los modelos Odoo para el modulo de registro de vehiculos.",
+        "components": [
+            {
+                "type": "model",
+                "name": "vehicle.vehicle",
+                "description": "Modelo principal de vehiculo",
+                "fields": [
+                    {"name": "plate", "type": "Char", "label": "Placa", "required": True, "size": 20},
+                    {"name": "brand_id", "type": "Many2one", "label": "Marca", "relation": "vehicle.brand"},
+                ],
+                "sdd_reference": "models.vehicle",
+            },
+            {
+                "type": "model",
+                "name": "vehicle.brand",
+                "description": "Catalogo de marcas",
+                "fields": [
+                    {"name": "name", "type": "Char", "label": "Nombre", "required": True, "size": 100},
+                ],
+                "sdd_reference": "models.brand",
+            },
+        ],
+        "files_to_generate": [
+            "models/__init__.py",
+            "models/vehicle.py",
+            "models/brand.py",
+        ],
+        "dependencies": [],
+    }
+
+
+class TestTaskIndexSchema:
+    def test_valid_index_passes(self, index_schema):
+        data = _valid_index()
+        jsonschema.validate(data, index_schema)
+
+    def test_missing_required_field(self, index_schema):
+        data = _valid_index()
+        del data["total_tasks"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, index_schema)
+
+    def test_module_name_too_short(self, index_schema):
+        data = _valid_index()
+        data["module_name"] = "ab"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, index_schema)
+
+    def test_zero_tasks(self, index_schema):
+        data = _valid_index()
+        data["total_tasks"] = 0
+        data["tasks"] = []
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, index_schema)
+
+    def test_empty_tasks_array(self, index_schema):
+        data = _valid_index()
+        data["total_tasks"] = 0
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, index_schema)
+
+    def test_task_id_pattern_invalid(self, index_schema):
+        data = _valid_index()
+        data["tasks"][0]["id"] = "1"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, index_schema)
+
+    def test_task_id_pattern_valid_formats(self, index_schema):
+        data = _valid_index()
+        for tid in ["T001", "T999", "T9999"]:
+            data_copy = json.loads(json.dumps(data))
+            data_copy["tasks"][0]["id"] = tid
+            jsonschema.validate(data_copy, index_schema)
+
+    def test_task_file_pattern_invalid(self, index_schema):
+        data = _valid_index()
+        data["tasks"][0]["file"] = "task1.txt"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, index_schema)
+
+    def test_task_file_pattern_valid(self, index_schema):
+        data = _valid_index()
+        data["tasks"][0]["file"] = "T001-modelos.json"
+        jsonschema.validate(data, index_schema)
+
+    def test_missing_required_task_field(self, index_schema):
+        data = _valid_index()
+        del data["tasks"][0]["sdd_components"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, index_schema)
+
+    def test_dependencies_invalid_format(self, index_schema):
+        data = _valid_index()
+        data["tasks"][1]["dependencies"] = ["1"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, index_schema)
+
+    def test_estimated_effort_invalid_enum(self, index_schema):
+        data = _valid_index()
+        data["tasks"][0]["estimated_effort"] = "extreme"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, index_schema)
+
+    def test_estimated_effort_valid_values(self, index_schema):
+        for effort in ["low", "medium", "high"]:
+            data = json.loads(json.dumps(_valid_index()))
+            data["tasks"][0]["estimated_effort"] = effort
+            jsonschema.validate(data, index_schema)
+
+    def test_order_negative(self, index_schema):
+        data = _valid_index()
+        data["tasks"][0]["order"] = -1
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, index_schema)
+
+    def test_order_zero(self, index_schema):
+        data = _valid_index()
+        data["tasks"][0]["order"] = 0
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, index_schema)
+
+
+class TestTaskItemSchema:
+    def test_valid_item_passes(self, item_schema):
+        data = _valid_item()
+        jsonschema.validate(data, item_schema)
+
+    def test_missing_required_field(self, item_schema):
+        data = _valid_item()
+        del data["description"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, item_schema)
+
+    def test_description_too_short(self, item_schema):
+        data = _valid_item()
+        data["description"] = "short"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, item_schema)
+
+    def test_id_pattern_invalid(self, item_schema):
+        data = _valid_item()
+        data["id"] = "1"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, item_schema)
+
+    def test_empty_components(self, item_schema):
+        data = _valid_item()
+        data["components"] = []
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, item_schema)
+
+    def test_component_missing_required(self, item_schema):
+        data = _valid_item()
+        del data["components"][0]["sdd_reference"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, item_schema)
+
+    def test_component_type_invalid_enum(self, item_schema):
+        data = _valid_item()
+        data["components"][0]["type"] = "invalid_type"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, item_schema)
+
+    def test_component_type_valid_values(self, item_schema):
+        for ctype in ["model", "view", "security_group", "access_right", "record_rule", "data", "report", "workflow", "wizard", "controller"]:
+            data = json.loads(json.dumps(_valid_item()))
+            data["components"][0]["type"] = ctype
+            if ctype != "model":
+                del data["components"][0]["fields"]
+            jsonschema.validate(data, item_schema)
+
+    def test_empty_files_to_generate(self, item_schema):
+        data = _valid_item()
+        data["files_to_generate"] = []
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, item_schema)
+
+    def test_files_to_generate_invalid_pattern(self, item_schema):
+        data = _valid_item()
+        data["files_to_generate"] = ["models/secret file.py"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, item_schema)
+
+    def test_field_name_invalid(self, item_schema):
+        data = _valid_item()
+        data["components"][0]["fields"][0]["name"] = "1plate"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, item_schema)
+
+    def test_field_type_invalid_enum(self, item_schema):
+        data = _valid_item()
+        data["components"][0]["fields"][0]["type"] = "Unknown"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, item_schema)
+
+    def test_field_selection_valid(self, item_schema):
+        data = _valid_item()
+        data["components"][0]["fields"] = [
+            {"name": "state", "type": "Selection", "label": "Estado",
+             "selection": [["draft", "Borrador"], ["done", "Completado"]]}
+        ]
+        jsonschema.validate(data, item_schema)
+
+    def test_dependencies_valid(self, item_schema):
+        data = _valid_item()
+        data["dependencies"] = ["T001", "T002"]
+        jsonschema.validate(data, item_schema)
+
+    def test_dependencies_invalid_format(self, item_schema):
+        data = _valid_item()
+        data["dependencies"] = ["001", "abc"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, item_schema)
+
+    def test_view_type_invalid(self, item_schema):
+        data = _valid_item()
+        data["components"][0]["type"] = "view"
+        data["components"][0]["view_type"] = "invalid_type"
+        del data["components"][0]["fields"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, item_schema)


### PR DESCRIPTION
## Summary
- Rediseña el sistema de tasks para generar un archivo por task en lugar de un solo `tasks.md`
- Modifica `/fba:build` para flujo iterativo: sesión fresca por task con commit git por task
- Agrega gate `tasks` con 4 reglas (incluyendo nuevo `task_files_exist`)

## Changes
| File | Change |
|------|--------|
| `schemas/task_index.schema.json` | Nuevo schema para `tasks/index.json` |
| `schemas/task_item.schema.json` | Nuevo schema para `tasks/T*.json` |
| `src/fba/gate.py` | Nuevo rule type `task_files_exist` |
| `src/fba/cli.py` | Gate `tasks` en `_init_factory_state()` |
| `templates/.opencode/commands/fba:tasks.md` | Nuevo flujo: index.json + T*.json |
| `templates/.opencode/commands/fba:build.md` | Flujo iterativo task-por-task |
| `templates/.opencode/agents/orchestrator.md` | Tabla de fases actualizada |
| `tests/test_task_schema.py` | 68 tests de schema |
| `tests/test_task_gate.py` | 21 tests del gate tasks |
| `tests/test_build_iterative.py` | 11 tests de build e integración |
| `docs/testing/m3-tasks-files.md` | Guía de testing |

## Test Results
```
294 passed in 1.44s
```

Closes #64