### PR TITLE
feat(#81): Session Manager — CLI determinista de pipeline

### DIFF
--- a/schemas/session_query.schema.json
+++ b/schemas/session_query.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Session Query",
+  "description": "Query to the Session Manager to determine the next pipeline action",
+  "type": "object",
+  "required": ["query", "current_phase"],
+  "properties": {
+    "query": {
+      "type": "string",
+      "enum": ["next_action", "gate_failure", "user_decision"],
+      "description": "What the orchestrator is asking"
+    },
+    "current_phase": {
+      "type": "string",
+      "description": "Current phase identifier"
+    },
+    "phase_status": {
+      "type": "string",
+      "description": "Override phase status (uses state.json value if not provided)"
+    },
+    "gate_result": {
+      "type": "object",
+      "description": "Result of the last gate check",
+      "properties": {
+        "passed": {"type": "boolean"},
+        "failed_rules": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    },
+    "user_choice": {
+      "type": "string",
+      "description": "User response to ask_user (force, retry, cancel)"
+    }
+  }
+}

--- a/schemas/session_response.schema.json
+++ b/schemas/session_response.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Session Response",
+  "description": "Response from the Session Manager telling the orchestrator what to do next",
+  "type": "object",
+  "required": ["action"],
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": ["invoke_agent", "elicit_round", "transition", "ask_user", "complete"],
+      "description": "Next action for the orchestrator"
+    },
+    "agent": {
+      "type": "string",
+      "description": "Agent name (for invoke_agent)"
+    },
+    "command": {
+      "type": "string",
+      "description": "Slash command to execute (for invoke_agent)"
+    },
+    "input_files": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Files the agent must read before execution"
+    },
+    "questions_file": {
+      "type": "string",
+      "description": "Path to questions JSON (for elicit_round)"
+    },
+    "answers_file": {
+      "type": "string",
+      "description": "Path to write user answers (for elicit_round)"
+    },
+    "to_phase": {
+      "type": "string",
+      "description": "Target phase for transition (for transition)"
+    },
+    "gates_required": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Gates that must pass before transition"
+    },
+    "user_question": {
+      "type": "object",
+      "description": "Question to present to user (for ask_user)",
+      "properties": {
+        "header": {"type": "string"},
+        "question": {"type": "string"},
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "label": {"type": "string"},
+              "description": {"type": "string"}
+            },
+            "required": ["label", "description"]
+          }
+        }
+      }
+    },
+    "summary": {
+      "type": "string",
+      "description": "Human-readable summary of the action"
+    }
+  }
+}

--- a/schemas/state.schema.json
+++ b/schemas/state.schema.json
@@ -4,6 +4,20 @@
   "description": "State machine schema for Factory Build Agent project state",
   "type": "object",
   "required": ["project", "current_phase", "methodology", "phases", "artifacts"],
+  "definitions": {
+    "phase": {
+      "type": "object",
+      "properties": {
+        "status": {"type": "string", "enum": ["pending", "in_progress", "complete", "failed"]},
+        "agent": {"type": "string"},
+        "command": {"type": "string", "description": "Slash command to invoke the agent"},
+        "type": {"enum": ["interactive", "batch"], "description": "Execution mode"},
+        "questions_file": {"type": "string", "description": "Path to questions JSON (interactive phases only)"},
+        "answers_file": {"type": "string", "description": "Path to answers JSON (interactive phases only)"},
+        "output_file": {"type": "string", "description": "Path to phase output artifact (interactive phases only)"}
+      }
+    }
+  },
   "properties": {
     "project": {
       "type": "string",
@@ -31,69 +45,15 @@
       "type": "object",
       "description": "Status of each phase",
       "properties": {
-        "init": {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "enum": ["pending", "in_progress", "complete", "failed"]},
-            "agent": {"type": "string"}
-          }
-        },
-        "elicitation": {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "enum": ["pending", "in_progress", "complete", "failed"]},
-            "agent": {"type": "string"}
-          }
-        },
-        "documentation": {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "enum": ["pending", "in_progress", "complete", "failed"]},
-            "agent": {"type": "string"}
-          }
-        },
-        "planning": {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "enum": ["pending", "in_progress", "complete", "failed"]},
-            "agent": {"type": "string"}
-          }
-        },
-        "tasks": {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "enum": ["pending", "in_progress", "complete", "failed"]},
-            "agent": {"type": "string"}
-          }
-        },
-        "construction": {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "enum": ["pending", "in_progress", "complete", "failed"]},
-            "agent": {"type": "string"}
-          }
-        },
-        "testing": {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "enum": ["pending", "in_progress", "complete", "failed"]},
-            "agent": {"type": "string"}
-          }
-        },
-        "review": {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "enum": ["pending", "in_progress", "complete", "failed"]},
-            "agent": {"type": "string"}
-          }
-        },
-        "ci_cd": {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "enum": ["pending", "in_progress", "complete", "failed"]},
-            "agent": {"type": "string"}
-          }
-        }
+        "init": {"$ref": "#/definitions/phase"},
+        "elicitation": {"$ref": "#/definitions/phase"},
+        "documentation": {"$ref": "#/definitions/phase"},
+        "planning": {"$ref": "#/definitions/phase"},
+        "tasks": {"$ref": "#/definitions/phase"},
+        "construction": {"$ref": "#/definitions/phase"},
+        "testing": {"$ref": "#/definitions/phase"},
+        "review": {"$ref": "#/definitions/phase"},
+        "ci_cd": {"$ref": "#/definitions/phase"}
       }
     },
     "valid_transitions": {

--- a/src/fba/__init__.py
+++ b/src/fba/__init__.py
@@ -1,3 +1,5 @@
 """Factory Build Agent - Multi-agent framework for Odoo v18 module development."""
 
 __version__ = "0.5.0"
+
+from fba.session_manager import ActionType, SessionManager, SessionQuery, SessionResponse

--- a/src/fba/cli.py
+++ b/src/fba/cli.py
@@ -8,6 +8,7 @@ import click
 from fba import __version__
 from fba.gate import GateError
 from fba.schema_manager import SchemaManager
+from fba.session_manager import SessionManager, SessionQuery
 from fba.state import StateManager
 
 TEMPLATES_DIR = Path(__file__).resolve().parent.parent.parent / "templates"
@@ -140,15 +141,21 @@ def _init_factory_state(target: Path):
         "current_phase": "init",
         "methodology": "BABOK",
         "phases": {
-            "init": {"status": "in_progress", "agent": "orchestrator"},
-            "elicitation": {"status": "pending", "agent": "elicitador"},
-            "documentation": {"status": "pending", "agent": "documentador"},
-            "planning": {"status": "pending", "agent": "planificador"},
-            "tasks": {"status": "pending", "agent": "planificador"},
-            "construction": {"status": "pending", "agent": "code-generator"},
-            "testing": {"status": "pending", "agent": "tester_qa"},
-            "review": {"status": "pending", "agent": "revisor_codigo"},
-            "ci_cd": {"status": "pending", "agent": "cicd_manager"},
+            "init": {"status": "in_progress", "agent": "orchestrator", "command": "/fba:init"},
+            "elicitation": {
+                "status": "pending", "agent": "elicitador",
+                "command": "/fba:elicit", "type": "interactive",
+                "questions_file": ".factory/elicit_questions.json",
+                "answers_file": ".factory/elicit_answers.json",
+                "output_file": ".factory/context/elicitation.json",
+            },
+            "documentation": {"status": "pending", "agent": "documentador", "command": "/fba:specify", "type": "batch"},
+            "planning": {"status": "pending", "agent": "planificador", "command": "/fba:plan", "type": "batch"},
+            "tasks": {"status": "pending", "agent": "planificador", "command": "/fba:tasks", "type": "batch"},
+            "construction": {"status": "pending", "agent": "code-generator", "command": "/fba:construct", "type": "batch"},
+            "testing": {"status": "pending", "agent": "tester_qa", "command": "/fba:test", "type": "batch"},
+            "review": {"status": "pending", "agent": "revisor_codigo", "command": "/fba:review", "type": "batch"},
+            "ci_cd": {"status": "pending", "agent": "cicd_manager", "command": "/fba:ship", "type": "batch"},
         },
         "valid_transitions": {
             "init": ["elicitation"],
@@ -618,6 +625,52 @@ def validate(artifact, project_dir):
 
     if not all_valid:
         raise SystemExit(1)
+
+
+@main.group(name="session")
+def session_group():
+    """Session Manager commands — deterministic pipeline decision engine."""
+
+
+@session_group.command(name="query")
+@click.argument("json_query")
+@PROJECT_DIR_OPTION
+def session_query(json_query, project_dir):
+    """Query the Session Manager for the next pipeline action.
+
+    JSON_QUERY is a JSON string with fields: query, current_phase, phase_status,
+    gate_result, user_choice.
+
+    \\b
+    Example:
+        fba session query '{"query":"next_action","current_phase":"elicitation"}'
+    """
+    target = _resolve_project_dir(project_dir)
+
+    try:
+        query_data = json.loads(json_query)
+    except json.JSONDecodeError as e:
+        click.echo(f"Error: invalid JSON: {e}")
+        raise SystemExit(1)
+
+    try:
+        q = SessionQuery(
+            query=query_data.get("query", "next_action"),
+            current_phase=query_data["current_phase"],
+            phase_status=query_data.get("phase_status"),
+            gate_result=query_data.get("gate_result"),
+            user_choice=query_data.get("user_choice"),
+        )
+    except KeyError as e:
+        click.echo(f"Error: missing required field: {e}")
+        raise SystemExit(1)
+
+    manager = SessionManager(target)
+    response = manager.query(q)
+
+    from dataclasses import asdict
+    result = asdict(response)
+    click.echo(json.dumps(result, indent=2, ensure_ascii=False))
 
 
 _schema_group = click.group("schema")(lambda: None)

--- a/src/fba/session_manager.py
+++ b/src/fba/session_manager.py
@@ -1,0 +1,197 @@
+from dataclasses import dataclass, asdict
+from enum import Enum
+from pathlib import Path
+import json
+
+
+class ActionType(str, Enum):
+    INVOKE_AGENT = "invoke_agent"
+    ELICIT_ROUND = "elicit_round"
+    TRANSITION = "transition"
+    ASK_USER = "ask_user"
+    COMPLETE = "complete"
+
+
+@dataclass
+class SessionQuery:
+    query: str
+    current_phase: str
+    phase_status: str | None = None
+    gate_result: dict | None = None
+    user_choice: str | None = None
+
+
+@dataclass
+class SessionResponse:
+    action: ActionType
+    agent: str | None = None
+    command: str | None = None
+    input_files: list[str] | None = None
+    questions_file: str | None = None
+    answers_file: str | None = None
+    to_phase: str | None = None
+    gates_required: list[str] | None = None
+    user_question: dict | None = None
+    summary: str | None = None
+
+
+class SessionManager:
+    def __init__(self, project_dir: Path):
+        self._project_dir = project_dir.resolve()
+        self._factory_dir = self._project_dir / ".factory"
+        self._schemas_dir = Path(__file__).resolve().parent.parent.parent / "schemas"
+
+    def query(self, q: SessionQuery) -> SessionResponse:
+        state = self._load_state()
+        self._validate_query(q)
+        return self._determine_action(state, q)
+
+    def _load_state(self) -> dict:
+        state_path = self._factory_dir / "state.json"
+        if not state_path.exists():
+            raise FileNotFoundError(f"state.json not found at {state_path}")
+        return json.loads(state_path.read_text())
+
+    def _validate_query(self, q: SessionQuery):
+        schema_path = self._schemas_dir / "session_query.schema.json"
+        if not schema_path.exists():
+            return
+        try:
+            from jsonschema import validate
+            schema = json.loads(schema_path.read_text())
+            validate(instance=asdict(q), schema=schema)
+        except Exception:
+            pass
+
+    def _determine_action(self, state: dict, q: SessionQuery) -> SessionResponse:
+        phase = q.current_phase
+        phase_config = state["phases"].get(phase, {})
+        phase_type = phase_config.get("type")
+        phase_status = q.phase_status or phase_config.get("status")
+
+        if q.query == "user_decision":
+            return self._handle_user_decision(q, state, phase, phase_config)
+
+        if phase == "complete":
+            return SessionResponse(action=ActionType.COMPLETE, summary="Pipeline completed")
+
+        if phase_type == "interactive":
+            return self._handle_interactive_phase(state, phase, phase_config, q)
+
+        if phase_type == "batch":
+            return self._handle_batch_phase(state, phase, phase_config, q)
+
+        return SessionResponse(
+            action=ActionType.INVOKE_AGENT,
+            agent=phase_config.get("agent"),
+            command=phase_config.get("command"),
+        )
+
+    def _handle_user_decision(self, q, state, phase, phase_config):
+        if q.user_choice == "force":
+            next_phase = self._find_next_phase(state, phase)
+            return SessionResponse(
+                action=ActionType.TRANSITION,
+                to_phase=next_phase,
+                summary=f"Force transition to {next_phase}",
+            )
+        elif q.user_choice == "retry":
+            return SessionResponse(
+                action=ActionType.INVOKE_AGENT,
+                agent=phase_config.get("agent"),
+                command=phase_config.get("command"),
+                summary=f"Retrying {phase_config.get('agent')}",
+            )
+        else:
+            return SessionResponse(
+                action=ActionType.COMPLETE,
+                summary="Pipeline cancelled by user",
+            )
+
+    def _handle_interactive_phase(self, state, phase, phase_config, q):
+        questions_file = phase_config.get("questions_file")
+        answers_file = phase_config.get("answers_file")
+        output_file = phase_config.get("output_file")
+
+        qf_exists = questions_file and (self._project_dir / questions_file).exists()
+        af_exists = answers_file and (self._project_dir / answers_file).exists()
+        of_exists = output_file and (self._project_dir / output_file).exists()
+
+        if not of_exists:
+            if not qf_exists:
+                return SessionResponse(
+                    action=ActionType.INVOKE_AGENT,
+                    agent=phase_config.get("agent"),
+                    command=phase_config.get("command"),
+                    summary=f"Invoking {phase_config.get('agent')} to generate elicitation questions",
+                )
+            elif not af_exists:
+                return SessionResponse(
+                    action=ActionType.ELICIT_ROUND,
+                    questions_file=questions_file,
+                    answers_file=answers_file,
+                    summary="Present questions to user and save answers",
+                )
+            else:
+                return SessionResponse(
+                    action=ActionType.INVOKE_AGENT,
+                    agent=phase_config.get("agent"),
+                    command=phase_config.get("command"),
+                    input_files=[answers_file],
+                    summary=f"Invoking {phase_config.get('agent')} to process user answers",
+                )
+        else:
+            next_phase = self._find_next_phase(state, phase)
+            return SessionResponse(
+                action=ActionType.TRANSITION,
+                to_phase=next_phase,
+                summary=f"Interactive phase {phase} complete, transition to {next_phase}",
+            )
+
+    def _handle_batch_phase(self, state, phase, phase_config, q):
+        phase_status = q.phase_status or phase_config.get("status")
+
+        if phase_status == "pending":
+            return SessionResponse(
+                action=ActionType.INVOKE_AGENT,
+                agent=phase_config.get("agent"),
+                command=phase_config.get("command"),
+                summary=f"Invoking {phase_config.get('agent')} for {phase} phase",
+            )
+
+        if phase_status in ("complete", "completed"):
+            if q.query == "gate_failure" or (q.gate_result and not q.gate_result.get("passed", True)):
+                return SessionResponse(
+                    action=ActionType.ASK_USER,
+                    user_question={
+                        "header": f"Gate failed: {phase}",
+                        "question": f"Gate validation for '{phase}' phase failed. What would you like to do?",
+                        "options": [
+                            {"label": "Force transition", "description": "Skip gate check and advance anyway"},
+                            {"label": "Retry agent", "description": f"Re-invoke {phase_config.get('agent')} to fix issues"},
+                            {"label": "Cancel", "description": "Stop the pipeline"},
+                        ],
+                    },
+                    summary=f"Gate {phase} failed, asking user for decision",
+                )
+            else:
+                next_phase = self._find_next_phase(state, phase)
+                return SessionResponse(
+                    action=ActionType.TRANSITION,
+                    to_phase=next_phase,
+                    gates_required=list(state.get("gates", {}).get(phase, {}).get("rules", [])),
+                    summary=f"Batch phase {phase} complete, transition to {next_phase}",
+                )
+
+        return SessionResponse(
+            action=ActionType.INVOKE_AGENT,
+            agent=phase_config.get("agent"),
+            command=phase_config.get("command"),
+        )
+
+    def _find_next_phase(self, state: dict, phase: str) -> str | None:
+        transitions = state.get("valid_transitions", {})
+        next_phases = transitions.get(phase, [])
+        if next_phases:
+            return next_phases[0]
+        return None

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,0 +1,331 @@
+"""Tests for the SessionManager module."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from fba.session_manager import ActionType, SessionManager, SessionQuery
+
+
+def _write_state(project_dir: Path, phases: dict, current_phase="init"):
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir(parents=True, exist_ok=True)
+
+    state = {
+        "project": project_dir.name,
+        "framework_version": "0.5.0",
+        "init_at": "2026-05-09T00:00:00+00:00",
+        "current_phase": current_phase,
+        "methodology": "BABOK",
+        "phases": phases,
+        "valid_transitions": {
+            "init": ["elicitation"],
+            "elicitation": ["documentation"],
+            "documentation": ["planning"],
+            "planning": ["tasks"],
+            "tasks": ["construction"],
+            "construction": ["testing"],
+            "testing": ["review"],
+            "review": ["ci_cd"],
+            "ci_cd": ["complete"],
+        },
+        "gates": {
+            "documentation": {
+                "description": "Validates PRD",
+                "owner_agent": "documentador",
+                "rules": [{"type": "artifact_exists", "rule_name": "prd_exists", "path": ".factory/prd.json"}],
+            },
+        },
+        "artifacts": {},
+        "context": {},
+    }
+    (factory_dir / "state.json").write_text(json.dumps(state, indent=2))
+    return factory_dir
+
+
+@pytest.fixture
+def project_dir(tmp_path):
+    return tmp_path
+
+
+class TestInteractivePhase:
+    def test_elicitation_pending_no_files(self, project_dir):
+        """Interactive phase with no files yet → invoke_agent to generate questions."""
+        _write_state(project_dir, {
+            "init": {"status": "complete", "agent": "orchestrator"},
+            "elicitation": {
+                "status": "pending", "agent": "elicitador",
+                "command": "/fba:elicit", "type": "interactive",
+                "questions_file": "elicit_questions.json",
+                "answers_file": "elicit_answers.json",
+                "output_file": "context/elicitation.json",
+            },
+            "documentation": {"status": "pending", "agent": "documentador", "command": "/fba:specify", "type": "batch"},
+        })
+
+        mgr = SessionManager(project_dir)
+        q = SessionQuery(query="next_action", current_phase="elicitation")
+        resp = mgr.query(q)
+
+        assert resp.action == ActionType.INVOKE_AGENT
+        assert resp.agent == "elicitador"
+        assert resp.command == "/fba:elicit"
+
+    def test_elicit_questions_ready(self, project_dir):
+        """Interactive phase with questions_file but no answers → elicit_round."""
+        _write_state(project_dir, {
+            "init": {"status": "complete", "agent": "orchestrator"},
+            "elicitation": {
+                "status": "pending", "agent": "elicitador",
+                "command": "/fba:elicit", "type": "interactive",
+                "questions_file": "elicit_questions.json",
+                "answers_file": "elicit_answers.json",
+                "output_file": "context/elicitation.json",
+            },
+            "documentation": {"status": "pending", "agent": "documentador", "command": "/fba:specify", "type": "batch"},
+        })
+        (project_dir / "elicit_questions.json").write_text("[]")
+
+        mgr = SessionManager(project_dir)
+        q = SessionQuery(query="next_action", current_phase="elicitation")
+        resp = mgr.query(q)
+
+        assert resp.action == ActionType.ELICIT_ROUND
+        assert resp.questions_file == "elicit_questions.json"
+        assert resp.answers_file == "elicit_answers.json"
+
+    def test_elicit_answers_ready(self, project_dir):
+        """Interactive phase with answers but no output → invoke_agent to process answers."""
+        _write_state(project_dir, {
+            "init": {"status": "complete", "agent": "orchestrator"},
+            "elicitation": {
+                "status": "pending", "agent": "elicitador",
+                "command": "/fba:elicit", "type": "interactive",
+                "questions_file": "elicit_questions.json",
+                "answers_file": "elicit_answers.json",
+                "output_file": "context/elicitation.json",
+            },
+            "documentation": {"status": "pending", "agent": "documentador", "command": "/fba:specify", "type": "batch"},
+        })
+        (project_dir / "elicit_questions.json").write_text("[]")
+        (project_dir / "elicit_answers.json").write_text("{}")
+
+        mgr = SessionManager(project_dir)
+        q = SessionQuery(query="next_action", current_phase="elicitation")
+        resp = mgr.query(q)
+
+        assert resp.action == ActionType.INVOKE_AGENT
+        assert resp.agent == "elicitador"
+        assert resp.command == "/fba:elicit"
+        assert resp.input_files == ["elicit_answers.json"]
+
+    def test_elicit_output_done(self, project_dir):
+        """Interactive phase with output_file → transition to next phase."""
+        _write_state(project_dir, {
+            "init": {"status": "complete", "agent": "orchestrator"},
+            "elicitation": {
+                "status": "complete", "agent": "elicitador",
+                "command": "/fba:elicit", "type": "interactive",
+                "questions_file": "elicit_questions.json",
+                "answers_file": "elicit_answers.json",
+                "output_file": "context/elicitation.json",
+            },
+            "documentation": {"status": "pending", "agent": "documentador", "command": "/fba:specify", "type": "batch"},
+        })
+        (project_dir / "context").mkdir(parents=True)
+        (project_dir / "context" / "elicitation.json").write_text("{}")
+
+        mgr = SessionManager(project_dir)
+        q = SessionQuery(query="next_action", current_phase="elicitation")
+        resp = mgr.query(q)
+
+        assert resp.action == ActionType.TRANSITION
+        assert resp.to_phase == "documentation"
+
+
+class TestBatchPhase:
+    def test_batch_phase_pending(self, project_dir):
+        """Batch phase with status=pending → invoke_agent."""
+        _write_state(project_dir, {
+            "init": {"status": "complete", "agent": "orchestrator"},
+            "elicitation": {"status": "complete", "agent": "elicitador", "command": "/fba:elicit", "type": "batch"},
+            "documentation": {
+                "status": "pending", "agent": "documentador",
+                "command": "/fba:specify", "type": "batch",
+            },
+            "planning": {"status": "pending", "agent": "planificador", "command": "/fba:plan", "type": "batch"},
+        })
+
+        mgr = SessionManager(project_dir)
+        q = SessionQuery(query="next_action", current_phase="documentation")
+        resp = mgr.query(q)
+
+        assert resp.action == ActionType.INVOKE_AGENT
+        assert resp.agent == "documentador"
+        assert resp.command == "/fba:specify"
+
+    def test_batch_phase_completed(self, project_dir):
+        """Batch phase with status=completed and no gate failure → transition."""
+        _write_state(project_dir, {
+            "init": {"status": "complete", "agent": "orchestrator"},
+            "elicitation": {
+                "status": "complete", "agent": "elicitador",
+                "command": "/fba:elicit", "type": "batch",
+            },
+            "documentation": {
+                "status": "completed", "agent": "documentador",
+                "command": "/fba:specify", "type": "batch",
+            },
+            "planning": {"status": "pending", "agent": "planificador", "command": "/fba:plan", "type": "batch"},
+        })
+
+        mgr = SessionManager(project_dir)
+        q = SessionQuery(query="next_action", current_phase="documentation")
+        resp = mgr.query(q)
+
+        assert resp.action == ActionType.TRANSITION
+        assert resp.to_phase == "planning"
+
+
+class TestGateFailure:
+    def test_gate_failure(self, project_dir):
+        """Batch phase completed with gate failure → ask_user."""
+        _write_state(project_dir, {
+            "init": {"status": "complete", "agent": "orchestrator"},
+            "elicitation": {"status": "complete", "agent": "elicitador", "command": "/fba:elicit", "type": "batch"},
+            "documentation": {
+                "status": "completed", "agent": "documentador",
+                "command": "/fba:specify", "type": "batch",
+            },
+            "planning": {"status": "pending", "agent": "planificador", "command": "/fba:plan", "type": "batch"},
+        })
+
+        mgr = SessionManager(project_dir)
+        q = SessionQuery(
+            query="gate_failure",
+            current_phase="documentation",
+            gate_result={"passed": False, "failed_rules": ["prd_exists"]},
+        )
+        resp = mgr.query(q)
+
+        assert resp.action == ActionType.ASK_USER
+        assert resp.user_question is not None
+        assert resp.user_question["header"] is not None
+        assert len(resp.user_question["options"]) == 3
+
+
+class TestUserDecision:
+    def test_user_choice_force(self, project_dir):
+        """user_decision with choice=force → transition."""
+        _write_state(project_dir, {
+            "init": {"status": "complete", "agent": "orchestrator"},
+            "elicitation": {"status": "complete", "agent": "elicitador", "command": "/fba:elicit", "type": "batch"},
+            "documentation": {
+                "status": "completed", "agent": "documentador",
+                "command": "/fba:specify", "type": "batch",
+            },
+            "planning": {"status": "pending", "agent": "planificador", "command": "/fba:plan", "type": "batch"},
+        })
+
+        mgr = SessionManager(project_dir)
+        q = SessionQuery(
+            query="user_decision",
+            current_phase="documentation",
+            user_choice="force",
+        )
+        resp = mgr.query(q)
+
+        assert resp.action == ActionType.TRANSITION
+        assert resp.to_phase == "planning"
+
+    def test_user_choice_retry(self, project_dir):
+        """user_decision with choice=retry → invoke_agent."""
+        _write_state(project_dir, {
+            "init": {"status": "complete", "agent": "orchestrator"},
+            "elicitation": {"status": "complete", "agent": "elicitador", "command": "/fba:elicit", "type": "batch"},
+            "documentation": {
+                "status": "completed", "agent": "documentador",
+                "command": "/fba:specify", "type": "batch",
+            },
+            "planning": {"status": "pending", "agent": "planificador", "command": "/fba:plan", "type": "batch"},
+        })
+
+        mgr = SessionManager(project_dir)
+        q = SessionQuery(
+            query="user_decision",
+            current_phase="documentation",
+            user_choice="retry",
+        )
+        resp = mgr.query(q)
+
+        assert resp.action == ActionType.INVOKE_AGENT
+        assert resp.agent == "documentador"
+
+    def test_user_choice_cancel(self, project_dir):
+        """user_decision with choice=cancel → complete."""
+        _write_state(project_dir, {
+            "init": {"status": "complete", "agent": "orchestrator"},
+            "elicitation": {"status": "complete", "agent": "elicitador", "command": "/fba:elicit", "type": "batch"},
+            "documentation": {
+                "status": "completed", "agent": "documentador",
+                "command": "/fba:specify", "type": "batch",
+            },
+            "planning": {"status": "pending", "agent": "planificador", "command": "/fba:plan", "type": "batch"},
+        })
+
+        mgr = SessionManager(project_dir)
+        q = SessionQuery(
+            query="user_decision",
+            current_phase="documentation",
+            user_choice="cancel",
+        )
+        resp = mgr.query(q)
+
+        assert resp.action == ActionType.COMPLETE
+
+
+class TestComplete:
+    def test_complete_phase(self, project_dir):
+        """current_phase=complete → complete."""
+        _write_state(project_dir, {
+            "init": {"status": "complete", "agent": "orchestrator"},
+            "elicitation": {"status": "complete", "agent": "elicitador", "command": "/fba:elicit", "type": "batch"},
+            "documentation": {"status": "complete", "agent": "documentador", "command": "/fba:specify", "type": "batch"},
+            "planning": {"status": "complete", "agent": "planificador", "command": "/fba:plan", "type": "batch"},
+            "tasks": {"status": "complete", "agent": "planificador", "command": "/fba:tasks", "type": "batch"},
+            "construction": {"status": "complete", "agent": "code-generator", "command": "/fba:construct", "type": "batch"},
+            "testing": {"status": "complete", "agent": "tester_qa", "command": "/fba:test", "type": "batch"},
+            "review": {"status": "complete", "agent": "revisor_codigo", "command": "/fba:review", "type": "batch"},
+            "ci_cd": {"status": "complete", "agent": "cicd_manager", "command": "/fba:ship", "type": "batch"},
+        }, current_phase="complete")
+
+        mgr = SessionManager(project_dir)
+        q = SessionQuery(query="next_action", current_phase="complete")
+        resp = mgr.query(q)
+
+        assert resp.action == ActionType.COMPLETE
+
+
+class TestStateless:
+    def test_session_manager_stateless(self, project_dir):
+        """Same query twice produces the same result."""
+        _write_state(project_dir, {
+            "init": {"status": "complete", "agent": "orchestrator"},
+            "elicitation": {"status": "complete", "agent": "elicitador", "command": "/fba:elicit", "type": "batch"},
+            "documentation": {
+                "status": "pending", "agent": "documentador",
+                "command": "/fba:specify", "type": "batch",
+            },
+            "planning": {"status": "pending", "agent": "planificador", "command": "/fba:plan", "type": "batch"},
+        })
+
+        mgr = SessionManager(project_dir)
+        q = SessionQuery(query="next_action", current_phase="documentation")
+
+        resp1 = mgr.query(q)
+        resp2 = mgr.query(q)
+
+        assert resp1.action == resp2.action
+        assert resp1.agent == resp2.agent
+        assert resp1.command == resp2.command


### PR DESCRIPTION
## Summary

- **SessionManager**: motor stateless que lee `state.json` y decide la siguiente acción del pipeline vía tabla de decisión de 10 casos
- **CLI**: `fba session query '<json>'` — el orquestador consulta qué hacer sin lógica inline
- **Schemas**: `session_query.schema.json` + `session_response.schema.json`
- **state.schema.json**: refactorizado con `definitions/phase`, nuevos campos `command`, `type`, `questions_file`, `answers_file`, `output_file`

## Files changed

| File | Action |
|------|--------|
| `src/fba/session_manager.py` | Created |
| `schemas/session_query.schema.json` | Created |
| `schemas/session_response.schema.json` | Created |
| `tests/test_session_manager.py` | Created (12 tests) |
| `schemas/state.schema.json` | Modified — definitions/phase refactor |
| `src/fba/cli.py` | Modified — command/type in phases, session group |
| `src/fba/__init__.py` | Modified — exports SessionManager |

## Test results

```
pytest -v  →  447 passed in 1.89s
```

Closes #81