### PR TITLE
feat(#102): optimizar consumo de tokens del orquestador (~25k → ~3k)

### DIFF
--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -4,8 +4,8 @@
   "last_session": {
     "date": "2026-05-09",
     "agent": "framework-builder",
-    "action": "M10 completado: 5 feats mergeados a milestone/10.0-framework-meta-dev",
-    "completed_feats": ["feat/10.1-framework-state", "feat/10.2-agentes-meta", "feat/10.3-slash-commands", "feat/10.4-fw-brief-template", "feat/10.5-docs"],
+    "action": "feat/10.6: optimizar consumo de tokens del orquestador (~25k → ~3k, solo lee framework-state.json)",
+    "completed_feats": ["feat/10.6-token-optimization"],
     "pending_feats": [],
     "blockers": []
   },
@@ -14,8 +14,8 @@
     "name": "Framework Meta-Development System",
     "branch": "milestone/10.0-framework-meta-dev",
     "status": "in_progress",
-    "feats_total": 5,
-    "feats_done": 5,
+    "feats_total": 6,
+    "feats_done": 6,
     "feats_pending": [],
     "ready_for_user_review": true
   },
@@ -32,6 +32,19 @@
     "M8": "planned",
     "M9": "planned"
   },
+  "roadmap_summary": [
+    {"milestone":"M0","name":"Fundacion","status":"completed","start_date":"2026-05-02","end_date":"2026-05-02"},
+    {"milestone":"M1","name":"Elicitacion + Documentacion","status":"completed","start_date":"2026-05-03","end_date":"2026-05-03"},
+    {"milestone":"M2","name":"Planificacion + SDD","status":"completed","start_date":"2026-05-04","end_date":"2026-05-04"},
+    {"milestone":"M4","name":"Sistema de Gates","status":"completed","start_date":"2026-05-05","end_date":"2026-05-05"},
+    {"milestone":"M3","name":"Construccion + MVP","status":"completed","start_date":"2026-05-05","end_date":"2026-05-06"},
+    {"milestone":"M5","name":"Bug Fixes & Stability","status":"completed","start_date":"2026-05-06","end_date":"2026-05-08"},
+    {"milestone":"M10","name":"Framework Meta-Development","status":"in_progress","start_date":"2026-05-09"},
+    {"milestone":"M6","name":"Optimizacion de Agentes","status":"planned"},
+    {"milestone":"M7","name":"User Stories + Code Gen Dual","status":"planned"},
+    {"milestone":"M8","name":"Pipeline, Performance, Multi-modulo","status":"planned"},
+    {"milestone":"M9","name":"Testing Avanzado + Feedback","status":"planned"}
+  ],
   "pending_decisions": [],
   "open_briefs": [],
   "agents": {

--- a/.opencode/agents/framework-orchestrator.md
+++ b/.opencode/agents/framework-orchestrator.md
@@ -11,6 +11,16 @@ permission:
 Eres el framework-orchestrator. Eres el unico punto de entrada para el meta-desarrollo
 del framework Factory Build Agent. Tu unico proposito es coordinar, delegar y reportar.
 
+## Reglas criticas (extraidas de CONTRIBUTING.md)
+
+- ⛔ **NUNCA hacer commit directo a `main`**. Solo se mergea via PR.
+- ⛔ **Siempre crear un GitHub Issue antes de escribir codigo**.
+- ⛔ **PR de milestone a `main` requiere confirmacion explicita del usuario.** Sin esto, no se abre.
+- **Commits**: formato `tipo(#XX): descripcion` (feat, fix, docs, test, chore, refactor).
+- **Branching**: `milestone/X.0-descripcion`, `feat/X.Y-descripcion`, `feat/X.Y.Z-descripcion`.
+- **Tests deben pasar** (`pytest`) antes de abrir PR.
+- Si un cambio modifica alcance o arquitectura, actualizar AGENTS.md, ROADMAP.md, CHANGELOG.md.
+
 ## Regla fundamental
 
 NO implementas codigo. NO modificas archivos. NO planificas mejoras.
@@ -18,16 +28,20 @@ Solo lees, delegas, y presentas resultados al usuario.
 
 ## Al iniciar sesion
 
-1. Lee `ROADMAP.md` para conocer milestone activo y pendientes.
-2. Lee `.factory/framework-state.json` para saber que quedo en progreso.
-3. Lee `CHANGELOG.md` para conocer que ya esta hecho.
-4. Lee `CONTRIBUTING.md` para recordar las reglas del workflow.
-5. Presenta al usuario un resumen compacto:
-   - Estado actual del roadmap (que milestones estan completados, cual es el activo)
+1. Lee UNICAMENTE `.factory/framework-state.json`. Este archivo contiene todo el contexto necesario:
+   - `roadmap_summary`: lista compacta de milestones con nombre, estado y fechas
+   - `last_session`: que se hizo en la ultima sesion (agente, accion, feats completados, pendientes, blockers)
+   - `active_milestone`: milestone en progreso (feats_total, feats_done, feats_pending, ready_for_user_review)
+   - `pending_decisions`: decisiones que esperan confirmacion del usuario
+   - `open_briefs`: briefs generados y pendientes de ejecucion
+   - `roadmap_status`: resumen de estado de cada milestone (completed, in_progress, planned)
+2. NO leas ROADMAP.md, CHANGELOG.md, ni CONTRIBUTING.md — esas lecturas las hace el planner/builder bajo demanda.
+3. Presenta al usuario un resumen compacto:
+   - Estado actual del roadmap (milestones completados, activo, planificados)
    - Ultima sesion (que se hizo, que quedo pendiente)
    - Proximo paso sugerido
    - Decisiones pendientes del usuario si las hay
-6. Espera la intencion del usuario.
+4. Espera la intencion del usuario.
 
 ## Tipos de intencion que manejas
 
@@ -36,7 +50,7 @@ Solo lees, delegas, y presentas resultados al usuario.
 | "implementa el M6 del roadmap" | Verifica si hay brief en open_briefs. Si no, delega al framework-planner. Luego lanza al framework-builder. |
 | "planifica el roadmap" / "planifica M7" | Delega completamente al framework-planner y presenta el resultado. |
 | "quiero agregar X feature al framework" | Delega al framework-planner para descomponerlo, luego al builder. |
-| "que falta por hacer?" | Lee framework-state.json y ROADMAP.md y responde con un resumen. |
+| "que falta por hacer?" | Lee framework-state.json y responde con un resumen. |
 | "continua donde quedamos" | Lee framework-state.json, identifica el ultimo punto de progreso, lanza al builder. |
 | "actualiza el roadmap con X" | Delega al framework-planner para evaluar impacto y re-priorizar. |
 
@@ -85,7 +99,7 @@ task(
 
 Antes de terminar, actualiza `.factory/framework-state.json`:
 - `last_session` con la fecha, tu nombre, accion realizada, feats completados, pendientes, blockers.
-- Si el milestone activo cambio de estado, reflejalo en `active_milestone` y `roadmap_status`.
+- Si el milestone activo cambio de estado, reflejalo en `active_milestone`, `roadmap_status` y `roadmap_summary`.
 - Si se resolvieron decisiones pendientes, actualiza `pending_decisions`.
 
 NUNCA borres historial — acumula resumenes en `last_session` y mantiene trazabilidad.

--- a/schemas/framework-state.schema.json
+++ b/schemas/framework-state.schema.json
@@ -3,7 +3,7 @@
   "title": "FBA Framework Meta-Development State",
   "description": "Persistent state schema for the framework meta-agents (orchestrator, planner, builder)",
   "type": "object",
-  "required": ["schema_version", "last_updated", "last_session", "active_milestone", "roadmap_status", "agents"],
+  "required": ["schema_version", "last_updated", "last_session", "active_milestone", "roadmap_status", "roadmap_summary", "agents"],
   "properties": {
     "schema_version": {
       "type": "string",
@@ -96,6 +96,21 @@
       "additionalProperties": {
         "type": "string",
         "enum": ["planned", "in_progress", "completed"]
+      }
+    },
+    "roadmap_summary": {
+      "type": "array",
+      "description": "Compact summary of all milestones for the orchestrator — eliminates need to read ROADMAP.md",
+      "items": {
+        "type": "object",
+        "required": ["milestone", "name", "status"],
+        "properties": {
+          "milestone": { "type": "string", "description": "Milestone ID (M0, M1, ...)" },
+          "name": { "type": "string", "description": "Short human-readable name" },
+          "status": { "type": "string", "enum": ["planned", "in_progress", "completed"], "description": "Current status" },
+          "start_date": { "type": "string", "description": "Start date (YYYY-MM-DD)" },
+          "end_date": { "type": "string", "description": "End date (YYYY-MM-DD)" }
+        }
       }
     },
     "pending_decisions": {

--- a/tests/test_framework_state_schema.py
+++ b/tests/test_framework_state_schema.py
@@ -43,6 +43,13 @@ def _valid_state():
             "M10": "in_progress",
             "M6": "planned"
         },
+        "roadmap_summary": [
+            {"milestone":"M0","name":"Fundacion","status":"completed","start_date":"2026-05-02","end_date":"2026-05-02"},
+            {"milestone":"M1","name":"Elicitacion","status":"completed","start_date":"2026-05-03","end_date":"2026-05-03"},
+            {"milestone":"M5","name":"Bug Fixes","status":"completed","start_date":"2026-05-06","end_date":"2026-05-08"},
+            {"milestone":"M10","name":"Meta-Development","status":"in_progress","start_date":"2026-05-09"},
+            {"milestone":"M6","name":"Optimizacion","status":"planned"}
+        ],
         "pending_decisions": [],
         "open_briefs": [],
         "agents": {
@@ -120,6 +127,12 @@ class TestFrameworkStateSchemaMissingFields:
     def test_missing_roadmap_status_fails(self, fw_state_schema):
         state = _valid_state()
         del state["roadmap_status"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_missing_roadmap_summary_fails(self, fw_state_schema):
+        state = _valid_state()
+        del state["roadmap_summary"]
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(state, fw_state_schema)
 


### PR DESCRIPTION
## Summary
- El orquestador ahora lee solo `.factory/framework-state.json` al iniciar (~55 lineas, ~1k tokens)
- Las reglas criticas de CONTRIBUTING.md estan embebidas en la definicion del agente
- ROADMAP.md, CHANGELOG.md y CONTRIBUTING.md quedan para planner/builder bajo demanda
- Se agrego `roadmap_summary` al schema y state file con resumen compacto de milestones

## Token savings
| Antes | Ahora |
|-------|-------|
| ROADMAP.md (1062L) | — |
| CHANGELOG.md (230L) | — |
| CONTRIBUTING.md (232L) | — |
| framework-state.json (42L) | framework-state.json (55L) |
| **~25k tokens** | **~3k tokens** (~8x reduccion) |

## Files changed
- `schemas/framework-state.schema.json` — nuevo campo `roadmap_summary`
- `.factory/framework-state.json` — datos iniciales de `roadmap_summary` + feat 10.6
- `.opencode/agents/framework-orchestrator.md` — startup reducido a 1 solo archivo
- `tests/test_framework_state_schema.py` — test actualizado + nuevo test missing_roadmap_summary

Closes #102