### PR TITLE
feat/10.3: slash commands /fba:fw, /fba:fw-plan, /fba:fw-build

### DIFF
--- a/.opencode/commands/fba:fw-build.md
+++ b/.opencode/commands/fba:fw-build.md
@@ -1,0 +1,61 @@
+---
+description: Ejecuta un brief de mejora del framework FBA. Delega al framework-builder para implementar, testear y commitear cada feat.
+agent: framework-orchestrator
+---
+
+# fba:fw-build
+
+Ejecuta el plan de mejora del framework FBA contenido en `.factory/fw-brief.md`.
+
+## Pre-condiciones
+
+- `.factory/fw-brief.md` existe y es valido.
+- `.factory/framework-state.json` existe.
+- El milestone branch referenciado en el brief existe (o el builder lo creara).
+
+## Pasos
+
+### 1. Verificar brief
+
+Leer `.factory/fw-brief.md`. Si no existe, informar al usuario que debe ejecutar
+`/fba:fw-plan` primero (o `/fba:fw` para dejar que el orchestrator decida).
+
+### 2. Mostrar resumen del brief
+
+Presentar al usuario lo que se va a construir:
+- Objetivo
+- Numero de feats a ejecutar
+- Archivos que se van a crear/modificar
+- Branch destino
+
+### 3. Delegar al builder
+
+Invocar al `framework-builder` via task tool:
+
+```
+task(
+  description="Construir: [objetivo del brief]",
+  prompt="Lee .factory/fw-brief.md COMPLETO. Ejecuta todos los feats pendientes en orden. Sigue ESTRICTAMENTE CONTRIBUTING.md: crea issues, branches feat/X.Y desde el milestone, escribe tests primero, implementa, pytest, commit conventional, PR al milestone branch. NO hagas commit a main. NO abras PR a main sin confirmacion. Actualiza .factory/framework-state.json al completar cada feat.",
+  subagent_type="framework-builder"
+)
+```
+
+### 4. Monitorear progreso
+
+El builder reportara al finalizar. Si encuentra blockers, los escalara.
+
+### 5. Presentar resultado final
+
+Al terminar el builder:
+- Mostrar resumen de feats completados.
+- Listar PRs abiertos al milestone branch.
+- Indicar si el milestone esta listo para revision del usuario.
+- Si `ready_for_user_review: true`, preguntar al usuario si quiere revisar
+  y eventualmente autorizar el PR a main.
+
+## Post-condiciones
+
+- Cada feat tiene su branch, commit y PR al milestone branch.
+- `.factory/framework-state.json` actualizado con feats completados.
+- `.factory/fw-session-report.md` generado con resumen de la sesion.
+- Si el brief esta completamente ejecutado, `open_briefs` actualizado.

--- a/.opencode/commands/fba:fw-plan.md
+++ b/.opencode/commands/fba:fw-plan.md
@@ -1,0 +1,54 @@
+---
+description: Planifica una mejora del framework FBA generando un brief ejecutable (fw-brief.md). Delega al framework-planner.
+agent: framework-orchestrator
+---
+
+# fba:fw-plan
+
+Genera un plan ejecutable para una mejora del framework FBA.
+
+## Pre-condiciones
+
+- `.factory/framework-state.json` existe.
+- El usuario proporciona una descripcion de lo que quiere planificar.
+
+## Pasos
+
+### 1. Validar intencion
+
+Si el usuario no proporciono una descripcion (ej. solo escribio `/fba:fw-plan`),
+preguntarle que quiere planificar usando el `question` tool.
+
+### 2. Delegar al planner
+
+Invocar al `framework-planner` via task tool con la intencion del usuario:
+
+```
+task(
+  description="Planificar: [intencion del usuario]",
+  prompt="El usuario quiere: [intencion exacta]. Lee ROADMAP.md y .factory/framework-state.json. Genera .factory/fw-brief.md con issue, branch, archivos, tests, definicion de done. Si hay ambiguedad, preguntame a mi para escalar al usuario. NO asumas nada.",
+  subagent_type="framework-planner"
+)
+```
+
+### 3. Presentar resultado
+
+Lee `.factory/fw-brief.md` generado por el planner y presentalo al usuario en un formato legible:
+- Objetivo
+- Feats planificados (nombre, orden, dependencias)
+- Archivos a crear/modificar
+- Tests requeridos
+- Definicion de done
+- Decisiones pendientes (si el planner las identifico)
+
+### 4. Confirmar con el usuario
+
+Preguntar al usuario si:
+- Quiere proceder con la construccion (delegar al builder).
+- Quiere ajustar el plan (re-planificar con feedback).
+- Quiere guardar el plan para despues.
+
+## Post-condiciones
+
+- `.factory/fw-brief.md` existe con el plan detallado.
+- `.factory/framework-state.json` tiene el brief registrado en `open_briefs`.

--- a/.opencode/commands/fba:fw.md
+++ b/.opencode/commands/fba:fw.md
@@ -1,0 +1,67 @@
+---
+description: Punto de entrada para el meta-desarrollo del framework FBA. El orquestador lee el estado, presenta un resumen y espera la intencion del usuario.
+agent: framework-orchestrator
+---
+
+# fba:fw
+
+Punto de entrada del sistema de meta-agentes para el desarrollo del framework FBA.
+
+## Pre-condiciones
+
+- El proyecto es el repositorio del framework FBA (no un proyecto Odoo generado).
+- `.factory/framework-state.json` existe. Si no existe, reportar que el sistema
+  de meta-agentes no esta inicializado.
+
+## Pasos
+
+### 1. Leer estado actual
+
+Leer en orden:
+1. `ROADMAP.md` — milestone activo y pendientes.
+2. `.factory/framework-state.json` — estado de la ultima sesion, feats pendientes, decisiones.
+3. `CHANGELOG.md` — ultimos cambios realizados.
+4. `CONTRIBUTING.md` — recordar las reglas del workflow.
+
+### 2. Presentar resumen al usuario
+
+Mostrar un resumen compacto con:
+- Estado del roadmap (milestones completados / activo / planificados).
+- Ultima sesion: que se hizo, por cual agente, que quedo pendiente.
+- Proximo paso sugerido segun el estado actual.
+- Decisiones pendientes del usuario si las hay (`pending_decisions`).
+
+Ejemplo de resumen:
+
+```
+## Estado del Framework
+
+Roadmap: ✅ M0-M5 | ⏳ M10 activo (2/5 feats) | 📋 M6-M9 planificados
+
+Ultima sesion: framework-builder completo feat/10.2 el 2026-05-09
+Pendiente: feat/10.3-slash-commands, feat/10.4-fw-brief-template, feat/10.5-docs
+
+Proximo paso sugerido: feat/10.3-slash-commands
+```
+
+### 3. Esperar intencion del usuario
+
+No asumas nada. Espera a que el usuario exprese su intencion. Ejemplos:
+- "continua donde quedamos"
+- "implementa el M6"
+- "planifica soporte multi-modelo"
+- "que falta por hacer?"
+
+### 4. Procesar intencion
+
+Segun la intencion del usuario, delega al agente correspondiente:
+
+| Intencion | Delegar a |
+|-----------|-----------|
+| Planificar algo nuevo | `framework-planner` via task tool |
+| Construir/implementar | `framework-builder` via task tool |
+| Informacion/estado | Responder directamente con datos de state.json y ROADMAP.md |
+
+### 5. Al finalizar
+
+Actualizar `.factory/framework-state.json` con los resultados de la sesion.


### PR DESCRIPTION
Closes #94

## Cambios

- **`/fba:fw`**: punto de entrada del orchestrator (lee estado, presenta resumen, espera intencion)
- **`/fba:fw-plan`**: delega al planner, presenta y confirma el brief generado
- **`/fba:fw-build`**: delega al builder para ejecutar feats secuencialmente