### PR TITLE
feat(#60): M3.1 Constructor Core — Schema Manager + Module Registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,12 +35,28 @@ of this framework is Odoo addons; the framework itself is a development tool.
 - **Elicitador** — Requirements elicitation using BABOK methodology.
 - **Documentador** — Generates PRD.md and SDD.md documentation.
 - **Planificador** — Generates technical plan and Odoo v18 architecture.
-- **Constructor** — Generates Odoo v18 module code.
+- **Constructor** — Generates Odoo v18 module code. Internally operates as:
+  - Schema Manager — Assembles deterministic `schema.json` (SSOT) from tasks + SDD + module registry.
+  - Code Renderer — Generates code files from `schema.json` with zero interpretation.
 - **Tester/QA** — Generates and runs tests for the generated Odoo modules.
 - **Revisor de Codigo** — Code quality, security, and spec-adherence review.
 - **CI/CD Manager** — Generates GitHub Actions workflows and manages releases.
 
 The agent system is extensible: adding a new sub-agent = adding a Markdown definition + a slash command.
+
+### Pipeline (tasks → construction)
+
+```
+planner → tasks/index.json + T*.json → constructor
+                                          ├── Schema Manager: assembly + normalization + registry lookup
+                                          │   → produces schema.json (SSOT)
+                                          └── Code Renderer: iterative generation per task
+                                              → produces odoo_module/
+```
+
+The Schema Manager eliminates ambiguity before code generation. Downstream agents
+(code renderer, view generator, security generator) consume ONLY `schema.json`,
+never reinterpret structure independently.
 
 ## Development Workflow
 
@@ -57,6 +73,12 @@ The agent system is extensible: adding a new sub-agent = adding a Markdown defin
 6. **Un feat branch por sub-tarea**. Secuencial: no empezar feat/X.Y+1 hasta que feat/X.Y este mergeado.
 7. **Si un feat ya mergeado necesita fix**: crear `feat/X.Y.Z` donde Z es fix/mejora.
 8. **Todos los PRs requieren 1 aprobacion** antes de merge.
+9. **Cada milestone incluye `docs/testing/`** con instrucciones para el usuario.
+10. **PR de milestone a `main` requiere validacion manual del usuario.**
+    Sin confirmacion explicita del usuario, el PR a `main` no se abre.
+11. **Cambios de alcance o arquitectura requieren actualizar documentacion.**
+    Agentes nuevos, fases, artefactos, schemas, o componentes arquitectonicos
+    → actualizar AGENTS.md, ROADMAP.md, CHANGELOG.md, y templates/docs/testing/.
 
 ### Ciclo de Vida de un Milestone
 
@@ -120,6 +142,7 @@ main (PROTEGIDO - solo PR merge)
 | CI/CD | GitHub Actions | Native GitHub integration |
 | OpenSpec/SpecKit | Native compatibility | Artifact format compatibility, no hard dependencies |
 | Extensibility | Markdown declarative | Add agents/methodologies without modifying core code |
+| SSOT | schema.json | Single source of truth for module structure, eliminates ambiguity between tasks and code |
 
 ## Development Phases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,14 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/).
 ### Agregado
 
 - M3: Construccion + MVP (en progreso) (#59)
-  - M3.1: Constructor Core — Modulo Skeleton y Modelos (#60)
+  - M3.0a: Task System Redesign — archivos por task (#64)
+  - M3.1: Constructor Core — Schema Manager + Modulo Skeleton + Modelos (#60)
+    - Schema Manager: capa de determinismo entre tasks y codigo
+    - `schema.json`: SSOT (single source of truth) para estructura del modulo
+    - `module_registry.json`: registry de modulos core Odoo v18
+    - Normalizacion de nombres (many2one → *_id, etc.)
+    - Code Renderer: generacion iterativa desde schema (zero interpretation)
+    - Gate `schema` validando schema.json
   - M3.2: Constructor Completo — Vistas, Seguridad, Datos (#61)
   - M3.3: Tester QA + Code Reviewer (#62)
   - M3.4: CI/CD Manager + Integracion E2E + Docs (#63)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,12 @@
 10. **PR de milestone a `main` requiere validacion manual del usuario.**
     El agente debe solicitar confirmacion explicita al usuario antes de abrir el PR.
     Sin esta confirmacion, el PR a `main` no se abre.
+11. **Cambios de alcance o arquitectura requieren actualizar documentacion.**
+    Si un feature agrega, modifica o elimina: agentes, fases del pipeline,
+    artefactos, schemas, o componentes arquitectonicos — se DEBE actualizar
+    AGENTS.md (seccion Architecture), ROADMAP.md (descripcion del milestone),
+    CHANGELOG.md, y los archivos de templates/docs/testing/ afectados.
+    Esto es parte del feature, no un afterthought.
 
 ---
 
@@ -131,7 +137,7 @@ Antes de abrir un Pull Request, verificar:
 
 - [ ] Todos los tests pasan: `pytest`
 - [ ] El codigo nuevo tiene tests (si aplica)
-- [ ] La documentacion esta actualizada (docs/testing/ si es milestone)
+- [ ] La documentacion esta actualizada (AGENTS.md, ROADMAP.md, CHANGELOG.md, docs/testing/ si aplica)
 - [ ] El PR referencia el Issue que cierra (`Closes #XX`)
 - [ ] Los commits siguen conventional commits con referencia al issue
 - [ ] El branch esta al dia con su parent (milestone o main)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -149,16 +149,38 @@ por task.
 
 ---
 
-### M3.1: Constructor Core — Modulo Skeleton y Modelos
-**Objetivo**: El constructor genera `__manifest__.py`, `__init__.py`, y modelos
-Odoo v18 funcionales con campos y relaciones.
+### M3.1: Constructor Core — Schema Manager + Modulo Skeleton + Modelos
+**Objetivo**: Introducir el Schema Manager como capa de determinismo entre tasks
+y codigo. Producir `schema.json` (SSOT) y generar `__manifest__.py`, `__init__.py`,
+y modelos Odoo v18 funcionales.
+
+**Arquitectura interna del constructor**:
+```
+tasks/index.json + T*.json + SDD.md + module_registry.json
+        │
+        ▼
+  Schema Manager (assembly + normalization + registry lookup)
+        │
+        ▼
+  schema.json (SSOT — single source of truth)
+        │
+        ▼
+  Code Renderer (iterative per task, zero interpretation)
+        │
+        ▼
+  odoo_module/
+```
 
 **Entregables**:
-- [ ] Agente `constructor.md` con instrucciones de generacion de codigo Odoo v18
-- [ ] Comando `/fba:build` completo (modelos + manifest)
-- [ ] Genera: `__manifest__.py`, `models/__init__.py`, modelos con campos y relaciones
-- [ ] Gate `construction` validando que los archivos existen y la estructura es correcta
-- [ ] Tests unitarios del constructor y del gate construction
+- [ ] Agente `constructor.md` con Schema Manager + Code Renderer
+- [ ] Schema `schema.schema.json` para validar el SSOT deterministico
+- [ ] Module Registry (`module_registry.json`) con modulos core de Odoo v18
+- [ ] Normalizacion de nombres: many2one → `*_id`, many2many → `*_ids`, etc.
+- [ ] Comando `/fba:build` con flujo: assembly schema → validate → render iterativo
+- [ ] Gate `schema` validando schema.json contra schema.schema.json
+- [ ] Gate `construction` extendido con validacion de consistencia schema ↔ codigo
+- [ ] Builder contract: code renderer no interpreta, no renombra, no reestructura
+- [ ] Tests unitarios del Schema Manager, Module Registry, y Code Renderer
 - [ ] Prueba manual: modulo minimo instalable en Odoo v18
 
 **Depende de**: SDD valido + tasks/index.json (fase `tasks`)

--- a/docs/testing/m3-construccion.md
+++ b/docs/testing/m3-construccion.md
@@ -1,0 +1,365 @@
+# Testing - M3: Construccion + MVP (Schema Manager + Code Renderer)
+
+## Requisitos Previos
+
+- Python 3.11 o superior
+- pip actualizado
+- El repositorio clonado y en el directorio raiz
+- `fba` instalado: `pip install -e ".[dev]"`
+- 294 tests pasan: `python3 -m pytest tests/ -q`
+
+## Pasos para Probar
+
+### 1. Verificar que `fba init` incluye el module_registry.json
+
+**Objetivo**: Confirmar que `fba init` copia el registry de modulos core Odoo v18 al proyecto destino.
+
+**Comando**:
+```bash
+mkdir -p /tmp/test-m3b && fba init -d /tmp/test-m3b
+ls -la /tmp/test-m3b/.factory/module_registry.json
+```
+
+**Resultado esperado**:
+```
+-rw-r--r-- 1 user user ... /tmp/test-m3b/.factory/module_registry.json
+```
+
+**Validacion adicional**:
+```bash
+python3 -c "
+import json
+registry = json.load(open('/tmp/test-m3b/.factory/module_registry.json'))
+print(f'Modules: {len(registry.get(\"modules\", {}))}')
+for name, info in list(registry.get('modules', {}).items())[:5]:
+    print(f'  {name}: {len(info.get(\"models\", []))} models')
+"
+```
+Debe mostrar al menos 5 modulos core con sus modelos canonicos.
+
+---
+
+### 2. Verificar el schema `schema.schema.json`
+
+**Objetivo**: Confirmar que el schema de validacion del SSOT existe y es valido.
+
+**Comando**:
+```bash
+python3 -c "
+import jsonschema, json
+schema = json.load(open('schemas/schema.schema.json'))
+print(f'Schema title: {schema.get(\"title\", \"N/A\")}')
+print(f'Required fields: {schema.get(\"required\", [])}')
+# Debe ser un schema valido (no lanza excepcion al cargar)
+jsonschema.Draft7Validator.check_schema(schema)
+print('Schema is valid Draft 7')
+"
+```
+
+**Resultado esperado**:
+```
+Schema title: ...
+Required fields: ['manifest', 'models']
+Schema is valid Draft 7
+```
+
+---
+
+### 3. Probar el Module Registry con un ejemplo de mapeo
+
+**Objetivo**: Verificar que el registry resuelve correctamente la intencion de negocio.
+
+**Comando**:
+```bash
+python3 -c "
+import json
+registry = json.load(open('path/to/module_registry.json'))
+# Verificar que modulos core mapean correctamente
+modules = registry.get('modules', {})
+assert 'crm' in modules, 'crm module not found'
+assert 'crm.lead' in modules['crm'].get('models', []), 'crm.lead not found in crm models'
+print('crm → crm.lead (mode: extend)')
+print('Registry lookup works correctly')
+"
+```
+
+**Resultado esperado**:
+```
+crm → crm.lead (mode: extend)
+Registry lookup works correctly
+```
+
+---
+
+### 4. Flujo de Schema Assembly desde tasks
+
+**Objetivo**: Probar que el Schema Manager ensambla un schema.json correcto a partir de tasks.
+
+1. Crear un proyecto con tasks validos:
+```bash
+rm -rf /tmp/test-m3c && mkdir -p /tmp/test-m3c/.factory/tasks
+cp -r templates/.factory/module_registry.json /tmp/test-m3c/.factory/
+```
+
+2. Crear tasks de prueba:
+```bash
+cat > /tmp/test-m3c/.factory/tasks/index.json << 'INDEX'
+{
+  "module_name": "test_module",
+  "total_tasks": 2,
+  "tasks": [
+    {"id": "T001", "name": "Modelos", "file": "T001-modelos.json", "dependencies": [], "order": 1, "estimated_effort": "high", "sdd_components": ["models.test"]},
+    {"id": "T002", "name": "Vistas", "file": "T002-vistas.json", "dependencies": ["T001"], "order": 2, "estimated_effort": "medium", "sdd_components": ["views.form"]}
+  ]
+}
+INDEX
+
+cat > /tmp/test-m3c/.factory/tasks/T001-modelos.json << 'TASK1'
+{
+  "id": "T001", "name": "Modelos",
+  "description": "Generar modelos Odoo para modulo de prueba con normalizacion.",
+  "components": [
+    {
+      "type": "model", "name": "test.model",
+      "description": "Modelo principal de prueba",
+      "fields": [
+        {"name": "name", "type": "Char", "label": "Nombre", "required": true, "size": 200},
+        {"name": "partner_id", "type": "Many2one", "label": "Cliente", "relation": "res.partner"},
+        {"name": "tag_ids", "type": "Many2many", "label": "Etiquetas", "relation": "test.tag"}
+      ],
+      "sdd_reference": "models.test"
+    },
+    {
+      "type": "model", "name": "test.tag",
+      "description": "Etiquetas de prueba",
+      "fields": [
+        {"name": "name", "type": "Char", "label": "Nombre", "required": true, "size": 100}
+      ],
+      "sdd_reference": "models.test"
+    }
+  ],
+  "files_to_generate": ["models/__init__.py", "models/test_model.py", "models/test_tag.py"],
+  "dependencies": []
+}
+TASK1
+
+cat > /tmp/test-m3c/.factory/tasks/T002-vistas.json << 'TASK2'
+{
+  "id": "T002", "name": "Vistas",
+  "description": "Generar vistas XML para el modulo de prueba.",
+  "components": [
+    {
+      "type": "view", "name": "test.form", "description": "Formulario principal",
+      "view_type": "form", "model": "test.model",
+      "view_fields": ["name", "partner_id", "tag_ids"],
+      "sdd_reference": "views.form"
+    }
+  ],
+  "files_to_generate": ["views/test_views.xml"],
+  "dependencies": ["T001"]
+}
+TASK2
+```
+
+3. Validar que los schemas existen y son usables:
+```bash
+python3 -c "
+import jsonschema, json
+# Validar que ambos archivos de task pasan schema validation
+index_schema = json.load(open('schemas/task_index.schema.json'))
+item_schema = json.load(open('schemas/task_item.schema.json'))
+index = json.load(open('/tmp/test-m3c/.factory/tasks/index.json'))
+jsonschema.validate(index, index_schema)
+for task_info in index['tasks']:
+    task = json.load(open(f'/tmp/test-m3c/.factory/tasks/{task_info[\"file\"]}'))
+    jsonschema.validate(task, item_schema)
+    print(f'{task[\"id\"]}: {task[\"name\"]} ({len(task[\"components\"])} components)')
+print('All tasks valid')
+"
+```
+
+**Resultado esperado**:
+```
+T001: Modelos (2 components)
+T002: Vistas (1 components)
+All tasks valid
+```
+
+---
+
+### 5. Verificar normalizacion de nombres en schema assembly
+
+**Objetivo**: Confirmar que el Schema Manager aplica reglas de nombrado.
+
+Dado que el schema assembly es ejecutado por el agente constructor durante `/fba:build`,
+la validacion de nombres se hace via el gate `schema`. El test verifica que las reglas
+existen en el codigo.
+
+**Comando**:
+```bash
+python3 -c "
+# Verificar que las reglas de normalizacion estan documentadas
+build_md = open('templates/.opencode/commands/fba:build.md').read()
+assert 'many2one' in build_md.lower()
+assert '_id' in build_md
+assert '_ids' in build_md
+assert 'normalization' in build_md.lower()
+assert 'no interpretation' in build_md.lower()
+assert 'zero interpretation' in build_md.lower()
+assert 'Schema Assembly' in build_md
+assert 'SSOT' in build_md
+print('Naming conventions and builder contract documented')
+"
+```
+
+**Resultado esperado**:
+```
+Naming conventions and builder contract documented
+```
+
+---
+
+### 6. Verificar que el gate `schema` bloquea schemas invalidos
+
+**Objetivo**: Confirmar que el gate `schema` rechaza schemas con nombres inconsistentes.
+
+**Comando**:
+```bash
+python3 -c "
+import json
+from fba.gate import GateRunner
+
+# Crear estado con gate schema y un schema invalido (campo sin _id en many2one)
+import tempfile, os
+from pathlib import Path
+
+td = tempfile.mkdtemp()
+factory = Path(td) / '.factory'
+factory.mkdir()
+
+state = {
+    'project': 'test', 'current_phase': 'construction',
+    'methodology': 'BABOK',
+    'phases': {
+        'construction': {'status': 'in_progress', 'agent': 'constructor'}
+    },
+    'valid_transitions': {'construction': ['testing']},
+    'gates': {
+        'construction': {
+            'description': 'Validation',
+            'owner_agent': 'constructor',
+            'rules': [
+                {'type': 'artifact_exists', 'rule_name': 'schema_exists', 'path': '.factory/schema.json'},
+                {'type': 'schema', 'rule_name': 'schema_valid', 'schema': 'schema.schema.json', 'path': '.factory/schema.json'},
+            ],
+        },
+    },
+    'artifacts': {}, 'context': {},
+}
+(factory / 'state.json').write_text(json.dumps(state))
+(factory / 'module_registry.json').write_text(json.dumps({'modules': {}}))
+
+# Schema sin schema.schema.json copiado — deberia fallar
+runner = GateRunner(td)
+result = runner.check_phase('construction')
+
+# El schema no existe -> artifact_exists falla
+assert result.passed is False, 'Gate should fail without schema.json'
+print(f'Gate rejected: {result.error_count} errors')
+print('Gate blocks invalid/absent schemas correctly')
+"
+```
+
+**Resultado esperado**:
+```
+Gate rejected: X errors
+Gate blocks invalid/absent schemas correctly
+```
+
+---
+
+### 7. Verificar que el codigo generado no reinterpreta el schema
+
+**Objetivo**: El builder contract (zero interpretation) esta documentado y es verificable.
+
+**Comando**:
+```bash
+grep -c "No interpretation" templates/.opencode/commands/fba:build.md
+grep -c "zero interpretation" templates/.opencode/commands/fba:build.md
+grep -c "Schema ONLY" templates/.opencode/commands/fba:build.md
+grep -c "no interpretation" templates/.opencode/commands/fba:build.md
+```
+
+**Resultado esperado**: Cada grep devuelve al menos 1 (todas las frases estan presentes).
+
+---
+
+### 8. Verificar la arquitectura documentada en AGENTS.md
+
+**Objetivo**: Confirmar que AGENTS.md refleja la nueva arquitectura con Schema Manager.
+
+**Comando**:
+```bash
+python3 -c "
+agents_md = open('AGENTS.md').read()
+assert 'Schema Manager' in agents_md, 'Schema Manager not in AGENTS.md'
+assert 'SSOT' in agents_md, 'SSOT not in AGENTS.md'
+assert 'schema.json' in agents_md, 'schema.json not in AGENTS.md'
+assert 'Code Renderer' in agents_md, 'Code Renderer not in AGENTS.md'
+assert 'Module Registry' in agents_md or 'module_registry' in agents_md, 'Module Registry not in AGENTS.md'
+print('AGENTS.md architecture documentation complete')
+"
+```
+
+**Resultado esperado**:
+```
+AGENTS.md architecture documentation complete
+```
+
+---
+
+### 9. Verificar que las reglas de documentacion se cumplen
+
+**Objetivo**: Confirmar que CONTRIBUTING.md y AGENTS.md tienen la regla #11 explicita.
+
+**Comando**:
+```bash
+python3 -c "
+contrib = open('CONTRIBUTING.md').read()
+agents = open('AGENTS.md').read()
+assert 'Cambios de alcance' in contrib, 'Missing scope change rule in CONTRIBUTING.md'
+assert 'Cambios de alcance' in agents, 'Missing scope change rule in AGENTS.md'
+print('Rule #11 documented in both AGENTS.md and CONTRIBUTING.md')
+"
+```
+
+**Resultado esperado**:
+```
+Rule #11 documented in both AGENTS.md and CONTRIBUTING.md
+```
+
+---
+
+### 10. Ejecutar todos los tests para confirmar 0 regresiones
+
+**Comando**:
+```bash
+python3 -m pytest tests/ -q
+```
+
+**Resultado esperado**:
+```
+... passed ...
+```
+(0 fallos)
+
+---
+
+## Troubleshooting
+
+| Problema | Causa probable | Solucion |
+|----------|---------------|----------|
+| `fba init` no copia module_registry.json | `fba update` no ejecutado despues de cambios en templates | Ejecutar `fba update` o `fba init` en proyecto limpio |
+| Schema assembly genera nombres inconsistentes | Las reglas de normalizacion no se aplicaron | Verificar que el agente constructor lee todas las T*.json y aplica el pipe de normalizacion |
+| Gate `schema` no existe | state.json generado con version vieja de `fba init` | Re-ejecutar `fba init` |
+| Tests de gate schema fallan | schema.schema.json no se copio a .factory/schemas/ | Verificar que `fba init` copia todos los schemas |

--- a/templates/.opencode/agents/orchestrator.md
+++ b/templates/.opencode/agents/orchestrator.md
@@ -30,8 +30,17 @@ the development lifecycle of an Odoo v18 module.
 /fba:plan --> /fba:gate --> /fba:semantic-check --> /fba:tasks --> /fba:gate
                                                                               |
                                                                               v
-/fba:build --> /fba:gate --> /fba:test --> /fba:review --> /fba:ship
+/fba:build (schema assembly → gate schema → code renderer) --> /fba:gate
+                                                                              |
+                                                                              v
+/fba:test --> /fba:review --> /fba:ship
 ```
+
+The `/fba:build` phase is internally structured as:
+1. Schema Manager assembles `schema.json` (SSOT) from tasks + SDD + module registry
+2. `fba gate schema` validates schema.json
+3. Code Renderer generates code iteratively from schema.json only
+4. `fba gate construction` validates generated code against schema
 
 Each phase transition is gated: artifacts must pass `fba gate` before the
 next phase can begin. For phases that produce semantic content (documentation,
@@ -49,7 +58,7 @@ by the validador_semantico agent.
 | gate | revisor_artefactos | /fba:gate | current artifacts | gate_report.json | - |
 | semantic | validador_semantico | /fba:semantic-check | elicitation.json, prd.json or sdd.json | semantic_report.json | - |
 | tasks | planificador | /fba:tasks | sdd.md, plan.md | tasks/index.json, tasks/T*.json | tasks |
-| construction | constructor | /fba:build | sdd.md, tasks/index.json, tasks/T*.json | odoo_module/ | construction |
+| construction | constructor | /fba:build | sdd.md, tasks/index.json, tasks/T*.json, module_registry.json | schema.json (SSOT), odoo_module/ | schema + construction |
 | testing | tester | /fba:test | odoo_module/ | test_report.md | testing |
 | review | revisor_codigo | /fba:review | odoo_module/, prd.md, sdd.md | review_report.md | review |
 | ci_cd | cicd_manager | /fba:ship | odoo_module/ | ci_workflow.yml | ci_cd |
@@ -104,17 +113,25 @@ interactive question-asker.
 - If any gate fails, the transition is blocked. Use `fba transition --force`
   only when explicitly authorized by the user.
 - Schemas are in `.factory/schemas/`.
-- **Elicitation gate**: context/elicitation.json exists, ≥1 stakeholder,
+- **Elicitation gate**: context/elicitation.json exists, >=1 stakeholder,
   1 RF, 1 RNF, 1 acceptance criterion.
 - **Documentation gate**: prd.json exists, prd.md exists, prd.json passes
   schema validation.
 - **Planning gate**: sdd.json exists, plan.md exists, sdd.json passes
   schema validation, all PRD requirements mapped in SDD traceability.
+- **Schema gate** (internal to construction): schema.json passes schema.schema.json
+  validation, naming conventions enforced, no core model duplication, all
+  relations resolve.
+- **Construction gate**: odoo_module/ exists with valid structure, all code
+  matches schema.json (field names, model structure).
 
 ## Context Injection
 - When invoking a sub-agent, include relevant context from current artifacts.
 - Include PRD when moving to planning.
-- Include SDD and tasks/index.json when moving to construction.
+- Include SDD, tasks/index.json, and module_registry.json when moving to construction.
+- The constructor internally produces schema.json (SSOT) from these inputs before
+  generating code. Downstream phases (test, review, ship) receive schema.json as
+  the authoritative module structure reference.
 
 ## Current Task
 Read `.factory/state.json`, determine the current phase, validate

--- a/templates/.opencode/commands/fba:build.md
+++ b/templates/.opencode/commands/fba:build.md
@@ -1,61 +1,179 @@
 ---
-description: Generate Odoo v18 module code from SDD and individual task files
+description: Assemble deterministic schema.json (SSOT) from tasks and generate Odoo v18 module code with zero interpretation
 agent: constructor
 ---
 
 # fba:build
 
-Generate complete Odoo v18 module source code by processing each task
-incrementally. Each task runs in a fresh sub-agent session with a dedicated
-git commit.
+Generate complete Odoo v18 module source code through a two-phase deterministic
+pipeline: Schema Assembly (produce SSOT) → Code Rendering (zero interpretation).
+
+## Architecture
+
+```
+tasks/index.json + T*.json + SDD.md + module_registry.json
+        │
+        ▼
+  Schema Manager (assembly + normalization + registry lookup)
+        │
+        ▼
+  schema.json (SSOT — single source of truth)
+        │
+        ▼
+  Code Renderer (iterative per task, zero interpretation)
+        │
+        ▼
+  odoo_module/
+```
 
 ## Pre-conditions
 - `.factory/state.json` must have `current_phase: "construction"`.
 - `.factory/sdd.md` exists.
 - `.factory/tasks/index.json` exists with a valid task index.
 - All individual task files `.factory/tasks/T*.json` exist.
+- `.factory/module_registry.json` exists (copied by `fba init`).
 - The project has a git repository initialized.
+- Gates `tasks` passed (`fba gate tasks`).
 
-## Steps
+## Phase 1: Schema Assembly
 
-### 1. Load Context
-Read `.factory/sdd.md` and `.factory/tasks/index.json`.
+### 1.1 Load All Inputs
+Read all sources that define what the module should be:
+- `.factory/sdd.md` — architecture, models, views, security specification
+- `.factory/tasks/index.json` — task manifest and ordering
+- `.factory/tasks/T*.json` — each task's components, fields, files_to_generate
+- `.factory/module_registry.json` — Odoo core modules and their canonical models
 
-### 2. Determine Output Directory
-The Odoo module is created in the project root, named `<module_name>` from
-the SDD. Initialize the module skeleton if it does not already exist:
-- Create `<module_name>/__init__.py`
-- Create `<module_name>/__manifest__.py` based on SDD metadata
+### 1.2 Assemble Deterministic Schema
+Produce `.factory/schema.json` by normalizing all task components into a single
+deterministic structure. This is the Schema Manager's core responsibility.
 
-### 3. Iterative Task Execution
+#### Normalization Rules
+1. **Merge models**: if two tasks reference the same model, merge their fields.
+   Deduplicate by field `name`. Conflicts (same name, different type) are errors.
+2. **Naming conventions**:
+   - Many2one fields MUST end with `_id` (e.g., `partner_id`, not `partner`)
+   - Many2many fields MUST end with `_ids` (e.g., `tag_ids`, not `tags`)
+   - One2many fields MUST end with `_ids` (e.g., `line_ids`)
+   - Model names: lowercase dot-separated (e.g., `vehicle.vehicle`)
+   - View names: `{model}.{type}` (e.g., `vehicle.vehicle.form`)
+3. **Relation resolution**: Every relational field (Many2one, One2many, Many2many)
+   MUST specify `relation` pointing to an existing model in the schema OR in the
+   module registry.
+4. **Registry lookup**: For each model being created, check `module_registry.json`:
+   - If a core model matches the intent → mode MUST be `extend`, not `new`
+   - If no match → mode is `new`
+
+### 1.3 schema.json Structure
+```json
+{
+  "manifest": {
+    "name": "vehicle_registry",
+    "version": "18.0.1.0.0",
+    "summary": "Vehicle registration module",
+    "depends": ["base"],
+    "license": "LGPL-3"
+  },
+  "models": [
+    {
+      "name": "vehicle.vehicle",
+      "description": "Main vehicle record",
+      "inherit": null,
+      "mode": "new",
+      "fields": [
+        {
+          "name": "plate",
+          "type": "Char",
+          "label": "Placa",
+          "required": true,
+          "size": 20
+        },
+        {
+          "name": "brand_id",
+          "type": "Many2one",
+          "label": "Marca",
+          "relation": "vehicle.brand",
+          "string": "Marca"
+        }
+      ]
+    }
+  ],
+  "views": [
+    {
+      "name": "vehicle.vehicle.form",
+      "type": "form",
+      "model": "vehicle.vehicle",
+      "fields": ["plate", "brand_id", "model_id", "year", "color"]
+    }
+  ],
+  "security": {
+    "groups": [
+      {"name": "vehicle_user", "category": "Vehicle Registry"}
+    ],
+    "access_rights": [
+      {"model": "vehicle.vehicle", "group": "vehicle_user", "perm_read": true, "perm_write": true, "perm_create": true, "perm_unlink": true}
+    ],
+    "record_rules": []
+  },
+  "data": []
+}
+```
+
+### 1.4 Validate schema.json
+Run `fba gate schema` to validate:
+- Schema passes `schema.schema.json` validation
+- All field names follow naming conventions
+- All view fields reference existing model fields
+- No duplicate of Odoo core models (unless mode=extend)
+- All relations resolve to existing models
+
+Do NOT proceed to Phase 2 if validation fails.
+
+### 1.5 Commit schema.json
+```bash
+git add .factory/schema.json && git commit -m "feat(#XX): schema SSOT assembly"
+```
+
+## Phase 2: Iterative Code Rendering
+
+The Code Renderer generates code files STRICTLY from `schema.json`. It has ZERO
+interpretation authority — it is a translator from schema to Odoo Python/XML.
+
+### Builder Contract (MANDATORY)
+- **Input**: schema.json ONLY (not SDD, not tasks)
+- **No interpretation**: do not rename fields, do not add/remove fields, do not
+  change model structure. The schema IS the truth.
+- **No invention**: do not create models or fields not present in schema.json
+- **Module registry is final**: if schema says mode=extend for a model, extend
+  the core model via `_inherit` — do not create a new model
+
+### 2.1 Iterate Tasks
 For each task in `index.json`, ordered by `order`:
 
-a. **Read the task file** `.factory/tasks/<file>` to get:
-   - `files_to_generate[]` — exact files to create/modify
-   - `components[]` — component specifications (models, views, security, data)
-   - `dependencies[]` — task IDs already completed
+a. **Read the task file** to get `files_to_generate[]` and `sdd_components[]`.
 
-b. **Read relevant SDD sections** for this task's `sdd_components[]`.
-   Include only the SDD content relevant to the current task to keep context focused.
+b. **Extract schema subset**: from `schema.json`, extract only the models,
+   fields, views, and security entries that this task owns (matched via
+   `sdd_components[]`).
 
-c. **Read already-generated code** from the module directory — include a
-   brief summary of existing files and their key structures (models defined,
-   views created, security groups registered). Only include files that are
-   dependencies of the current task.
+c. **Read existing code** from the module directory — include a brief
+   summary of already-generated files (models defined, views created).
 
 d. **Invoke a fresh sub-agent session** using the `task` tool:
    ```
    task(
-     description="Build task TXXX: <name>",
-     prompt="You are building Odoo v18 module code for task TXXX.
+     description="Render task TXXX: <name>",
+     prompt="You are RENDERING Odoo v18 module code from schema.json.
+     You do NOT interpret, design, or make decisions. You translate
+     schema entries into Python/XML files exactly as specified.
 
    Context:
-   - Task specification: <summarize task JSON>
-   - SDD sections: <relevant SDD excerpts>
+   - Schema subset: <schema entries for this task>
+   - Files to generate: <files_to_generate[]>
    - Existing code summary: <brief summary of already-generated files>
 
-   Generate the files listed in files_to_generate[] following Odoo v18
-   conventions. Return which files you created/modified and a brief summary.",
+   Render the files EXACTLY as specified in the schema. Return which files
+   you created/modified and a brief summary.",
      subagent_type="general"
    )
    ```
@@ -65,14 +183,13 @@ e. **Commit the generated code**:
    ```bash
    git add <module_name>/ && git commit -m "feat(#XX): task <id> <name>"
    ```
-   Replace `<id>` with the task ID (e.g., T001) and `<name>` with the task name.
 
 f. **Log progress** — append an event to `.factory/events.jsonl`:
    ```json
    {"type": "task_built", "data": {"task_id": "<id>", "files_generated": [...], "status": "complete"}}
    ```
 
-### 4. Finalize
+### 2.2 Finalize
 After all tasks complete:
 - Update `.factory/state.json`: set `phases.construction.status` to `"complete"`.
   DO NOT change `current_phase` — the orchestrator handles transitions.
@@ -81,14 +198,15 @@ After all tasks complete:
 ## Iterative Protocol Rules
 
 1. **One session per task** — never reuse `task_id` between tasks.
-2. **Context isolation** — each session only receives SDD sections relevant
-   to its task, plus a brief summary of existing code (not full files).
+2. **Schema ONLY** — code renderer sub-agents receive schema subset, not raw tasks/SDD.
 3. **Ordered execution** — tasks must be processed in `order` sequence.
-   A task with unmet dependencies must wait.
-4. **Per-task commits** — each task gets its own git commit with `feat(#XX): task <id> <name>`.
+4. **Per-task commits** — each task gets its own git commit.
+5. **No interpretation** — the schema is the SSOT. Render exactly what it specifies.
 
 ## Post-conditions
+- `.factory/schema.json` exists and is valid (SSOT).
 - A valid Odoo v18 module directory exists with all files from `files_to_generate[]`.
-- One git commit per task in the project repository.
+- All code is generated deterministically from schema.json (zero interpretation).
+- One git commit per task + one commit for schema assembly.
 - `phases.construction.status` is `"complete"`.
 - Ready for `/fba:test`.

--- a/tests/test_build_iterative.py
+++ b/tests/test_build_iterative.py
@@ -28,7 +28,7 @@ class TestBuildCommandFrontmatter:
         assert len(parts) >= 3
         frontmatter = yaml.safe_load(parts[1])
         assert frontmatter.get("agent") == "constructor"
-        assert "Generate" in frontmatter.get("description", "")
+        assert "generate" in frontmatter.get("description", "").lower()
 
     def test_build_command_body_has_iterative_content(self):
         cmd_path = TEMPLATES_DIR / ".opencode" / "commands" / "fba:build.md"


### PR DESCRIPTION
## Summary

Documentacion actualizada para el nuevo alcance de M3.1. El constructor ahora opera como:

```
tasks → Schema Assembly (schema.json SSOT) → Code Renderer (zero interpretation) → odoo_module/
```

## Changes (documentacion)

| File | Change |
|------|--------|
| `AGENTS.md` | +Schema Manager en Agent System, pipeline `tasks→schema→build`, SSOT en Integration Decisions |
| `ROADMAP.md` | M3.1 renombrado, deliverables expandidos con schema, registry, normalizacion, builder contract |
| `CHANGELOG.md` | M3.0a completado, M3.1 detallado |
| `CONTRIBUTING.md` | +Regla #11: cambios de alcance → actualizar docs |
| `fba:build.md` | Rediseño completo: Phase 1 Schema Assembly + Phase 2 Code Rendering |
| `orchestrator.md` | Pipeline actualizado, gate `schema+construction`, context injection |
| `docs/testing/m3-construccion.md` | Nuevo — 10 pasos de verificacion |
| `test_build_iterative.py` | Fix frontmatter check case-insensitive |

## Upcoming (en este mismo branch)

- [ ] `schemas/schema.schema.json` — schema del SSOT
- [ ] `src/fba/module_registry.json` — registry modulos core Odoo v18
- [ ] `templates/.opencode/agents/constructor.md` — agente constructor
- [ ] `src/fba/cli.py` — gate `schema` en `_init_factory_state()`
- [ ] `src/fba/gate.py` — regla de normalizacion si aplica
- [ ] Tests del Schema Manager y Module Registry

## Test Results
```
294 passed
```

Closes #60