### PR TITLE
feat(#109): agregar comando fba doctor para diagnostico de salud del proyecto

### DIFF
--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.0",
-  "last_updated": "2026-05-12T20:20:00Z",
+  "last_updated": "2026-05-12T20:25:00Z",
   "last_session": {
     "date": "2026-05-12",
     "agent": "framework-registry",
-    "action": "Completed feat/11.2-rollback-state",
-    "completed_feats": ["feat/11.2-rollback-state"],
-    "pending_feats": ["feat/11.3-registry-robustez", "feat/11.4-fba-doctor", "feat/11.5-wizard-schema-alignment"],
+    "action": "Completed feat/11.3-registry-robustez",
+    "completed_feats": ["feat/11.3-registry-robustez"],
+    "pending_feats": ["feat/11.4-fba-doctor", "feat/11.5-wizard-schema-alignment"],
     "blockers": []
   },
   "active_milestone": {
@@ -15,9 +15,8 @@
     "branch": "milestone/11.0-foundation-hardening",
     "status": "in_progress",
     "feats_total": 5,
-    "feats_done": 2,
+    "feats_done": 3,
     "feats_pending": [
-      "feat/11.3-registry-robustez",
       "feat/11.4-fba-doctor",
       "feat/11.5-wizard-schema-alignment"
     ],

--- a/src/fba/cli.py
+++ b/src/fba/cli.py
@@ -735,4 +735,152 @@ def _find_schema(target: Path, schema_name: str) -> Path | None:
     return None
 
 
+@main.command()
+@PROJECT_DIR_OPTION
+@click.option("--verbose", "-v", is_flag=True, help="Detailed diagnostic output")
+@click.option("--json", "json_output", is_flag=True, help="Output in JSON format (for CI)")
+def doctor(project_dir, verbose, json_output):
+    """Diagnose the health of a Factory Build Agent project.
+
+    Checks: registry health, state file integrity, writability, and schema alignment.
+    Exit codes: 0=OK (no errors or warnings), 1=warnings present, 2=errors present.
+    """
+    target = Path(project_dir).resolve() if project_dir else Path.cwd()
+    factory_dir = target / ".factory"
+
+    checks = []
+    errors = []
+    results = []
+
+    if not factory_dir.exists():
+        msg = "No .factory/ directory found. Run 'fba init' first."
+        if json_output:
+            click.echo(json.dumps({"status": "ERROR", "checks": [], "exit_code": 2, "error": msg}))
+        else:
+            click.echo(f"❌ {msg}")
+        raise SystemExit(2)
+
+    def _check(label, fn):
+        try:
+            ok, detail, severity = fn()
+            results.append({"label": label, "ok": ok, "detail": detail, "severity": severity or ("error" if not ok else "ok")})
+            if not ok:
+                if severity == "warning":
+                    checks.append(("⚠", label, detail))
+                else:
+                    errors.append(("❌", label, detail))
+        except Exception as e:
+            results.append({"label": label, "ok": False, "detail": str(e), "severity": "error"})
+            errors.append(("❌", label, str(e)))
+
+    def _d1_check():
+        try:
+            import warnings as _w
+            with _w.catch_warnings(record=True) as caught:
+                _w.simplefilter("always")
+                from fba.module_registry import ModuleRegistry
+                registry = ModuleRegistry(target)
+            reg_warnings = [str(w.message) for w in caught]
+            modules = registry.modules
+            model_count = sum(len(info.get("models", [])) for info in modules.values())
+            detail = f"{len(modules)} modules, {model_count} models"
+            if reg_warnings:
+                detail += f", warnings: {'; '.join(reg_warnings)}"
+                return False, detail, "error" if len(modules) == 0 else "warning"
+            if len(modules) == 0:
+                return False, detail + " (registry empty)", "warning"
+            return True, detail, None
+        except Exception as e:
+            return False, f"Registry error: {e}", "error"
+
+    def _d2_check():
+        state_path = factory_dir / "state.json"
+        if state_path.exists():
+            return True, f"Found at {state_path}", None
+        return False, "state.json not found", "error"
+
+    def _d3_check():
+        state_path = factory_dir / "state.json"
+        if not state_path.exists():
+            return False, "state.json does not exist", "error"
+        try:
+            data = json.loads(state_path.read_text())
+            phase = data.get("current_phase", "unknown")
+            return True, f"Valid JSON, current phase: {phase}", None
+        except json.JSONDecodeError as e:
+            return False, f"Invalid JSON: {e}", "error"
+
+    def _d4_check():
+        test_file = factory_dir / ".doctor_write_test"
+        try:
+            test_file.write_text("test")
+            test_file.unlink()
+            return True, "Writable", None
+        except Exception as e:
+            return False, f"Not writable: {e}", "error"
+
+    def _d5_check():
+        implemented_types = {"model", "view", "security_group", "access_right", "record_rule", "data"}
+        schema_path = factory_dir / "schemas" / "task_item.schema.json"
+        if not schema_path.exists():
+            schema_path = SCHEMAS_DIR / "task_item.schema.json"
+        if not schema_path.exists():
+            return True, "task_item.schema.json not found, skipping alignment check", None
+        try:
+            schema = json.loads(schema_path.read_text())
+            enum = schema.get("properties", {}).get("components", {}).get("items", {}).get("properties", {}).get("type", {}).get("enum", [])
+        except Exception:
+            return True, "Could not parse schema, skipping alignment check", None
+        unimplemented = [t for t in enum if t not in implemented_types]
+        if unimplemented:
+            return False, f"Unimplemented types: {', '.join(unimplemented)}", "warning"
+        return True, "All schema types have implementations", None
+
+    _check("registry", _d1_check)
+    _check("state_exists", _d2_check)
+    _check("state_json", _d3_check)
+    _check("writable", _d4_check)
+    _check("schema_alignment", _d5_check)
+
+    if json_output:
+        output = {
+            "status": "ERROR" if errors else ("WARNING" if checks else "OK"),
+            "checks": results,
+            "exit_code": 2 if errors else (1 if checks else 0),
+            "warnings": len(checks),
+            "errors": len(errors),
+        }
+        click.echo(json.dumps(output, indent=2, ensure_ascii=False))
+        raise SystemExit(output["exit_code"])
+
+    for symbol, label, detail in errors:
+        click.echo(f"{symbol} {label}: {detail}")
+    for symbol, label, detail in checks:
+        click.echo(f"{symbol} {label}: {detail}")
+
+    ok_count = len(results) - len(errors) - len(checks)
+    if not errors and not checks:
+        for r in results:
+            click.echo(f"✅ {r['label']}: {r['detail']}")
+    else:
+        for r in results:
+            if r["severity"] == "ok":
+                click.echo(f"✅ {r['label']}: {r['detail']}")
+
+    if verbose:
+        click.echo("")
+        click.echo("─" * 40)
+        click.echo("Verbose details:")
+        click.echo(f"  Project: {target}")
+        click.echo(f"  Factory dir: {factory_dir}")
+        for r in results:
+            click.echo(f"  [{r['severity'].upper()}] {r['label']}: {r['detail']}")
+
+    if errors:
+        raise SystemExit(2)
+    if checks:
+        raise SystemExit(1)
+    raise SystemExit(0)
+
+
 main.add_command(_schema_group)

--- a/tests/test_fba_doctor.py
+++ b/tests/test_fba_doctor.py
@@ -1,0 +1,116 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from fba.cli import main
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def healthy_project(tmp_path):
+    project_dir = tmp_path / "healthy"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+
+    state = {
+        "project": "test-project",
+        "current_phase": "init",
+        "phases": {"init": {"status": "in_progress"}},
+        "valid_transitions": {},
+        "artifacts": {},
+    }
+    (factory_dir / "state.json").write_text(json.dumps(state, indent=2))
+
+    registry_dir = factory_dir / "schemas"
+    registry_dir.mkdir(parents=True, exist_ok=True)
+
+    return project_dir
+
+
+def test_doctor_healthy_project(runner, healthy_project):
+    result = runner.invoke(main, ["doctor", "-d", str(healthy_project)])
+    assert result.exit_code in (0, 1)
+    output = result.output.lower()
+    assert "registry" in output or "state" in output or "writable" in output
+
+
+def test_doctor_state_missing(runner, tmp_path):
+    project_dir = tmp_path / "nostate"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+
+    result = runner.invoke(main, ["doctor", "-d", str(project_dir)])
+    assert result.exit_code == 2
+    assert "state" in result.output.lower()
+
+
+def test_doctor_state_invalid_json(runner, tmp_path):
+    project_dir = tmp_path / "badstate"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    (factory_dir / "state.json").write_text("{invalid")
+
+    result = runner.invoke(main, ["doctor", "-d", str(project_dir)])
+    assert result.exit_code == 2
+
+
+def test_doctor_registry_not_loading(runner, tmp_path):
+    project_dir = tmp_path / "noregistry"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    (factory_dir / "state.json").write_text(json.dumps({"current_phase": "init", "phases": {}, "valid_transitions": {}, "artifacts": {}}))
+
+    result = runner.invoke(main, ["doctor", "-d", str(project_dir)])
+    assert result.exit_code in (1, 2)
+
+
+def test_doctor_verbose_output(runner, healthy_project):
+    result = runner.invoke(main, ["doctor", "-d", str(healthy_project), "--verbose"])
+    assert result.exit_code in (0, 1, 2)
+
+
+def test_doctor_json_output(runner, healthy_project):
+    result = runner.invoke(main, ["doctor", "-d", str(healthy_project), "--json"])
+    assert result.exit_code in (0, 1)
+    data = json.loads(result.output)
+    assert "status" in data
+    assert "checks" in data
+    assert "exit_code" in data
+    assert data["exit_code"] in (0, 1)
+
+
+def test_doctor_factory_not_writable(runner, tmp_path):
+    project_dir = tmp_path / "readonly"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    state = {"current_phase": "init", "phases": {}, "valid_transitions": {}, "artifacts": {}}
+    (factory_dir / "state.json").write_text(json.dumps(state, indent=2))
+
+    os.chmod(str(factory_dir), 0o444)
+
+    try:
+        result = runner.invoke(main, ["doctor", "-d", str(project_dir)])
+    finally:
+        os.chmod(str(factory_dir), 0o755)
+
+    assert result.exit_code in (1, 2)
+
+
+def test_doctor_no_factory_dir(runner, tmp_path):
+    project_dir = tmp_path / "nofactory"
+    project_dir.mkdir()
+
+    result = runner.invoke(main, ["doctor", "-d", str(project_dir)])
+    assert result.exit_code == 2


### PR DESCRIPTION
## Summary
- New `fba doctor` command with 5 diagnostic checks: registry health, state file exists, state valid JSON, factory dir writable, schema alignment
- Exit codes: 0=OK, 1=warnings, 2=errors
- Supports `--verbose` for detailed output and `--json` for CI-compatible output
- Added 8 new tests in `tests/test_fba_doctor.py`
- All 485 tests continue to pass

Closes #109