### PR TITLE
M5: Bug Fixes & Stability — Cierre formal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Orden corregido: M6 → M7 → M8 (Pipeline) → M9 (Testing). M8 provee la infr
   - `constructor` es propiedad readonly de `Object.prototype` en JS — causa crash `TypeError` al iniciar `opencode .`
   - `build` es agente built-in de OpenCode — conflicto de nombres
   - Renombrados todos los archivos: templates (2 renames), commands (4 contenido), source cli.py, tests (7 archivos), docs (7 archivos)
+- M5: Bug Fixes & Stability — completado (#76)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,7 +13,7 @@ Ver tambien: [README.md](README.md) | [AGENTS.md](AGENTS.md) | [docs/PRD.md](doc
 | M2: Planificacion + SDD | ✅ Completado | 2026-05-04 / 2026-05-04 |
 | M4: Sistema de Gates | ✅ Completado | 2026-05-05 / 2026-05-05 |
 | M3: Construccion + MVP | ✅ Completado | 2026-05-05 / 2026-05-06 |
-| M5: Bug Fixes & Stability | 🔄 En progreso | 2026-05-06 / — |
+| M5: Bug Fixes & Stability | ✅ Completado | 2026-05-06 / 2026-05-08 |
 | M6: Optimización de Agentes | ⏳ Planificado | — / — |
 | M7: User Stories + Code Gen Dual | ⏳ Planificado | — / — |
 | M8: Pipeline, Performance, Multi-modulo | ⏳ Planificado | — / — |
@@ -341,7 +341,7 @@ fba transition tasks       # ✅ gate planning passed, transicion ok
 
 **Objetivo**: Corregir bugs encontrados post-release de los milestones core (M0-M4).
 
-**Estado**: 🔄 En progreso
+**Estado**: ✅ Completado
 
 ### Tareas
 


### PR DESCRIPTION
## Resumen
Cierre formal del milestone M5: Bug Fixes & Stability.

## Cambios
- **ROADMAP.md**: Marcar M5 como `✅ Completado` con fecha de fin `2026-05-08`
- **CHANGELOG.md**: Agregar entrada de cierre M5 en `[0.5.1]`

## Verificacion
- [x] `pytest`: 435 tests pasan
- [x] Fixes M5 ya en main: rename `constructor` → `code-generator`, `fba:build` → `fba:construct`
- [x] No hay issues abiertos de M5

Closes #76