### PR TITLE
fix(#110): agregar deteccion de tipos no implementados en SchemaManager con IMPLEMENTED_TYPES

### DIFF
--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.0",
-  "last_updated": "2026-05-12T20:25:00Z",
+  "last_updated": "2026-05-12T20:45:00Z",
   "last_session": {
     "date": "2026-05-12",
     "agent": "framework-registry",
-    "action": "Completed feat/11.3-registry-robustez",
-    "completed_feats": ["feat/11.3-registry-robustez"],
-    "pending_feats": ["feat/11.4-fba-doctor", "feat/11.5-wizard-schema-alignment"],
+    "action": "Completed feat/11.4-fba-doctor",
+    "completed_feats": ["feat/11.4-fba-doctor"],
+    "pending_feats": ["feat/11.5-wizard-schema-alignment"],
     "blockers": []
   },
   "active_milestone": {
@@ -15,9 +15,8 @@
     "branch": "milestone/11.0-foundation-hardening",
     "status": "in_progress",
     "feats_total": 5,
-    "feats_done": 3,
+    "feats_done": 4,
     "feats_pending": [
-      "feat/11.4-fba-doctor",
       "feat/11.5-wizard-schema-alignment"
     ],
     "ready_for_user_review": false

--- a/src/fba/cli.py
+++ b/src/fba/cli.py
@@ -820,7 +820,7 @@ def doctor(project_dir, verbose, json_output):
             return False, f"Not writable: {e}", "error"
 
     def _d5_check():
-        implemented_types = {"model", "view", "security_group", "access_right", "record_rule", "data"}
+        implemented_types = set(SchemaManager.IMPLEMENTED_TYPES)
         schema_path = factory_dir / "schemas" / "task_item.schema.json"
         if not schema_path.exists():
             schema_path = SCHEMAS_DIR / "task_item.schema.json"

--- a/src/fba/schema_manager.py
+++ b/src/fba/schema_manager.py
@@ -40,6 +40,10 @@ class SchemaManager:
     code rendering consumes with zero interpretation.
     """
 
+    IMPLEMENTED_TYPES = frozenset({
+        "model", "view", "security_group", "access_right", "record_rule", "data",
+    })
+
     RELATIONAL_TYPES = {"Many2one", "One2many", "Many2many"}
 
     NAMING_RULES = {
@@ -94,6 +98,8 @@ class SchemaManager:
 
         tasks_data = self._load_all_tasks(task_index)
         sdd_data = self._load_sdd()
+
+        self._detect_unknown_types(tasks_data)
 
         models = self._assemble_models(tasks_data)
         views = self._assemble_views(tasks_data)
@@ -172,6 +178,19 @@ class SchemaManager:
                 f"Path: {sdd_path}",
             ))
             return {}
+
+    def _detect_unknown_types(self, tasks_data: dict[str, dict]) -> None:
+        """Warn about component types that are in the schema enum but not yet implemented."""
+        for task_id, task in tasks_data.items():
+            for component in task.get("components", []):
+                ctype = component.get("type", "")
+                if ctype and ctype not in self.IMPLEMENTED_TYPES:
+                    self._warnings.append(AssemblyWarning(
+                        "warning",
+                        f"component type '{ctype}' is declared in schema "
+                        f"but not yet implemented by SchemaManager",
+                        f"Task: {task_id}, component: {component.get('name', 'unnamed')}",
+                    ))
 
     def _assemble_manifest(self, sdd_data: dict, task_index: dict) -> dict:
         module_name = sdd_data.get("module_name", "") or task_index.get("module_name", "unknown")

--- a/tests/test_schema_manager_unknown_types.py
+++ b/tests/test_schema_manager_unknown_types.py
@@ -1,0 +1,385 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from fba.schema_manager import SchemaManager, AssemblyWarning, AssemblyResult
+
+
+def create_task_data(task_id, components, task_name="test"):
+    return {
+        task_id: {
+            "id": task_id,
+            "name": task_name,
+            "description": f"Test task {task_id}",
+            "components": components,
+            "files_to_generate": ["test.py"],
+            "dependencies": [],
+        }
+    }
+
+
+def create_project_structure(tmp_path, models_only=True):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    tasks_dir = factory_dir / "tasks"
+    tasks_dir.mkdir()
+
+    components = [
+        {
+            "type": "model",
+            "name": "test.model",
+            "description": "A test model",
+            "sdd_reference": "test.model",
+            "fields": [{"name": "name", "type": "Char", "label": "Name"}],
+        }
+    ]
+    if not models_only:
+        components.append({
+            "type": "view",
+            "name": "test.view",
+            "description": "A test view",
+            "sdd_reference": "test.view",
+            "model": "test.model",
+            "view_type": "form",
+            "view_fields": ["name"],
+        })
+
+    task = {
+        "id": "T001",
+        "name": "test",
+        "description": "A test task description",
+        "components": components,
+        "files_to_generate": ["test.py"],
+        "dependencies": [],
+    }
+    (tasks_dir / "T001.json").write_text(json.dumps(task, indent=2))
+
+    index = {
+        "tasks": [
+            {
+                "id": "T001",
+                "name": "test",
+                "file": "T001.json",
+                "order": 1,
+                "estimated_effort": "small",
+                "dependencies": [],
+            }
+        ]
+    }
+    (tasks_dir / "index.json").write_text(json.dumps(index, indent=2))
+
+    return project_dir
+
+
+def test_implemented_types_class_constant():
+    assert hasattr(SchemaManager, "IMPLEMENTED_TYPES")
+    assert isinstance(SchemaManager.IMPLEMENTED_TYPES, (set, frozenset))
+    assert "model" in SchemaManager.IMPLEMENTED_TYPES
+    assert "view" in SchemaManager.IMPLEMENTED_TYPES
+    assert "security_group" in SchemaManager.IMPLEMENTED_TYPES
+    assert "access_right" in SchemaManager.IMPLEMENTED_TYPES
+    assert "record_rule" in SchemaManager.IMPLEMENTED_TYPES
+    assert "data" in SchemaManager.IMPLEMENTED_TYPES
+    assert "wizard" not in SchemaManager.IMPLEMENTED_TYPES
+    assert "workflow" not in SchemaManager.IMPLEMENTED_TYPES
+    assert "report" not in SchemaManager.IMPLEMENTED_TYPES
+    assert "controller" not in SchemaManager.IMPLEMENTED_TYPES
+
+
+def test_wizard_component_produces_warning(tmp_path):
+    project_dir = tmp_path / "wizardproj"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    tasks_dir = factory_dir / "tasks"
+    tasks_dir.mkdir()
+
+    index = {
+        "tasks": [
+            {
+                "id": "T001", "name": "test", "file": "T001.json",
+                "order": 1, "estimated_effort": "small", "dependencies": [],
+            }
+        ]
+    }
+    (tasks_dir / "index.json").write_text(json.dumps(index, indent=2))
+
+    task = {
+        "id": "T001",
+        "name": "test",
+        "description": "A test task with wizard",
+        "components": [
+            {
+                "type": "model", "name": "test.model",
+                "description": "A test model", "sdd_reference": "test.model",
+                "fields": [{"name": "name", "type": "Char", "label": "Name"}],
+            },
+            {
+                "type": "wizard",
+                "name": "test.wizard",
+                "description": "A test wizard component",
+                "sdd_reference": "test.wizard",
+            }
+        ],
+        "files_to_generate": ["test.py"],
+        "dependencies": [],
+    }
+    (tasks_dir / "T001.json").write_text(json.dumps(task, indent=2))
+
+    sm = SchemaManager(project_dir)
+    result = sm.assemble()
+
+    assert result.success
+    warning_msgs = result.warning_messages
+    wizard_warnings = [w for w in warning_msgs if "wizard" in w.lower() and "not yet implemented" in w.lower()]
+    assert len(wizard_warnings) >= 1, f"No wizard/not-implemented warning found in: {warning_msgs}"
+
+
+def test_workflow_component_produces_warning(tmp_path):
+    project_dir = tmp_path / "workflowproj"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    tasks_dir = factory_dir / "tasks"
+    tasks_dir.mkdir()
+
+    index = {
+        "tasks": [
+            {
+                "id": "T001", "name": "test", "file": "T001.json",
+                "order": 1, "estimated_effort": "small", "dependencies": [],
+            }
+        ]
+    }
+    (tasks_dir / "index.json").write_text(json.dumps(index, indent=2))
+
+    task = {
+        "id": "T001",
+        "name": "test",
+        "description": "A test task with workflow",
+        "components": [
+            {
+                "type": "model", "name": "test.model",
+                "description": "A test model", "sdd_reference": "test.model",
+                "fields": [{"name": "name", "type": "Char", "label": "Name"}],
+            },
+            {
+                "type": "workflow",
+                "name": "test.workflow",
+                "description": "A test workflow component",
+                "sdd_reference": "test.workflow",
+            }
+        ],
+        "files_to_generate": ["test.py"],
+        "dependencies": [],
+    }
+    (tasks_dir / "T001.json").write_text(json.dumps(task, indent=2))
+
+    sm = SchemaManager(project_dir)
+    result = sm.assemble()
+    assert result.success
+
+    workflow_warnings = [w for w in result.warning_messages if "workflow" in w.lower()]
+    assert len(workflow_warnings) >= 1
+
+
+def test_report_controller_produce_warnings(tmp_path):
+    project_dir = tmp_path / "reportproj"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    tasks_dir = factory_dir / "tasks"
+    tasks_dir.mkdir()
+
+    index = {
+        "tasks": [
+            {
+                "id": "T001", "name": "test", "file": "T001.json",
+                "order": 1, "estimated_effort": "small", "dependencies": [],
+            }
+        ]
+    }
+    (tasks_dir / "index.json").write_text(json.dumps(index, indent=2))
+
+    task = {
+        "id": "T001",
+        "name": "test",
+        "description": "A test task with multiple unknown types",
+        "components": [
+            {
+                "type": "model", "name": "test.model",
+                "description": "A test model", "sdd_reference": "test.model",
+                "fields": [{"name": "name", "type": "Char", "label": "Name"}],
+            },
+            {
+                "type": "report", "name": "test.report",
+                "description": "A report", "sdd_reference": "test.report",
+            },
+            {
+                "type": "controller", "name": "test.controller",
+                "description": "A controller", "sdd_reference": "test.controller",
+            },
+        ],
+        "files_to_generate": ["test.py"],
+        "dependencies": [],
+    }
+    (tasks_dir / "T001.json").write_text(json.dumps(task, indent=2))
+
+    sm = SchemaManager(project_dir)
+    result = sm.assemble()
+    assert result.success
+
+    unknown_warnings = [w for w in result.warning_messages if "not yet implemented" in w.lower()]
+    assert len(unknown_warnings) >= 2, f"Expected at least 2 unknown type warnings, got: {unknown_warnings}"
+
+
+def test_known_types_produce_no_unknown_warnings(tmp_path):
+    project_dir = create_project_structure(tmp_path, models_only=True)
+    sm = SchemaManager(project_dir)
+    result = sm.assemble()
+
+    unknown_warnings = [w for w in result.warning_messages if "not yet implemented" in w.lower()]
+    assert len(unknown_warnings) == 0, f"Unexpected unknown type warnings: {unknown_warnings}"
+
+
+def test_multiple_unknown_components_one_warning_each(tmp_path):
+    project_dir = tmp_path / "multiproj"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    tasks_dir = factory_dir / "tasks"
+    tasks_dir.mkdir()
+
+    index = {
+        "tasks": [
+            {
+                "id": "T001", "name": "test", "file": "T001.json",
+                "order": 1, "estimated_effort": "small", "dependencies": [],
+            }
+        ]
+    }
+    (tasks_dir / "index.json").write_text(json.dumps(index, indent=2))
+
+    task = {
+        "id": "T001",
+        "name": "test",
+        "description": "A test task with multiple unknown types",
+        "components": [
+            {
+                "type": "model", "name": "test.model",
+                "description": "A test model", "sdd_reference": "test.model",
+                "fields": [{"name": "name", "type": "Char", "label": "Name"}],
+            },
+            {
+                "type": "wizard", "name": "test.wiz1",
+                "description": "Wiz 1", "sdd_reference": "test.wiz1",
+            },
+            {
+                "type": "wizard", "name": "test.wiz2",
+                "description": "Wiz 2", "sdd_reference": "test.wiz2",
+            },
+        ],
+        "files_to_generate": ["test.py"],
+        "dependencies": [],
+    }
+    (tasks_dir / "T001.json").write_text(json.dumps(task, indent=2))
+
+    sm = SchemaManager(project_dir)
+    result = sm.assemble()
+    assert result.success
+
+    unknown_warnings = [w for w in result.warning_messages if "not yet implemented" in w.lower()]
+    assert len(unknown_warnings) >= 2, f"Expected 2 unknown type warnings (one per component), got: {unknown_warnings}"
+
+
+def test_warning_level_is_warning(tmp_path):
+    project_dir = tmp_path / "levelproj"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    tasks_dir = factory_dir / "tasks"
+    tasks_dir.mkdir()
+
+    index = {
+        "tasks": [
+            {
+                "id": "T001", "name": "test", "file": "T001.json",
+                "order": 1, "estimated_effort": "small", "dependencies": [],
+            }
+        ]
+    }
+    (tasks_dir / "index.json").write_text(json.dumps(index, indent=2))
+
+    task = {
+        "id": "T001", "name": "test",
+        "description": "A test task with wizard",
+        "components": [
+            {
+                "type": "model", "name": "test.model",
+                "description": "A test model", "sdd_reference": "test.model",
+                "fields": [{"name": "name", "type": "Char", "label": "Name"}],
+            },
+            {
+                "type": "wizard", "name": "test.wizard",
+                "description": "A test wizard", "sdd_reference": "test.wizard",
+            }
+        ],
+        "files_to_generate": ["test.py"],
+        "dependencies": [],
+    }
+    (tasks_dir / "T001.json").write_text(json.dumps(task, indent=2))
+
+    sm = SchemaManager(project_dir)
+    result = sm.assemble()
+
+    unknown_warnings = [w for w in result.warnings if "not yet implemented" in w.message.lower()]
+    assert len(unknown_warnings) >= 1
+    for w in unknown_warnings:
+        assert w.level == "warning"
+
+
+def test_assembly_result_success_remains_true(tmp_path):
+    project_dir = tmp_path / "succproj"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    tasks_dir = factory_dir / "tasks"
+    tasks_dir.mkdir()
+
+    index = {
+        "tasks": [
+            {
+                "id": "T001", "name": "test", "file": "T001.json",
+                "order": 1, "estimated_effort": "small", "dependencies": [],
+            }
+        ]
+    }
+    (tasks_dir / "index.json").write_text(json.dumps(index, indent=2))
+
+    task = {
+        "id": "T001", "name": "test",
+        "description": "A test task with both known and unknown types",
+        "components": [
+            {
+                "type": "model", "name": "test.model",
+                "description": "A test model", "sdd_reference": "test.model",
+                "fields": [{"name": "name", "type": "Char", "label": "Name"}],
+            },
+            {
+                "type": "wizard", "name": "test.wizard",
+                "description": "A test wizard", "sdd_reference": "test.wizard",
+            },
+        ],
+        "files_to_generate": ["test.py"],
+        "dependencies": [],
+    }
+    (tasks_dir / "T001.json").write_text(json.dumps(task, indent=2))
+
+    sm = SchemaManager(project_dir)
+    result = sm.assemble()
+
+    assert result.success is True
+    assert len(result.schema.get("models", [])) == 1


### PR DESCRIPTION
## Summary
- Added `IMPLEMENTED_TYPES` class constant to SchemaManager (frozenset)
- Added `_detect_unknown_types()` method that emits AssemblyWarning for wizard, workflow, report, controller
- Updated `fba doctor` D5 to use SchemaManager.IMPLEMENTED_TYPES instead of hardcoded set
- Added 8 new tests in `tests/test_schema_manager_unknown_types.py`
- All 493 tests continue to pass

Closes #110