### PR TITLE
feat/10.1: framework-state.json + schema de validacion

### DIFF
--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "1.0",
+  "last_updated": "2026-05-09T00:00:00Z",
+  "last_session": {
+    "date": "2026-05-09",
+    "agent": "framework-builder",
+    "action": "feat/10.1-framework-state creado",
+    "completed_feats": [],
+    "pending_feats": ["feat/10.2", "feat/10.3", "feat/10.4", "feat/10.5"],
+    "blockers": []
+  },
+  "active_milestone": {
+    "id": "M10",
+    "name": "Framework Meta-Development System",
+    "branch": "milestone/10.0-framework-meta-dev",
+    "status": "in_progress",
+    "feats_total": 5,
+    "feats_done": 0,
+    "feats_pending": ["feat/10.1-framework-state", "feat/10.2-agentes-meta", "feat/10.3-slash-commands", "feat/10.4-fw-brief-template", "feat/10.5-docs"],
+    "ready_for_user_review": false
+  },
+  "roadmap_status": {
+    "M0": "completed",
+    "M1": "completed",
+    "M2": "completed",
+    "M3": "completed",
+    "M4": "completed",
+    "M5": "completed",
+    "M10": "in_progress",
+    "M6": "planned",
+    "M7": "planned",
+    "M8": "planned",
+    "M9": "planned"
+  },
+  "pending_decisions": [],
+  "open_briefs": [],
+  "agents": {
+    "framework-orchestrator": { "status": "active", "file": ".opencode/agents/framework-orchestrator.md" },
+    "framework-planner":     { "status": "active", "file": ".opencode/agents/framework-planner.md" },
+    "framework-builder":     { "status": "active", "file": ".opencode/agents/framework-builder.md" }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -71,5 +71,6 @@ venv.bak/
 .opencode/log/
 
 # Factory Build Agent target projects (these are output, not source)
-.factory/
-!templates/.factory/module_registry.json
+.factory/*
+!.factory/framework-state.json
+!templates/.factory/*

--- a/schemas/framework-state.schema.json
+++ b/schemas/framework-state.schema.json
@@ -1,0 +1,179 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "FBA Framework Meta-Development State",
+  "description": "Persistent state schema for the framework meta-agents (orchestrator, planner, builder)",
+  "type": "object",
+  "required": ["schema_version", "last_updated", "last_session", "active_milestone", "roadmap_status", "agents"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "description": "Version of this schema"
+    },
+    "last_updated": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of last update"
+    },
+    "last_session": {
+      "type": "object",
+      "description": "Summary of the last development session",
+      "required": ["date", "agent", "action", "completed_feats", "pending_feats"],
+      "properties": {
+        "date": {
+          "type": "string",
+          "description": "Date of the last session (YYYY-MM-DD)"
+        },
+        "agent": {
+          "type": "string",
+          "description": "Agent that executed the last session (framework-builder, framework-planner)"
+        },
+        "action": {
+          "type": "string",
+          "description": "Summary of the last action performed"
+        },
+        "completed_feats": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Feats completed in the last session"
+        },
+        "pending_feats": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Feats left pending at the end of the last session"
+        },
+        "blockers": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Blockers identified during the last session"
+        }
+      }
+    },
+    "active_milestone": {
+      "type": "object",
+      "description": "The milestone currently being worked on",
+      "required": ["id", "name", "branch", "status", "feats_total", "feats_done", "feats_pending"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Milestone ID (e.g. M10)"
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable milestone name"
+        },
+        "branch": {
+          "type": "string",
+          "description": "Git branch name for the milestone"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["pending", "in_progress", "completed"],
+          "description": "Current status of the milestone"
+        },
+        "feats_total": {
+          "type": "integer",
+          "description": "Total number of feats in the milestone"
+        },
+        "feats_done": {
+          "type": "integer",
+          "description": "Number of completed feats"
+        },
+        "feats_pending": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of pending feat identifiers"
+        },
+        "ready_for_user_review": {
+          "type": "boolean",
+          "description": "Whether the milestone is ready for user review before PR to main",
+          "default": false
+        }
+      }
+    },
+    "roadmap_status": {
+      "type": "object",
+      "description": "Status of all milestones in the roadmap",
+      "additionalProperties": {
+        "type": "string",
+        "enum": ["planned", "in_progress", "completed"]
+      }
+    },
+    "pending_decisions": {
+      "type": "array",
+      "description": "Decisions awaiting user input",
+      "items": {
+        "type": "object",
+        "required": ["id", "description", "raised_by", "raised_at", "status"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Decision identifier (e.g. DEC-001)"
+          },
+          "description": {
+            "type": "string",
+            "description": "What needs to be decided"
+          },
+          "raised_by": {
+            "type": "string",
+            "description": "Agent that raised the decision"
+          },
+          "raised_at": {
+            "type": "string",
+            "description": "Date when the decision was raised"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["awaiting_user", "resolved"],
+            "description": "Current decision status"
+          }
+        }
+      }
+    },
+    "open_briefs": {
+      "type": "array",
+      "description": "Briefs that have been generated but not yet fully executed",
+      "items": {
+        "type": "object",
+        "required": ["file", "milestone", "feats_remaining", "status"],
+        "properties": {
+          "file": {
+            "type": "string",
+            "description": "Path to the brief file"
+          },
+          "milestone": {
+            "type": "string",
+            "description": "Milestone the brief belongs to"
+          },
+          "feats_remaining": {
+            "type": "integer",
+            "description": "Number of feats remaining to be built"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["active", "completed"],
+            "description": "Current status of the brief"
+          }
+        }
+      }
+    },
+    "agents": {
+      "type": "object",
+      "description": "Status of all meta-agents",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["status", "file"],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": ["active", "inactive", "deprecated"],
+            "description": "Current status of the agent"
+          },
+          "file": {
+            "type": "string",
+            "description": "Path to the agent definition file"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/.factory/module_registry.json
+++ b/templates/.factory/module_registry.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://opencode.ai/fba/schemas/module_registry.schema.json",
+  "odoo_version": "18.0",
+  "description": "Registry of Odoo v18 core modules and their canonical models. Used by the Schema Manager to determine new vs extend mode.",
+  "modules": {
+    "base": {
+      "description": "Core Odoo module with base models",
+      "models": [
+        "res.partner",
+        "res.users",
+        "res.company",
+        "res.country",
+        "res.country.state",
+        "res.currency",
+        "res.lang",
+        "ir.model",
+        "ir.model.fields",
+        "ir.actions.act_window",
+        "ir.actions.server",
+        "ir.ui.menu",
+        "ir.ui.view",
+        "ir.attachment",
+        "ir.config_parameter"
+      ]
+    },
+    "mail": {
+      "description": "Odoo mail and messaging module",
+      "models": [
+        "mail.message",
+        "mail.activity",
+        "mail.activity.type",
+        "mail.channel",
+        "mail.channel.member",
+        "mail.notification",
+        "mail.template"
+      ]
+    },
+    "product": {
+      "description": "Odoo product management module",
+      "models": [
+        "product.product",
+        "product.template",
+        "product.category",
+        "product.attribute",
+        "product.attribute.value",
+        "product.pricelist",
+        "product.pricelist.item",
+        "product.uom",
+        "product.uom.category",
+        "product.packaging"
+      ]
+    },
+    "sale": {
+      "description": "Odoo sales management module",
+      "models": [
+        "sale.order",
+        "sale.order.line",
+        "sale.order.template",
+        "sale.order.template.line",
+        "sale.advance.payment.inv",
+        "sale.report"
+      ]
+    },
+    "account": {
+      "description": "Odoo accounting module",
+      "models": [
+        "account.move",
+        "account.move.line",
+        "account.account",
+        "account.journal",
+        "account.payment",
+        "account.tax",
+        "account.tax.group",
+        "account.fiscal.position",
+        "account.payment.term",
+        "account.analytic.account",
+        "account.analytic.line",
+        "account.chart.template",
+        "account.financial.year"
+      ]
+    },
+    "stock": {
+      "description": "Odoo inventory and warehouse management module",
+      "models": [
+        "stock.move",
+        "stock.move.line",
+        "stock.picking",
+        "stock.picking.type",
+        "stock.location",
+        "stock.warehouse",
+        "stock.quant",
+        "stock.inventory",
+        "stock.production.lot",
+        "stock.rule",
+        "stock.package.type",
+        "stock.putaway.rule"
+      ]
+    },
+    "hr": {
+      "description": "Odoo human resources module",
+      "models": [
+        "hr.employee",
+        "hr.department",
+        "hr.job",
+        "hr.contract",
+        "hr.leave",
+        "hr.leave.type",
+        "hr.attendance",
+        "hr.expense",
+        "hr.applicant"
+      ]
+    },
+    "crm": {
+      "description": "Odoo CRM module",
+      "models": [
+        "crm.lead",
+        "crm.team",
+        "crm.stage",
+        "crm.activity.report",
+        "crm.lead.lost",
+        "crm.merge.opportunity"
+      ]
+    },
+    "web": {
+      "description": "Odoo web client core module",
+      "models": [
+        "ir.http",
+        "ir.qweb"
+      ]
+    },
+    "purchase": {
+      "description": "Odoo purchase management module",
+      "models": [
+        "purchase.order",
+        "purchase.order.line",
+        "purchase.requisition",
+        "purchase.requisition.line"
+      ]
+    },
+    "fleet": {
+      "description": "Odoo fleet management module",
+      "models": [
+        "fleet.vehicle",
+        "fleet.vehicle.model",
+        "fleet.vehicle.model.brand",
+        "fleet.vehicle.odometer",
+        "fleet.vehicle.log.contract",
+        "fleet.vehicle.log.services"
+      ]
+    },
+    "uom": {
+      "description": "Odoo unit of measure module",
+      "models": [
+        "uom.uom",
+        "uom.category"
+      ]
+    }
+  }
+}

--- a/tests/test_framework_state_schema.py
+++ b/tests/test_framework_state_schema.py
@@ -1,0 +1,198 @@
+"""Tests for framework-state schema validation."""
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "schemas" / "framework-state.schema.json"
+
+
+@pytest.fixture
+def fw_state_schema():
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+def _valid_state():
+    return {
+        "schema_version": "1.0",
+        "last_updated": "2026-05-09T00:00:00Z",
+        "last_session": {
+            "date": "2026-05-09",
+            "agent": "framework-builder",
+            "action": "test session",
+            "completed_feats": ["feat/10.1"],
+            "pending_feats": ["feat/10.2"],
+            "blockers": []
+        },
+        "active_milestone": {
+            "id": "M10",
+            "name": "Framework Meta-Development",
+            "branch": "milestone/10.0-framework-meta-dev",
+            "status": "in_progress",
+            "feats_total": 5,
+            "feats_done": 1,
+            "feats_pending": ["feat/10.2", "feat/10.3", "feat/10.4", "feat/10.5"],
+            "ready_for_user_review": False
+        },
+        "roadmap_status": {
+            "M0": "completed",
+            "M1": "completed",
+            "M5": "completed",
+            "M10": "in_progress",
+            "M6": "planned"
+        },
+        "pending_decisions": [],
+        "open_briefs": [],
+        "agents": {
+            "framework-orchestrator": {"status": "active", "file": ".opencode/agents/framework-orchestrator.md"},
+            "framework-planner":     {"status": "active", "file": ".opencode/agents/framework-planner.md"},
+            "framework-builder":     {"status": "active", "file": ".opencode/agents/framework-builder.md"}
+        }
+    }
+
+
+class TestFrameworkStateSchemaValid:
+    """Valid states must pass validation."""
+
+    def test_valid_state_passes(self, fw_state_schema):
+        jsonschema.validate(_valid_state(), fw_state_schema)
+
+    def test_with_pending_decisions_passes(self, fw_state_schema):
+        state = _valid_state()
+        state["pending_decisions"] = [
+            {
+                "id": "DEC-001",
+                "description": "Should we add multi-model support?",
+                "raised_by": "framework-planner",
+                "raised_at": "2026-05-08",
+                "status": "awaiting_user"
+            }
+        ]
+        jsonschema.validate(state, fw_state_schema)
+
+    def test_with_open_briefs_passes(self, fw_state_schema):
+        state = _valid_state()
+        state["open_briefs"] = [
+            {
+                "file": ".factory/fw-brief.md",
+                "milestone": "M10",
+                "feats_remaining": 4,
+                "status": "active"
+            }
+        ]
+        jsonschema.validate(state, fw_state_schema)
+
+    def test_with_blockers_passes(self, fw_state_schema):
+        state = _valid_state()
+        state["last_session"]["blockers"] = ["Missing dependency X"]
+        jsonschema.validate(state, fw_state_schema)
+
+
+class TestFrameworkStateSchemaMissingFields:
+    """Missing required fields must fail validation."""
+
+    def test_missing_schema_version_fails(self, fw_state_schema):
+        state = _valid_state()
+        del state["schema_version"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_missing_last_updated_fails(self, fw_state_schema):
+        state = _valid_state()
+        del state["last_updated"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_missing_last_session_fails(self, fw_state_schema):
+        state = _valid_state()
+        del state["last_session"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_missing_active_milestone_fails(self, fw_state_schema):
+        state = _valid_state()
+        del state["active_milestone"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_missing_roadmap_status_fails(self, fw_state_schema):
+        state = _valid_state()
+        del state["roadmap_status"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_missing_agents_fails(self, fw_state_schema):
+        state = _valid_state()
+        del state["agents"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_missing_last_session_date_fails(self, fw_state_schema):
+        state = _valid_state()
+        del state["last_session"]["date"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_missing_active_milestone_id_fails(self, fw_state_schema):
+        state = _valid_state()
+        del state["active_milestone"]["id"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+
+class TestFrameworkStateSchemaInvalidValues:
+    """Invalid enum values must fail validation."""
+
+    def test_invalid_milestone_status_fails(self, fw_state_schema):
+        state = _valid_state()
+        state["active_milestone"]["status"] = "unknown"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_invalid_roadmap_status_fails(self, fw_state_schema):
+        state = _valid_state()
+        state["roadmap_status"]["M6"] = "started"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_invalid_decision_status_fails(self, fw_state_schema):
+        state = _valid_state()
+        state["pending_decisions"] = [
+            {
+                "id": "DEC-001",
+                "description": "Test",
+                "raised_by": "framework-planner",
+                "raised_at": "2026-05-08",
+                "status": "in_progress"
+            }
+        ]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_invalid_brief_status_fails(self, fw_state_schema):
+        state = _valid_state()
+        state["open_briefs"] = [
+            {
+                "file": "brief.md",
+                "milestone": "M10",
+                "feats_remaining": 3,
+                "status": "paused"
+            }
+        ]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_decision_status_resolved_passes(self, fw_state_schema):
+        state = _valid_state()
+        state["pending_decisions"] = [
+            {
+                "id": "DEC-001",
+                "description": "Test",
+                "raised_by": "framework-planner",
+                "raised_at": "2026-05-08",
+                "status": "resolved"
+            }
+        ]
+        jsonschema.validate(state, fw_state_schema)


### PR DESCRIPTION
Closes #92

## Cambios

- **`.factory/framework-state.json`**: estado persistente entre sesiones con roadmap_status, active_milestone, last_session, pending_decisions, open_briefs, agents
- **`schemas/framework-state.schema.json`**: JSON Schema para validar el archivo de estado
- **`tests/test_framework_state_schema.py`**: 17 tests (validos, missing fields, valores invalidos)
- **`.gitignore`**: ajustado para incluir `.factory/framework-state.json` en el repo