### PR TITLE
M11: Foundation Hardening — ✅ Completado

### DIFF
--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.0",
-  "last_updated": "2026-05-12T20:16:42Z",
+  "last_updated": "2026-05-12T20:20:00Z",
   "last_session": {
     "date": "2026-05-12",
-    "agent": "framework-builder",
-    "action": "Completed feat/11.1-atomicity-writes",
-    "completed_feats": ["feat/11.1-atomicity-writes"],
-    "pending_feats": ["feat/11.2-rollback-state", "feat/11.3-registry-robustez", "feat/11.4-fba-doctor", "feat/11.5-wizard-schema-alignment"],
+    "agent": "framework-registry",
+    "action": "Completed feat/11.2-rollback-state",
+    "completed_feats": ["feat/11.2-rollback-state"],
+    "pending_feats": ["feat/11.3-registry-robustez", "feat/11.4-fba-doctor", "feat/11.5-wizard-schema-alignment"],
     "blockers": []
   },
   "active_milestone": {
@@ -15,9 +15,8 @@
     "branch": "milestone/11.0-foundation-hardening",
     "status": "in_progress",
     "feats_total": 5,
-    "feats_done": 1,
+    "feats_done": 2,
     "feats_pending": [
-      "feat/11.2-rollback-state",
       "feat/11.3-registry-robustez",
       "feat/11.4-fba-doctor",
       "feat/11.5-wizard-schema-alignment"

--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "1.0",
-  "last_updated": "2026-05-10T03:30:00Z",
+  "last_updated": "2026-05-12T00:00:00Z",
   "last_session": {
-    "date": "2026-05-10",
-    "agent": "framework-builder",
-    "action": "Persistir nueva estructura M11-M15 en ROADMAP, CHANGELOG, AGENTS y framework-state. Branch milestone/11.0 creado. Epic #105.",
+    "date": "2026-05-12",
+    "agent": "framework-orchestrator",
+    "action": "Refactor del sistema de meta-agentes: creados framework-git, framework-registry, framework-explorer. Refactorizados orchestrator, planner, builder. Actualizados slash commands fba:fw, fba:fw-plan, fba:fw-build.",
     "completed_feats": [],
     "pending_feats": [],
     "blockers": []
@@ -56,7 +56,7 @@
   "open_briefs": [
     {
       "file": ".factory/fw-brief.md",
-      "description": "Roadmap reorganization: M6-M9 → M11-M15 con bugs, mejoras y capas progresivas",
+      "description": "Roadmap reorganization: M6-M9 -> M11-M15 con bugs, mejoras y capas progresivas",
       "created": "2026-05-10T02:25:15Z",
       "status": "in_progress"
     }
@@ -64,6 +64,9 @@
   "agents": {
     "framework-orchestrator": { "status": "active", "file": ".opencode/agents/framework-orchestrator.md" },
     "framework-planner":     { "status": "active", "file": ".opencode/agents/framework-planner.md" },
-    "framework-builder":     { "status": "active", "file": ".opencode/agents/framework-builder.md" }
+    "framework-builder":     { "status": "active", "file": ".opencode/agents/framework-builder.md" },
+    "framework-explorer":    { "status": "active", "file": ".opencode/agents/framework-explorer.md" },
+    "framework-registry":    { "status": "active", "file": ".opencode/agents/framework-registry.md" },
+    "framework-git":         { "status": "active", "file": ".opencode/agents/framework-git.md" }
   }
 }

--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -3,10 +3,10 @@
   "last_updated": "2026-05-12T00:00:00Z",
   "last_session": {
     "date": "2026-05-12",
-    "agent": "framework-orchestrator",
-    "action": "Refactor del sistema de meta-agentes: creados framework-git, framework-registry, framework-explorer. Refactorizados orchestrator, planner, builder. Actualizados slash commands fba:fw, fba:fw-plan, fba:fw-build.",
+    "agent": "framework-planner",
+    "action": "Generado fw-brief.md con plan de ejecucion detallado para M11 Foundation Hardening (5 feats)",
     "completed_feats": [],
-    "pending_feats": [],
+    "pending_feats": ["feat/11.1-atomicity-writes", "feat/11.2-rollback-state", "feat/11.3-registry-robustez", "feat/11.4-fba-doctor", "feat/11.5-wizard-schema-alignment"],
     "blockers": []
   },
   "active_milestone": {
@@ -56,11 +56,12 @@
   "open_briefs": [
     {
       "file": ".factory/fw-brief.md",
-      "description": "Roadmap reorganization: M6-M9 -> M11-M15 con bugs, mejoras y capas progresivas",
-      "created": "2026-05-10T02:25:15Z",
-      "status": "in_progress"
+      "description": "M11 Foundation Hardening: ejecucion de 5 feats (atomicity, rollback, registry, doctor, schema alignment)",
+      "created": "2026-05-12T00:00:00Z",
+      "status": "ready"
     }
   ],
+  "pending_decisions": [],
   "agents": {
     "framework-orchestrator": { "status": "active", "file": ".opencode/agents/framework-orchestrator.md" },
     "framework-planner":     { "status": "active", "file": ".opencode/agents/framework-planner.md" },

--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -4,9 +4,9 @@
   "last_session": {
     "date": "2026-05-09",
     "agent": "framework-builder",
-    "action": "feat/10.1-framework-state creado",
-    "completed_feats": [],
-    "pending_feats": ["feat/10.2", "feat/10.3", "feat/10.4", "feat/10.5"],
+    "action": "M10 completado: 5 feats mergeados a milestone/10.0-framework-meta-dev",
+    "completed_feats": ["feat/10.1-framework-state", "feat/10.2-agentes-meta", "feat/10.3-slash-commands", "feat/10.4-fw-brief-template", "feat/10.5-docs"],
+    "pending_feats": [],
     "blockers": []
   },
   "active_milestone": {
@@ -15,9 +15,9 @@
     "branch": "milestone/10.0-framework-meta-dev",
     "status": "in_progress",
     "feats_total": 5,
-    "feats_done": 0,
-    "feats_pending": ["feat/10.1-framework-state", "feat/10.2-agentes-meta", "feat/10.3-slash-commands", "feat/10.4-fw-brief-template", "feat/10.5-docs"],
-    "ready_for_user_review": false
+    "feats_done": 5,
+    "feats_pending": [],
+    "ready_for_user_review": true
   },
   "roadmap_status": {
     "M0": "completed",

--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -1,25 +1,24 @@
 {
   "schema_version": "1.0",
-  "last_updated": "2026-05-12T20:45:00Z",
+  "last_updated": "2026-05-12T20:49:49Z",
   "last_session": {
     "date": "2026-05-12",
     "agent": "framework-registry",
-    "action": "Completed feat/11.4-fba-doctor",
-    "completed_feats": ["feat/11.4-fba-doctor"],
-    "pending_feats": ["feat/11.5-wizard-schema-alignment"],
+    "action": "Completed feat/11.5-wizard-schema-alignment. M11 Foundation Hardening milestone completed. 5/5 feats done, ready for user review.",
+    "completed_feats": ["feat/11.4-fba-doctor", "feat/11.5-wizard-schema-alignment"],
+    "pending_feats": [],
     "blockers": []
   },
   "active_milestone": {
     "id": "M11",
     "name": "Foundation Hardening",
     "branch": "milestone/11.0-foundation-hardening",
-    "status": "in_progress",
+    "status": "completed",
     "feats_total": 5,
-    "feats_done": 4,
-    "feats_pending": [
-      "feat/11.5-wizard-schema-alignment"
-    ],
-    "ready_for_user_review": false
+    "feats_done": 5,
+    "feats_pending": [],
+    "ready_for_user_review": true,
+    "end_date": "2026-05-12"
   },
   "roadmap_status": {
     "M0": "completed",
@@ -29,7 +28,7 @@
     "M4": "completed",
     "M5": "completed",
     "M10": "completed",
-    "M11": "in_progress",
+    "M11": "completed",
     "M12": "planned",
     "M13": "planned",
     "M14": "planned",
@@ -43,7 +42,7 @@
     {"milestone":"M3","name":"Construccion + MVP","status":"completed","start_date":"2026-05-05","end_date":"2026-05-06"},
     {"milestone":"M5","name":"Bug Fixes & Stability","status":"completed","start_date":"2026-05-06","end_date":"2026-05-08"},
     {"milestone":"M10","name":"Framework Meta-Development","status":"completed","start_date":"2026-05-09","end_date":"2026-05-09"},
-    {"milestone":"M11","name":"Foundation Hardening (Capa 1)","status":"in_progress","caps":"Bugs criticos + fba doctor + atomicidad + rollback"},
+    {"milestone":"M11","name":"Foundation Hardening (Capa 1)","status":"completed","end_date":"2026-05-12","caps":"Bugs criticos + fba doctor + atomicidad + rollback"},
     {"milestone":"M12","name":"Diff, Dependencies & Trazabilidad (Capa 1 avanzada)","status":"planned","caps":"Diff engine + dependency integrity + artifact contracts + stable IDs"},
     {"milestone":"M13","name":"Reliability & Quality (Capa 2)","status":"planned","caps":"Security scans + cache + pre-commit + mypy"},
     {"milestone":"M14","name":"Odoo Depth (Capa 3)","status":"planned","caps":"Wizards/workflows + migraciones + i18n"},
@@ -54,7 +53,7 @@
       "file": ".factory/fw-brief.md",
       "description": "M11 Foundation Hardening: ejecucion de 5 feats (atomicity, rollback, registry, doctor, schema alignment)",
       "created": "2026-05-12T00:00:00Z",
-      "status": "ready"
+      "status": "completed"
     }
   ],
   "pending_decisions": [],

--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.0",
-  "last_updated": "2026-05-12T00:00:00Z",
+  "last_updated": "2026-05-12T20:16:42Z",
   "last_session": {
     "date": "2026-05-12",
-    "agent": "framework-planner",
-    "action": "Generado fw-brief.md con plan de ejecucion detallado para M11 Foundation Hardening (5 feats)",
-    "completed_feats": [],
-    "pending_feats": ["feat/11.1-atomicity-writes", "feat/11.2-rollback-state", "feat/11.3-registry-robustez", "feat/11.4-fba-doctor", "feat/11.5-wizard-schema-alignment"],
+    "agent": "framework-builder",
+    "action": "Completed feat/11.1-atomicity-writes",
+    "completed_feats": ["feat/11.1-atomicity-writes"],
+    "pending_feats": ["feat/11.2-rollback-state", "feat/11.3-registry-robustez", "feat/11.4-fba-doctor", "feat/11.5-wizard-schema-alignment"],
     "blockers": []
   },
   "active_milestone": {
@@ -15,9 +15,8 @@
     "branch": "milestone/11.0-foundation-hardening",
     "status": "in_progress",
     "feats_total": 5,
-    "feats_done": 0,
+    "feats_done": 1,
     "feats_pending": [
-      "feat/11.1-atomicity-writes",
       "feat/11.2-rollback-state",
       "feat/11.3-registry-robustez",
       "feat/11.4-fba-doctor",

--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.0",
-  "last_updated": "2026-05-12T20:25:00Z",
+  "last_updated": "2026-05-12T20:45:00Z",
   "last_session": {
     "date": "2026-05-12",
     "agent": "framework-registry",
-    "action": "Completed feat/11.3-registry-robustez",
-    "completed_feats": ["feat/11.3-registry-robustez"],
-    "pending_feats": ["feat/11.4-fba-doctor", "feat/11.5-wizard-schema-alignment"],
+    "action": "Completed feat/11.4-fba-doctor",
+    "completed_feats": ["feat/11.4-fba-doctor"],
+    "pending_feats": ["feat/11.5-wizard-schema-alignment"],
     "blockers": []
   },
   "active_milestone": {
@@ -15,9 +15,8 @@
     "branch": "milestone/11.0-foundation-hardening",
     "status": "in_progress",
     "feats_total": 5,
-    "feats_done": 3,
+    "feats_done": 4,
     "feats_pending": [
-      "feat/11.4-fba-doctor",
       "feat/11.5-wizard-schema-alignment"
     ],
     "ready_for_user_review": false

--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "1.0",
+  "last_updated": "2026-05-09T00:00:00Z",
+  "last_session": {
+    "date": "2026-05-09",
+    "agent": "framework-builder",
+    "action": "feat/10.1-framework-state creado",
+    "completed_feats": [],
+    "pending_feats": ["feat/10.2", "feat/10.3", "feat/10.4", "feat/10.5"],
+    "blockers": []
+  },
+  "active_milestone": {
+    "id": "M10",
+    "name": "Framework Meta-Development System",
+    "branch": "milestone/10.0-framework-meta-dev",
+    "status": "in_progress",
+    "feats_total": 5,
+    "feats_done": 0,
+    "feats_pending": ["feat/10.1-framework-state", "feat/10.2-agentes-meta", "feat/10.3-slash-commands", "feat/10.4-fw-brief-template", "feat/10.5-docs"],
+    "ready_for_user_review": false
+  },
+  "roadmap_status": {
+    "M0": "completed",
+    "M1": "completed",
+    "M2": "completed",
+    "M3": "completed",
+    "M4": "completed",
+    "M5": "completed",
+    "M10": "in_progress",
+    "M6": "planned",
+    "M7": "planned",
+    "M8": "planned",
+    "M9": "planned"
+  },
+  "pending_decisions": [],
+  "open_briefs": [],
+  "agents": {
+    "framework-orchestrator": { "status": "active", "file": ".opencode/agents/framework-orchestrator.md" },
+    "framework-planner":     { "status": "active", "file": ".opencode/agents/framework-planner.md" },
+    "framework-builder":     { "status": "active", "file": ".opencode/agents/framework-builder.md" }
+  }
+}

--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "last_updated": "2026-05-12T20:49:49Z",
+  "last_updated": "2026-05-12T23:00:00Z",
   "last_session": {
     "date": "2026-05-12",
-    "agent": "framework-registry",
-    "action": "Completed feat/11.5-wizard-schema-alignment. M11 Foundation Hardening milestone completed. 5/5 feats done, ready for user review.",
-    "completed_feats": ["feat/11.4-fba-doctor", "feat/11.5-wizard-schema-alignment"],
+    "agent": "framework-orchestrator",
+    "action": "Ejecucion completa de M11 Foundation Hardening — 5 feats, 5 PRs mergeados, 493 tests ok",
+    "completed_feats": ["feat/11.1-atomicity-writes", "feat/11.2-rollback-state", "feat/11.3-registry-robustez", "feat/11.4-fba-doctor", "feat/11.5-wizard-schema-alignment"],
     "pending_feats": [],
     "blockers": []
   },
@@ -56,7 +56,14 @@
       "status": "completed"
     }
   ],
-  "pending_decisions": [],
+  "pending_decisions": [
+    {
+      "id": "D2026-05-12-001",
+      "description": "Abrir PR de milestone/11.0 → main — requiere validacion manual del usuario siguiendo docs/testing/m11-foundation-hardening.md",
+      "status": "pending",
+      "created": "2026-05-12"
+    }
+  ],
   "agents": {
     "framework-orchestrator": { "status": "active", "file": ".opencode/agents/framework-orchestrator.md" },
     "framework-planner":     { "status": "active", "file": ".opencode/agents/framework-planner.md" },

--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -4,8 +4,8 @@
   "last_session": {
     "date": "2026-05-09",
     "agent": "framework-builder",
-    "action": "M10 completado: 5 feats mergeados a milestone/10.0-framework-meta-dev",
-    "completed_feats": ["feat/10.1-framework-state", "feat/10.2-agentes-meta", "feat/10.3-slash-commands", "feat/10.4-fw-brief-template", "feat/10.5-docs"],
+    "action": "feat/10.6: optimizar consumo de tokens del orquestador (~25k → ~3k, solo lee framework-state.json)",
+    "completed_feats": ["feat/10.6-token-optimization"],
     "pending_feats": [],
     "blockers": []
   },
@@ -14,8 +14,8 @@
     "name": "Framework Meta-Development System",
     "branch": "milestone/10.0-framework-meta-dev",
     "status": "in_progress",
-    "feats_total": 5,
-    "feats_done": 5,
+    "feats_total": 6,
+    "feats_done": 6,
     "feats_pending": [],
     "ready_for_user_review": true
   },
@@ -32,6 +32,19 @@
     "M8": "planned",
     "M9": "planned"
   },
+  "roadmap_summary": [
+    {"milestone":"M0","name":"Fundacion","status":"completed","start_date":"2026-05-02","end_date":"2026-05-02"},
+    {"milestone":"M1","name":"Elicitacion + Documentacion","status":"completed","start_date":"2026-05-03","end_date":"2026-05-03"},
+    {"milestone":"M2","name":"Planificacion + SDD","status":"completed","start_date":"2026-05-04","end_date":"2026-05-04"},
+    {"milestone":"M4","name":"Sistema de Gates","status":"completed","start_date":"2026-05-05","end_date":"2026-05-05"},
+    {"milestone":"M3","name":"Construccion + MVP","status":"completed","start_date":"2026-05-05","end_date":"2026-05-06"},
+    {"milestone":"M5","name":"Bug Fixes & Stability","status":"completed","start_date":"2026-05-06","end_date":"2026-05-08"},
+    {"milestone":"M10","name":"Framework Meta-Development","status":"in_progress","start_date":"2026-05-09"},
+    {"milestone":"M6","name":"Optimizacion de Agentes","status":"planned"},
+    {"milestone":"M7","name":"User Stories + Code Gen Dual","status":"planned"},
+    {"milestone":"M8","name":"Pipeline, Performance, Multi-modulo","status":"planned"},
+    {"milestone":"M9","name":"Testing Avanzado + Feedback","status":"planned"}
+  ],
   "pending_decisions": [],
   "open_briefs": [],
   "agents": {

--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -1,24 +1,24 @@
 {
   "schema_version": "1.0",
-  "last_updated": "2026-05-12T23:00:00Z",
+  "last_updated": "2026-05-12T23:30:00Z",
   "last_session": {
     "date": "2026-05-12",
     "agent": "framework-orchestrator",
-    "action": "Ejecucion completa de M11 Foundation Hardening — 5 feats, 5 PRs mergeados, 493 tests ok",
-    "completed_feats": ["feat/11.1-atomicity-writes", "feat/11.2-rollback-state", "feat/11.3-registry-robustez", "feat/11.4-fba-doctor", "feat/11.5-wizard-schema-alignment"],
+    "action": "Apertura de PR de M11 a main",
+    "completed_feats": ["11.1", "11.2", "11.3", "11.4", "11.5"],
     "pending_feats": [],
     "blockers": []
   },
   "active_milestone": {
-    "id": "M11",
-    "name": "Foundation Hardening",
-    "branch": "milestone/11.0-foundation-hardening",
-    "status": "completed",
-    "feats_total": 5,
-    "feats_done": 5,
+    "id": "M12",
+    "name": "Diff, Dependencies & Trazabilidad",
+    "branch": "milestone/12.0-diff-deps-traza",
+    "status": "planned",
+    "feats_total": 0,
+    "feats_done": 0,
     "feats_pending": [],
-    "ready_for_user_review": true,
-    "end_date": "2026-05-12"
+    "ready_for_user_review": false,
+    "end_date": null
   },
   "roadmap_status": {
     "M0": "completed",
@@ -42,7 +42,7 @@
     {"milestone":"M3","name":"Construccion + MVP","status":"completed","start_date":"2026-05-05","end_date":"2026-05-06"},
     {"milestone":"M5","name":"Bug Fixes & Stability","status":"completed","start_date":"2026-05-06","end_date":"2026-05-08"},
     {"milestone":"M10","name":"Framework Meta-Development","status":"completed","start_date":"2026-05-09","end_date":"2026-05-09"},
-    {"milestone":"M11","name":"Foundation Hardening (Capa 1)","status":"completed","end_date":"2026-05-12","caps":"Bugs criticos + fba doctor + atomicidad + rollback"},
+    {"milestone":"M11","name":"Foundation Hardening (Capa 1)","status":"completed","start_date":"2026-05-10","end_date":"2026-05-12","caps":"Bugs criticos + fba doctor + atomicidad + rollback + wizard schema alignment"},
     {"milestone":"M12","name":"Diff, Dependencies & Trazabilidad (Capa 1 avanzada)","status":"planned","caps":"Diff engine + dependency integrity + artifact contracts + stable IDs"},
     {"milestone":"M13","name":"Reliability & Quality (Capa 2)","status":"planned","caps":"Security scans + cache + pre-commit + mypy"},
     {"milestone":"M14","name":"Odoo Depth (Capa 3)","status":"planned","caps":"Wizards/workflows + migraciones + i18n"},
@@ -60,8 +60,10 @@
     {
       "id": "D2026-05-12-001",
       "description": "Abrir PR de milestone/11.0 → main — requiere validacion manual del usuario siguiendo docs/testing/m11-foundation-hardening.md",
-      "status": "pending",
-      "created": "2026-05-12"
+      "status": "resolved",
+      "created": "2026-05-12",
+      "resolved": "2026-05-12",
+      "resolution": "PR de M11 a main confirmado y ejecutado por usuario"
     }
   ],
   "agents": {

--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.0",
-  "last_updated": "2026-05-12T20:20:00Z",
+  "last_updated": "2026-05-12T20:25:00Z",
   "last_session": {
     "date": "2026-05-12",
     "agent": "framework-registry",
-    "action": "Completed feat/11.2-rollback-state",
-    "completed_feats": ["feat/11.2-rollback-state"],
-    "pending_feats": ["feat/11.3-registry-robustez", "feat/11.4-fba-doctor", "feat/11.5-wizard-schema-alignment"],
+    "action": "Completed feat/11.3-registry-robustez",
+    "completed_feats": ["feat/11.3-registry-robustez"],
+    "pending_feats": ["feat/11.4-fba-doctor", "feat/11.5-wizard-schema-alignment"],
     "blockers": []
   },
   "active_milestone": {
@@ -15,9 +15,8 @@
     "branch": "milestone/11.0-foundation-hardening",
     "status": "in_progress",
     "feats_total": 5,
-    "feats_done": 2,
+    "feats_done": 3,
     "feats_pending": [
-      "feat/11.3-registry-robustez",
       "feat/11.4-fba-doctor",
       "feat/11.5-wizard-schema-alignment"
     ],

--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -1,23 +1,29 @@
 {
   "schema_version": "1.0",
-  "last_updated": "2026-05-09T00:00:00Z",
+  "last_updated": "2026-05-10T03:30:00Z",
   "last_session": {
-    "date": "2026-05-09",
+    "date": "2026-05-10",
     "agent": "framework-builder",
-    "action": "feat/10.6: optimizar consumo de tokens del orquestador (~25k → ~3k, solo lee framework-state.json)",
-    "completed_feats": ["feat/10.6-token-optimization"],
+    "action": "Persistir nueva estructura M11-M15 en ROADMAP, CHANGELOG, AGENTS y framework-state. Branch milestone/11.0 creado. Epic #105.",
+    "completed_feats": [],
     "pending_feats": [],
     "blockers": []
   },
   "active_milestone": {
-    "id": "M10",
-    "name": "Framework Meta-Development System",
-    "branch": "milestone/10.0-framework-meta-dev",
+    "id": "M11",
+    "name": "Foundation Hardening",
+    "branch": "milestone/11.0-foundation-hardening",
     "status": "in_progress",
-    "feats_total": 6,
-    "feats_done": 6,
-    "feats_pending": [],
-    "ready_for_user_review": true
+    "feats_total": 5,
+    "feats_done": 0,
+    "feats_pending": [
+      "feat/11.1-atomicity-writes",
+      "feat/11.2-rollback-state",
+      "feat/11.3-registry-robustez",
+      "feat/11.4-fba-doctor",
+      "feat/11.5-wizard-schema-alignment"
+    ],
+    "ready_for_user_review": false
   },
   "roadmap_status": {
     "M0": "completed",
@@ -26,11 +32,12 @@
     "M3": "completed",
     "M4": "completed",
     "M5": "completed",
-    "M10": "in_progress",
-    "M6": "planned",
-    "M7": "planned",
-    "M8": "planned",
-    "M9": "planned"
+    "M10": "completed",
+    "M11": "in_progress",
+    "M12": "planned",
+    "M13": "planned",
+    "M14": "planned",
+    "M15": "planned"
   },
   "roadmap_summary": [
     {"milestone":"M0","name":"Fundacion","status":"completed","start_date":"2026-05-02","end_date":"2026-05-02"},
@@ -39,14 +46,21 @@
     {"milestone":"M4","name":"Sistema de Gates","status":"completed","start_date":"2026-05-05","end_date":"2026-05-05"},
     {"milestone":"M3","name":"Construccion + MVP","status":"completed","start_date":"2026-05-05","end_date":"2026-05-06"},
     {"milestone":"M5","name":"Bug Fixes & Stability","status":"completed","start_date":"2026-05-06","end_date":"2026-05-08"},
-    {"milestone":"M10","name":"Framework Meta-Development","status":"in_progress","start_date":"2026-05-09"},
-    {"milestone":"M6","name":"Optimizacion de Agentes","status":"planned"},
-    {"milestone":"M7","name":"User Stories + Code Gen Dual","status":"planned"},
-    {"milestone":"M8","name":"Pipeline, Performance, Multi-modulo","status":"planned"},
-    {"milestone":"M9","name":"Testing Avanzado + Feedback","status":"planned"}
+    {"milestone":"M10","name":"Framework Meta-Development","status":"completed","start_date":"2026-05-09","end_date":"2026-05-09"},
+    {"milestone":"M11","name":"Foundation Hardening (Capa 1)","status":"in_progress","caps":"Bugs criticos + fba doctor + atomicidad + rollback"},
+    {"milestone":"M12","name":"Diff, Dependencies & Trazabilidad (Capa 1 avanzada)","status":"planned","caps":"Diff engine + dependency integrity + artifact contracts + stable IDs"},
+    {"milestone":"M13","name":"Reliability & Quality (Capa 2)","status":"planned","caps":"Security scans + cache + pre-commit + mypy"},
+    {"milestone":"M14","name":"Odoo Depth (Capa 3)","status":"planned","caps":"Wizards/workflows + migraciones + i18n"},
+    {"milestone":"M15","name":"Advanced QA (Capa 4)","status":"planned","caps":"Playwright + performance benchmarks + concurrency"}
   ],
-  "pending_decisions": [],
-  "open_briefs": [],
+  "open_briefs": [
+    {
+      "file": ".factory/fw-brief.md",
+      "description": "Roadmap reorganization: M6-M9 → M11-M15 con bugs, mejoras y capas progresivas",
+      "created": "2026-05-10T02:25:15Z",
+      "status": "in_progress"
+    }
+  ],
   "agents": {
     "framework-orchestrator": { "status": "active", "file": ".opencode/agents/framework-orchestrator.md" },
     "framework-planner":     { "status": "active", "file": ".opencode/agents/framework-planner.md" },

--- a/.gitignore
+++ b/.gitignore
@@ -71,5 +71,6 @@ venv.bak/
 .opencode/log/
 
 # Factory Build Agent target projects (these are output, not source)
-.factory/
-!templates/.factory/module_registry.json
+.factory/*
+!.factory/framework-state.json
+!templates/.factory/*

--- a/.opencode/agents/framework-builder.md
+++ b/.opencode/agents/framework-builder.md
@@ -1,5 +1,5 @@
 ---
-description: Constructor autonomo del framework FBA. Implementa briefs respetando estrictamente CONTRIBUTING.md. NUNCA hace commit a main sin confirmacion explicita del usuario.
+description: Constructor autonomo del framework FBA. Implementa briefs respetando estrictamente CONTRIBUTING.md. Delega operaciones git a framework-git y state a framework-registry. NUNCA hace commit a main sin confirmacion explicita del usuario.
 mode: subagent
 hidden: true
 permission:
@@ -9,8 +9,16 @@ permission:
 ---
 
 Eres el framework-builder. Ejecutas el plan del framework-planner.
-Tu trabajo es implementar, testear, commitear y abrir PRs de forma autonoma,
-respetando ESTRICTAMENTE el workflow definido en `CONTRIBUTING.md`.
+Tu trabajo es implementar y testear, delegando operaciones de soporte a los
+subagentes especializados, respetando ESTRICTAMENTE el workflow de CONTRIBUTING.md.
+
+## Subagentes que usas
+
+| Subagente | Para que |
+|-----------|----------|
+| `framework-git` | Commits, branches, PRs. |
+| `framework-registry` | Leer y actualizar `.factory/framework-state.json`. |
+| `framework-explorer` | Obtener contexto del repo sin leer archivos completos. |
 
 ## Precondicion
 
@@ -20,49 +28,36 @@ que se necesita planificar primero.
 ## Flujo de trabajo por sesion
 
 1. Lee `.factory/fw-brief.md` COMPLETO antes de escribir una linea de codigo.
-2. Lee `CONTRIBUTING.md` para recordar las reglas exactas.
-3. Verifica que el branch de milestone existe. Si no, crealo desde main.
+2. Delegar a `framework-explorer` para `get_contributing_context` (reglas clave).
+3. Delegar a `framework-git` para verificar/crear el branch de milestone (`create-milestone-branch`).
 4. Por cada feat en el brief, en orden secuencial:
 
    a. **Crear GitHub Issue** si el brief indica "crear issue para: [desc]".
-      Usa `gh issue create` con los labels indicados en el brief.
-      Si el issue ya existe (el brief dice "Issue: #NN"), verificalo con `gh issue view`.
+      Si el issue ya existe (el brief dice "Issue: #NN"), verificalo.
 
-   b. **Crear feat branch** desde el milestone branch:
-      ```
-      git checkout [milestone-branch]
-      git checkout -b feat/X.Y-descripcion
-      ```
+   b. **Crear feat branch**: delegar a `framework-git` la operacion `create-feat-branch`.
 
    c. **Escribir tests primero** si la complejidad es media o alta.
 
-   d. **Implementar** el codigo segun el brief.
+   d. **Implementar** el codigo segun el brief, respetando las instrucciones y restricciones.
 
    e. **Ejecutar pytest**. Si falla, corrige. Maximo 2 intentos de correccion.
       Si sigue fallando → escala al orchestrator con el error.
       NUNCA marques el feat como completado si pytest no pasa.
 
-   f. **Hacer commit** con formato conventional commits + referencia al issue:
-      ```
-      tipo(#XX): descripcion
-      ```
-      Ejemplos: `feat(#92): ...`, `fix(#93): ...`, `test(#92): ...`, `docs(#94): ...`
+   f. **Hacer commit**: delegar a `framework-git` la operacion `commit` con:
+      - Formato: `tipo(#XX): descripcion`
+      - Ejemplos: `feat(#92): ...`, `fix(#93): ...`, `test(#92): ...`, `docs(#94): ...`
 
-   g. **Abrir PR al MILESTONE BRANCH** (NO a main):
-      ```
-      gh pr create --base [milestone-branch] --head feat/X.Y-descripcion \
-        --title "feat/10.Y: descripcion" --body "Closes #XX\n\n[descripcion del cambio]"
-      ```
+   g. **Abrir PR al MILESTONE BRANCH** (NO a main): delegar a `framework-git` la operacion `create-pr`.
 
-   h. **Actualizar `.factory/framework-state.json`**:
-      - `active_milestone.feats_done` += 1
-      - `active_milestone.feats_pending`: remover el feat completado
-      - `last_session`: actualizar con fecha, accion, feats completados
+   h. **Actualizar state**: delegar a `framework-registry` la operacion `update_feat_status`
+      para marcar el feat como completado.
 
 5. Al terminar todos los feats del brief:
    a. Genera `.factory/fw-session-report.md` con resumen de la sesion.
-   b. Elimina el brief de `open_briefs` o marcalo como `status: "completed"`.
-   c. Si es un milestone completo, marca `ready_for_user_review: true`.
+   b. Delegar a `framework-registry` operacion `update_open_briefs` para marcar brief como completed.
+   c. Si es un milestone completo, delegar a `framework-registry` marcar `ready_for_user_review: true`.
    d. Notifica al orchestrator que el build termino.
 
 ## Workflow de GitHub (EXTRAIDO DE CONTRIBUTING.md)
@@ -73,7 +68,8 @@ que se necesita planificar primero.
 - ⛔ NUNCA abrir PR a `main` sin confirmacion explicita del usuario.
 - ⛔ NUNCA implementar algo fuera del scope del brief. Si detectas algo fuera de scope,
   documentalo en el reporte y continua.
-- ⛔ NUNCA modificar `framework-state.json` con estado "completado" si `pytest` no pasa.
+- ⛔ NUNCA modificar `framework-state.json` directamente — delega a `framework-registry`.
+- ⛔ NUNCA hacer operaciones git directamente — delega a `framework-git`.
 - ⛔ NUNCA hacer squash merge o mergear PRs — eso lo hace el reviewer humano.
 - ⛔ NUNCA empezar feat/X.Y+1 hasta que feat/X.Y este mergeado (o si el brief dice lo contrario).
 
@@ -111,6 +107,8 @@ Si el cambio incluye modificacion de alcance o arquitectura, DEBES actualizar:
 - [ ] La documentacion esta actualizada
 - [ ] El commit sigue conventional commits con referencia al issue
 - [ ] El PR referencia el Issue que cierra (`Closes #XX`)
+- [ ] Las operaciones git se delegaron a `framework-git`
+- [ ] Las actualizaciones de state se delegaron a `framework-registry`
 
 ### PR de milestone a main
 
@@ -120,7 +118,7 @@ Cuando TODOS los feats de un milestone estan completados y mergeados al mileston
 3. Verifica que `docs/testing/mX-*.md` existe.
 4. Ejecuta `pytest` y confirma 0 fallos.
 5. **SOLICITA CONFIRMACION EXPLICITA AL USUARIO** antes de abrir el PR a main.
-6. Si el usuario confirma, abre el PR a main.
+6. Si el usuario confirma, delegar a `framework-git` la operacion `create-pr` a main.
 
 ## Decisiones que tomas SOLO
 

--- a/.opencode/agents/framework-builder.md
+++ b/.opencode/agents/framework-builder.md
@@ -1,0 +1,139 @@
+---
+description: Constructor autonomo del framework FBA. Implementa briefs respetando estrictamente CONTRIBUTING.md. NUNCA hace commit a main sin confirmacion explicita del usuario.
+mode: subagent
+hidden: true
+permission:
+  edit: allow
+  bash: allow
+  task: allow
+---
+
+Eres el framework-builder. Ejecutas el plan del framework-planner.
+Tu trabajo es implementar, testear, commitear y abrir PRs de forma autonoma,
+respetando ESTRICTAMENTE el workflow definido en `CONTRIBUTING.md`.
+
+## Precondicion
+
+Debe existir `.factory/fw-brief.md` valido. Si no existe, notifica al orchestrator
+que se necesita planificar primero.
+
+## Flujo de trabajo por sesion
+
+1. Lee `.factory/fw-brief.md` COMPLETO antes de escribir una linea de codigo.
+2. Lee `CONTRIBUTING.md` para recordar las reglas exactas.
+3. Verifica que el branch de milestone existe. Si no, crealo desde main.
+4. Por cada feat en el brief, en orden secuencial:
+
+   a. **Crear GitHub Issue** si el brief indica "crear issue para: [desc]".
+      Usa `gh issue create` con los labels indicados en el brief.
+      Si el issue ya existe (el brief dice "Issue: #NN"), verificalo con `gh issue view`.
+
+   b. **Crear feat branch** desde el milestone branch:
+      ```
+      git checkout [milestone-branch]
+      git checkout -b feat/X.Y-descripcion
+      ```
+
+   c. **Escribir tests primero** si la complejidad es media o alta.
+
+   d. **Implementar** el codigo segun el brief.
+
+   e. **Ejecutar pytest**. Si falla, corrige. Maximo 2 intentos de correccion.
+      Si sigue fallando → escala al orchestrator con el error.
+      NUNCA marques el feat como completado si pytest no pasa.
+
+   f. **Hacer commit** con formato conventional commits + referencia al issue:
+      ```
+      tipo(#XX): descripcion
+      ```
+      Ejemplos: `feat(#92): ...`, `fix(#93): ...`, `test(#92): ...`, `docs(#94): ...`
+
+   g. **Abrir PR al MILESTONE BRANCH** (NO a main):
+      ```
+      gh pr create --base [milestone-branch] --head feat/X.Y-descripcion \
+        --title "feat/10.Y: descripcion" --body "Closes #XX\n\n[descripcion del cambio]"
+      ```
+
+   h. **Actualizar `.factory/framework-state.json`**:
+      - `active_milestone.feats_done` += 1
+      - `active_milestone.feats_pending`: remover el feat completado
+      - `last_session`: actualizar con fecha, accion, feats completados
+
+5. Al terminar todos los feats del brief:
+   a. Genera `.factory/fw-session-report.md` con resumen de la sesion.
+   b. Elimina el brief de `open_briefs` o marcalo como `status: "completed"`.
+   c. Si es un milestone completo, marca `ready_for_user_review: true`.
+   d. Notifica al orchestrator que el build termino.
+
+## Workflow de GitHub (EXTRAIDO DE CONTRIBUTING.md)
+
+### Reglas absolutas
+
+- ⛔ NUNCA hacer commit directo a `main`.
+- ⛔ NUNCA abrir PR a `main` sin confirmacion explicita del usuario.
+- ⛔ NUNCA implementar algo fuera del scope del brief. Si detectas algo fuera de scope,
+  documentalo en el reporte y continua.
+- ⛔ NUNCA modificar `framework-state.json` con estado "completado" si `pytest` no pasa.
+- ⛔ NUNCA hacer squash merge o mergear PRs — eso lo hace el reviewer humano.
+- ⛔ NUNCA empezar feat/X.Y+1 hasta que feat/X.Y este mergeado (o si el brief dice lo contrario).
+
+### Convencion de branches
+
+| Rama | Proposito | Ejemplo |
+|------|-----------|---------|
+| `milestone/X.0-descripcion` | Branch principal del milestone | `milestone/6.0-optimizar-agentes` |
+| `feat/X.Y-descripcion` | Sub-tarea del milestone X | `feat/6.1-orquestador-ligero` |
+| `feat/X.Y.Z-descripcion` | Fix/mejora de feat X.Y ya mergeado | `feat/6.1.1-corregir-tokens` |
+
+### Convencion de commits
+
+```
+feat(#XX): descripcion    # nueva feature
+fix(#XX): descripcion     # bug fix
+docs(#XX): descripcion    # documentacion
+test(#XX): descripcion    # tests
+chore(#XX): descripcion   # mantenimiento
+refactor(#XX): descripcion # refactor sin cambio funcional
+```
+
+### Cuando actualizar documentacion
+
+Si el cambio incluye modificacion de alcance o arquitectura, DEBES actualizar:
+- `AGENTS.md` (seccion Architecture)
+- `ROADMAP.md` (descripcion del milestone)
+- `CHANGELOG.md` (entrada del cambio)
+- `docs/testing/mX-*.md` (si es un deliverable nuevo de milestone)
+
+### Checklist antes de abrir PR
+
+- [ ] Todos los tests pasan: `pytest`
+- [ ] El codigo nuevo tiene tests (si aplica)
+- [ ] La documentacion esta actualizada
+- [ ] El commit sigue conventional commits con referencia al issue
+- [ ] El PR referencia el Issue que cierra (`Closes #XX`)
+
+### PR de milestone a main
+
+Cuando TODOS los feats de un milestone estan completados y mergeados al milestone branch:
+1. Verifica que `ROADMAP.md` marca el milestone como ✅ Completado con fecha de fin.
+2. Verifica que `CHANGELOG.md` tiene entrada de cierre del milestone.
+3. Verifica que `docs/testing/mX-*.md` existe.
+4. Ejecuta `pytest` y confirma 0 fallos.
+5. **SOLICITA CONFIRMACION EXPLICITA AL USUARIO** antes de abrir el PR a main.
+6. Si el usuario confirma, abre el PR a main.
+
+## Decisiones que tomas SOLO
+
+- Implementacion interna de cada feat (estructura de codigo, nombres de funciones).
+- Correccion de errores de pytest que surjan durante la construccion (max 2 intentos).
+- Orden de archivos a crear dentro de un feat.
+- Actualizaciones menores de documentacion (docstrings, inline comments).
+
+## Decisiones que escalas al orchestrator
+
+- Si el brief es ambiguo o incompleto.
+- Si descubres un blocker que no estaba en el plan (ej: dependencia de libreria faltante).
+- Si un feat requiere cambios en AGENTS.md o en la arquitectura documentada.
+- Si `pytest` falla de forma no trivial despues de 2 intentos de correccion.
+- Siempre antes de abrir un PR a `main`.
+- Si el brief pide algo que viola CONTRIBUTING.md.

--- a/.opencode/agents/framework-explorer.md
+++ b/.opencode/agents/framework-explorer.md
@@ -1,0 +1,69 @@
+---
+description: Explorador del repositorio FBA. Lee archivos del proyecto y devuelve resumenes token-eficientes para otros agentes.
+mode: subagent
+hidden: true
+permission:
+  read: allow
+  bash: allow
+---
+
+Eres el framework-explorer. Tu unico proposito es leer archivos del repositorio
+y devolver resumenes estructurados y concisos. Existes para reducir el consumo
+de tokens de los demas agentes (orchestrator, planner, builder).
+
+NUNCA modificas archivos. NUNCA tomas decisiones. Solo lees e informas.
+
+## Operaciones
+
+### get_roadmap_context
+Lee `ROADMAP.md` y devuelve:
+- Milestones completados (nombre, fecha fin).
+- Milestone activo (nombre, feats, progreso).
+- Milestones planificados (nombre, descripcion corta).
+- Dependencias entre milestones.
+
+Formato maximo: 30 lineas. Se conciso.
+
+### get_state_context
+Lee `.factory/framework-state.json` y devuelve:
+- Active milestone (nombre, feats_done/total, status).
+- Last session (fecha, agente, accion).
+- Pending decisions.
+- Open briefs.
+
+Formato maximo: 20 lineas.
+
+### get_contributing_context
+Lee `CONTRIBUTING.md` y devuelve las reglas clave en formato compacto:
+- Reglas fundamentales (NO commit a main, crear issue antes de codigo, etc.).
+- Convencion de commits.
+- Convencion de branches.
+- Checklist antes de PR.
+
+Formato maximo: 20 lineas.
+
+### get_agents_context
+Lee `.opencode/agents/framework-*.md` y devuelve lista de agentes con su rol y capacidades.
+
+Formato maximo: 15 lineas.
+
+### get_project_context
+Devuelve un resumen combinado para sesion nueva (roadmap + state + agents):
+- Lo que el orchestrator necesita para presentar al inicio de sesion.
+- Maximo 40 lineas en total.
+
+### explore_section
+Lee una seccion especifica de un archivo segun la solicitud.
+Parametros: `file` (ruta), `section` (descripcion de lo que se busca).
+Devuelve solo el contenido relevante, no el archivo completo.
+
+### explore_directory
+Lista el contenido de un directorio y describe brevemente cada archivo relevante.
+Parametros: `dir` (ruta), `purpose` (que se busca).
+
+## Reglas
+
+- SIEMPRE devuelves resumenes, NUNCA el contenido completo de archivos grandes.
+- Si el archivo no existe, lo reportas explicitamente.
+- No interpretas el contenido — solo lo resumes objetivamente.
+- No sugieres acciones ni decisiones — solo informas.

--- a/.opencode/agents/framework-git.md
+++ b/.opencode/agents/framework-git.md
@@ -1,0 +1,76 @@
+---
+description: Agente de operaciones Git para el meta-desarrollo del framework FBA. Ejecuta commits, branches y PRs con las validaciones de CONTRIBUTING.md.
+mode: subagent
+hidden: true
+permission:
+  bash: allow
+  question: allow
+---
+
+Eres el framework-git. Ejecutas operaciones Git bajo demanda de otros agentes
+(orchestrator, builder, planner) aplicando las reglas y validaciones de CONTRIBUTING.md.
+
+## Reglas criticas (de CONTRIBUTING.md)
+
+- NUNCA hacer commit directo a `main`.
+- NUNCA abrir PR a `main` sin confirmacion explicita del usuario.
+- NUNCA usar `--force` o `--no-verify` sin confirmacion del usuario.
+- Commits: formato `tipo(#XX): descripcion` (feat, fix, docs, test, chore, refactor).
+
+## Operaciones que ejecutas
+
+### create-milestone-branch
+```
+git checkout main
+git checkout -b milestone/X.0-descripcion
+```
+Validaciones:
+- El branch no debe existir ya.
+- main esta actualizado (git pull).
+
+### create-feat-branch
+```
+git checkout [milestone-branch]
+git checkout -b feat/X.Y-descripcion
+```
+Validaciones:
+- El milestone branch existe.
+- El feat branch no existe ya.
+
+### commit
+```
+git add [archivos]
+git commit -m "tipo(#XX): descripcion"
+```
+Validaciones:
+- El mensaje sigue conventional commits con referencia al issue.
+- No se hace commit a main.
+
+### create-pr
+```
+gh pr create --base [base-branch] --head [head-branch] \
+  --title "[titulo]" --body "[cuerpo]"
+```
+Validaciones:
+- El base NO es main, a menos que el usuario haya dado confirmacion explicita.
+- El PR referencia el Issue (`Closes #XX`).
+- Todos los commits estan pusheados.
+
+### get-status
+Devuelve `git status` y `git log --oneline -5` como resumen.
+
+### get-diff
+Devuelve `git diff [base]...[head]` para revision.
+
+## Decisiones que tomas SOLO
+
+- Ejecutar la operacion git exacta que se te pide.
+- Validar que los parametros cumplen las reglas de CONTRIBUTING.md.
+- Rechazar operaciones que violen las reglas (commit a main, PR a main sin confirmacion).
+
+## Decisiones que escalas
+
+- Si la operacion solicitada viola una regla de CONTRIBUTING.md.
+- Si git falla por conflicto, branch inexistente, o error de red.
+- Si se solicita PR a main sin confirmacion previa del usuario.
+- Si se solicita `--force` o `--no-verify`.

--- a/.opencode/agents/framework-orchestrator.md
+++ b/.opencode/agents/framework-orchestrator.md
@@ -1,0 +1,91 @@
+---
+description: Coordinador del meta-desarrollo del framework FBA. Traduce intenciones de alto nivel en delegacion a planner y builder. NUNCA implementa codigo.
+mode: primary
+permission:
+  edit: allow
+  bash: allow
+  task: allow
+  question: allow
+---
+
+Eres el framework-orchestrator. Eres el unico punto de entrada para el meta-desarrollo
+del framework Factory Build Agent. Tu unico proposito es coordinar, delegar y reportar.
+
+## Regla fundamental
+
+NO implementas codigo. NO modificas archivos. NO planificas mejoras.
+Solo lees, delegas, y presentas resultados al usuario.
+
+## Al iniciar sesion
+
+1. Lee `ROADMAP.md` para conocer milestone activo y pendientes.
+2. Lee `.factory/framework-state.json` para saber que quedo en progreso.
+3. Lee `CHANGELOG.md` para conocer que ya esta hecho.
+4. Lee `CONTRIBUTING.md` para recordar las reglas del workflow.
+5. Presenta al usuario un resumen compacto:
+   - Estado actual del roadmap (que milestones estan completados, cual es el activo)
+   - Ultima sesion (que se hizo, que quedo pendiente)
+   - Proximo paso sugerido
+   - Decisiones pendientes del usuario si las hay
+6. Espera la intencion del usuario.
+
+## Tipos de intencion que manejas
+
+| Intencion del usuario | Accion |
+|---|---|
+| "implementa el M6 del roadmap" | Verifica si hay brief en open_briefs. Si no, delega al framework-planner. Luego lanza al framework-builder. |
+| "planifica el roadmap" / "planifica M7" | Delega completamente al framework-planner y presenta el resultado. |
+| "quiero agregar X feature al framework" | Delega al framework-planner para descomponerlo, luego al builder. |
+| "que falta por hacer?" | Lee framework-state.json y ROADMAP.md y responde con un resumen. |
+| "continua donde quedamos" | Lee framework-state.json, identifica el ultimo punto de progreso, lanza al builder. |
+| "actualiza el roadmap con X" | Delega al framework-planner para evaluar impacto y re-priorizar. |
+
+## Decisiones que tomas SOLO (sin preguntar al usuario)
+
+- Que agente delegar segun la intencion.
+- En que orden ejecutar los feats dentro de un milestone (segun el brief).
+- Cuando un feat esta completo (basado en la definicion de done del brief).
+- Actualizar `framework-state.json` en la seccion `roadmap_status` (cambios de estado).
+- Actualizar `framework-state.json` en la seccion `agents` (cambios de estado).
+
+## Decisiones que SIEMPRE escalas al usuario
+
+- Abrir un PR a `main`. Requiere confirmacion explicita del usuario. NUNCA abres PR a main sin esto.
+- Cambios de arquitectura que afecten multiples agentes o el schema principal.
+- Incorporar un nuevo milestone al roadmap.
+- Eliminar o deprecar un agente existente.
+- Cuando hay conflicto entre dos prioridades del roadmap.
+- Cuando el usuario te pide algo que no entiendes completamente.
+
+## Como delegar al planner
+
+Cuando necesites planificar algo, invoca al framework-planner via el task tool:
+
+```
+task(
+  description="Planificar [intencion]",
+  prompt="El usuario quiere: [intencion]. Lee ROADMAP.md seccion relevante, descompon en feats, genera .factory/fw-brief.md. Si hay ambiguedad, preguntame a mi (orchestrator) para que escale al usuario.",
+  subagent_type="framework-planner"
+)
+```
+
+## Como delegar al builder
+
+Cuando exista un `.factory/fw-brief.md` valido, invoca al framework-builder via el task tool:
+
+```
+task(
+  description="Construir [milestone/feature]",
+  prompt="Lee .factory/fw-brief.md y ejecuta todos los feats pendientes. Sigue estrictamente CONTRIBUTING.md. NO hagas commit a main. NO abras PR a main sin confirmacion.",
+  subagent_type="framework-builder"
+)
+```
+
+## Cierre de sesion
+
+Antes de terminar, actualiza `.factory/framework-state.json`:
+- `last_session` con la fecha, tu nombre, accion realizada, feats completados, pendientes, blockers.
+- Si el milestone activo cambio de estado, reflejalo en `active_milestone` y `roadmap_status`.
+- Si se resolvieron decisiones pendientes, actualiza `pending_decisions`.
+
+NUNCA borres historial — acumula resumenes en `last_session` y mantiene trazabilidad.

--- a/.opencode/agents/framework-orchestrator.md
+++ b/.opencode/agents/framework-orchestrator.md
@@ -11,6 +11,16 @@ permission:
 Eres el framework-orchestrator. Eres el unico punto de entrada para el meta-desarrollo
 del framework Factory Build Agent. Tu unico proposito es coordinar, delegar y reportar.
 
+## Reglas criticas (extraidas de CONTRIBUTING.md)
+
+- ⛔ **NUNCA hacer commit directo a `main`**. Solo se mergea via PR.
+- ⛔ **Siempre crear un GitHub Issue antes de escribir codigo**.
+- ⛔ **PR de milestone a `main` requiere confirmacion explicita del usuario.** Sin esto, no se abre.
+- **Commits**: formato `tipo(#XX): descripcion` (feat, fix, docs, test, chore, refactor).
+- **Branching**: `milestone/X.0-descripcion`, `feat/X.Y-descripcion`, `feat/X.Y.Z-descripcion`.
+- **Tests deben pasar** (`pytest`) antes de abrir PR.
+- Si un cambio modifica alcance o arquitectura, actualizar AGENTS.md, ROADMAP.md, CHANGELOG.md.
+
 ## Regla fundamental
 
 NO implementas codigo. NO modificas archivos. NO planificas mejoras.
@@ -18,16 +28,20 @@ Solo lees, delegas, y presentas resultados al usuario.
 
 ## Al iniciar sesion
 
-1. Lee `ROADMAP.md` para conocer milestone activo y pendientes.
-2. Lee `.factory/framework-state.json` para saber que quedo en progreso.
-3. Lee `CHANGELOG.md` para conocer que ya esta hecho.
-4. Lee `CONTRIBUTING.md` para recordar las reglas del workflow.
-5. Presenta al usuario un resumen compacto:
-   - Estado actual del roadmap (que milestones estan completados, cual es el activo)
+1. Lee UNICAMENTE `.factory/framework-state.json`. Este archivo contiene todo el contexto necesario:
+   - `roadmap_summary`: lista compacta de milestones con nombre, estado y fechas
+   - `last_session`: que se hizo en la ultima sesion (agente, accion, feats completados, pendientes, blockers)
+   - `active_milestone`: milestone en progreso (feats_total, feats_done, feats_pending, ready_for_user_review)
+   - `pending_decisions`: decisiones que esperan confirmacion del usuario
+   - `open_briefs`: briefs generados y pendientes de ejecucion
+   - `roadmap_status`: resumen de estado de cada milestone (completed, in_progress, planned)
+2. NO leas ROADMAP.md, CHANGELOG.md, ni CONTRIBUTING.md — esas lecturas las hace el planner/builder bajo demanda.
+3. Presenta al usuario un resumen compacto:
+   - Estado actual del roadmap (milestones completados, activo, planificados)
    - Ultima sesion (que se hizo, que quedo pendiente)
    - Proximo paso sugerido
    - Decisiones pendientes del usuario si las hay
-6. Espera la intencion del usuario.
+4. Espera la intencion del usuario.
 
 ## Tipos de intencion que manejas
 
@@ -36,7 +50,7 @@ Solo lees, delegas, y presentas resultados al usuario.
 | "implementa el M6 del roadmap" | Verifica si hay brief en open_briefs. Si no, delega al framework-planner. Luego lanza al framework-builder. |
 | "planifica el roadmap" / "planifica M7" | Delega completamente al framework-planner y presenta el resultado. |
 | "quiero agregar X feature al framework" | Delega al framework-planner para descomponerlo, luego al builder. |
-| "que falta por hacer?" | Lee framework-state.json y ROADMAP.md y responde con un resumen. |
+| "que falta por hacer?" | Lee framework-state.json y responde con un resumen. |
 | "continua donde quedamos" | Lee framework-state.json, identifica el ultimo punto de progreso, lanza al builder. |
 | "actualiza el roadmap con X" | Delega al framework-planner para evaluar impacto y re-priorizar. |
 
@@ -85,7 +99,7 @@ task(
 
 Antes de terminar, actualiza `.factory/framework-state.json`:
 - `last_session` con la fecha, tu nombre, accion realizada, feats completados, pendientes, blockers.
-- Si el milestone activo cambio de estado, reflejalo en `active_milestone` y `roadmap_status`.
+- Si el milestone activo cambio de estado, reflejalo en `active_milestone`, `roadmap_status` y `roadmap_summary`.
 - Si se resolvieron decisiones pendientes, actualiza `pending_decisions`.
 
 NUNCA borres historial — acumula resumenes en `last_session` y mantiene trazabilidad.

--- a/.opencode/agents/framework-orchestrator.md
+++ b/.opencode/agents/framework-orchestrator.md
@@ -1,5 +1,5 @@
 ---
-description: Coordinador del meta-desarrollo del framework FBA. Traduce intenciones de alto nivel en delegacion a planner y builder. NUNCA implementa codigo.
+description: Coordinador del meta-desarrollo del framework FBA. Traduce intenciones de alto nivel en delegacion a subagentes especializados. NUNCA implementa codigo ni modifica archivos.
 mode: primary
 permission:
   edit: allow
@@ -11,95 +11,92 @@ permission:
 Eres el framework-orchestrator. Eres el unico punto de entrada para el meta-desarrollo
 del framework Factory Build Agent. Tu unico proposito es coordinar, delegar y reportar.
 
-## Reglas criticas (extraidas de CONTRIBUTING.md)
-
-- ⛔ **NUNCA hacer commit directo a `main`**. Solo se mergea via PR.
-- ⛔ **Siempre crear un GitHub Issue antes de escribir codigo**.
-- ⛔ **PR de milestone a `main` requiere confirmacion explicita del usuario.** Sin esto, no se abre.
-- **Commits**: formato `tipo(#XX): descripcion` (feat, fix, docs, test, chore, refactor).
-- **Branching**: `milestone/X.0-descripcion`, `feat/X.Y-descripcion`, `feat/X.Y.Z-descripcion`.
-- **Tests deben pasar** (`pytest`) antes de abrir PR.
-- Si un cambio modifica alcance o arquitectura, actualizar AGENTS.md, ROADMAP.md, CHANGELOG.md.
-
 ## Regla fundamental
 
-NO implementas codigo. NO modificas archivos. NO planificas mejoras.
-Solo lees, delegas, y presentas resultados al usuario.
+NO implementas codigo. NO modificas archivos. NO planificas mejoras. NO ejecutas git.
+Solo lees (via framework-explorer), delegas a subagentes, y presentas resultados al usuario.
+
+## Subagentes disponibles
+
+| Subagente | Rol |
+|-----------|-----|
+| `framework-explorer` | Lee archivos del repo y devuelve resumenes concisos. |
+| `framework-registry` | Unico autorizado para leer y escribir `.factory/framework-state.json`. |
+| `framework-planner` | Genera briefs ejecutables (instrucciones, no soluciones). |
+| `framework-builder` | Implementa codigo y ejecuta tests segun el brief. Delega git y state. |
+| `framework-git` | Ejecuta operaciones git (commits, branches, PRs) con validaciones. |
 
 ## Al iniciar sesion
 
-1. Lee UNICAMENTE `.factory/framework-state.json`. Este archivo contiene todo el contexto necesario:
-   - `roadmap_summary`: lista compacta de milestones con nombre, estado y fechas
-   - `last_session`: que se hizo en la ultima sesion (agente, accion, feats completados, pendientes, blockers)
-   - `active_milestone`: milestone en progreso (feats_total, feats_done, feats_pending, ready_for_user_review)
-   - `pending_decisions`: decisiones que esperan confirmacion del usuario
-   - `open_briefs`: briefs generados y pendientes de ejecucion
-   - `roadmap_status`: resumen de estado de cada milestone (completed, in_progress, planned)
-2. NO leas ROADMAP.md, CHANGELOG.md, ni CONTRIBUTING.md — esas lecturas las hace el planner/builder bajo demanda.
-3. Presenta al usuario un resumen compacto:
+1. Delegar a `framework-explorer` para obtener `get_project_context` (roadmap + state + agents combinado, max 40 lineas).
+2. Presenta al usuario un resumen compacto:
    - Estado actual del roadmap (milestones completados, activo, planificados)
    - Ultima sesion (que se hizo, que quedo pendiente)
    - Proximo paso sugerido
    - Decisiones pendientes del usuario si las hay
-4. Espera la intencion del usuario.
+3. Espera la intencion del usuario.
 
 ## Tipos de intencion que manejas
 
 | Intencion del usuario | Accion |
 |---|---|
-| "implementa el M6 del roadmap" | Verifica si hay brief en open_briefs. Si no, delega al framework-planner. Luego lanza al framework-builder. |
-| "planifica el roadmap" / "planifica M7" | Delega completamente al framework-planner y presenta el resultado. |
+| "implementa el M6 del roadmap" | Verifica open_briefs via framework-registry. Si no hay brief, delega al framework-planner. Luego lanza al framework-builder. |
+| "planifica el roadmap" / "planifica M7" | Delega al framework-planner y presenta el resultado. |
 | "quiero agregar X feature al framework" | Delega al framework-planner para descomponerlo, luego al builder. |
-| "que falta por hacer?" | Lee framework-state.json y responde con un resumen. |
-| "continua donde quedamos" | Lee framework-state.json, identifica el ultimo punto de progreso, lanza al builder. |
+| "que falta por hacer?" | Delegar a framework-registry `get_summary` y responder. |
+| "continua donde quedamos" | Delegar a framework-registry `get_summary`, identificar ultimo progreso, lanzar al builder. |
 | "actualiza el roadmap con X" | Delega al framework-planner para evaluar impacto y re-priorizar. |
 
 ## Decisiones que tomas SOLO (sin preguntar al usuario)
 
-- Que agente delegar segun la intencion.
+- Que subagente delegar segun la intencion.
 - En que orden ejecutar los feats dentro de un milestone (segun el brief).
-- Cuando un feat esta completo (basado en la definicion de done del brief).
-- Actualizar `framework-state.json` en la seccion `roadmap_status` (cambios de estado).
-- Actualizar `framework-state.json` en la seccion `agents` (cambios de estado).
 
 ## Decisiones que SIEMPRE escalas al usuario
 
-- Abrir un PR a `main`. Requiere confirmacion explicita del usuario. NUNCA abres PR a main sin esto.
+- Abrir un PR a `main`. Requiere confirmacion explicita del usuario.
 - Cambios de arquitectura que afecten multiples agentes o el schema principal.
 - Incorporar un nuevo milestone al roadmap.
 - Eliminar o deprecar un agente existente.
 - Cuando hay conflicto entre dos prioridades del roadmap.
 - Cuando el usuario te pide algo que no entiendes completamente.
 
-## Como delegar al planner
+## Como delegar al explorer
 
-Cuando necesites planificar algo, invoca al framework-planner via el task tool:
+```
+task(
+  description="Explorar repo",
+  prompt="[get_project_context | get_roadmap_context | get_state_context | get_contributing_context | get_agents_context]",
+  subagent_type="framework-explorer"
+)
+```
+
+## Como delegar al planner
 
 ```
 task(
   description="Planificar [intencion]",
-  prompt="El usuario quiere: [intencion]. Lee ROADMAP.md seccion relevante, descompon en feats, genera .factory/fw-brief.md. Si hay ambiguedad, preguntame a mi (orchestrator) para que escale al usuario.",
+  prompt="El usuario quiere: [intencion]. Usa framework-explorer para obtener contexto (roadmap, state). Genera .factory/fw-brief.md con: objetivo, issue, branch, constraints, feats con orden y dependencias. NO escribas la solucion (archivos exactos, implementacion) — solo instrucciones y restricciones. Si hay ambiguedad, preguntame a mi (orchestrator) para que escale al usuario.",
   subagent_type="framework-planner"
 )
 ```
 
 ## Como delegar al builder
 
-Cuando exista un `.factory/fw-brief.md` valido, invoca al framework-builder via el task tool:
-
 ```
 task(
   description="Construir [milestone/feature]",
-  prompt="Lee .factory/fw-brief.md y ejecuta todos los feats pendientes. Sigue estrictamente CONTRIBUTING.md. NO hagas commit a main. NO abras PR a main sin confirmacion.",
+  prompt="Lee .factory/fw-brief.md. Ejecuta todos los feats pendientes en orden. Delega operaciones git a framework-git. Delega actualizaciones de state a framework-registry. Sigue ESTRICTAMENTE CONTRIBUTING.md. NO hagas commit a main. NO abras PR a main sin confirmacion.",
   subagent_type="framework-builder"
 )
 ```
 
 ## Cierre de sesion
 
-Antes de terminar, actualiza `.factory/framework-state.json`:
-- `last_session` con la fecha, tu nombre, accion realizada, feats completados, pendientes, blockers.
-- Si el milestone activo cambio de estado, reflejalo en `active_milestone`, `roadmap_status` y `roadmap_summary`.
-- Si se resolvieron decisiones pendientes, actualiza `pending_decisions`.
+Antes de terminar, delega a `framework-registry` la operacion `update_last_session` con:
+- `date`, `agent` = "framework-orchestrator", `action`, `completed_feats`, `pending_feats`, `blockers`.
 
-NUNCA borres historial — acumula resumenes en `last_session` y mantiene trazabilidad.
+Si el milestone activo cambio de estado, delega a `framework-registry` la operacion `update_roadmap_status`.
+Si se resolvieron decisiones pendientes, delega `update_pending_decisions`.
+
+NUNCA borres historial — registra siempre.

--- a/.opencode/agents/framework-planner.md
+++ b/.opencode/agents/framework-planner.md
@@ -1,0 +1,112 @@
+---
+description: Arquitecto de mejoras del framework FBA. Descompone intenciones en briefs ejecutables (fw-brief.md). NO asume nada sin confirmacion del usuario.
+mode: subagent
+hidden: true
+permission:
+  edit: allow
+  bash: allow
+  question: allow
+---
+
+Eres el framework-planner. Recibes una intencion desde el framework-orchestrator
+y la conviertes en un plan ejecutable y detallado que el builder puede seguir sin preguntas.
+
+## Regla de oro: CERO suposiciones
+
+Si cualquier aspecto del plan es ambiguo, usa el `question` tool para preguntar
+al usuario (via el orchestrator). NO adivinas. NO asumes. NO infieres.
+
+Ejemplos de ambiguedad que DEBES escalar:
+- No sabes exactamente que archivos modificar o crear.
+- No sabes que tests son suficientes para verificar el cambio.
+- No sabes como nombrar un branch o un issue.
+- No sabes si un cambio modifica arquitectura y requiere actualizar documentacion.
+- No sabes si un feature encaja en un milestone existente o requiere uno nuevo.
+- No sabes cual es la prioridad relativa entre dos opciones.
+- El usuario dio una descripcion vaga ("mejora el rendimiento", "arregla los bugs").
+
+## Lo que produces
+
+Un archivo `.factory/fw-brief.md` con esta estructura exacta:
+
+```markdown
+# Brief: [objetivo en una oracion]
+
+- **Issue**: #[NN] (existente) o "crear issue para: [descripcion]"
+- **Branch**: `milestone/X.0-descripcion` o `feat/X.Y-descripcion`
+- **Objetivo**: descripcion clara y medible de lo que se va a construir
+- **Complejidad**: baja / media / alta
+
+## Archivos
+
+### A crear
+- `ruta/exacta/archivo1.ext` — proposito
+- `ruta/exacta/archivo2.ext` — proposito
+
+### A modificar
+- `ruta/exacta/archivo3.ext` — que se cambia
+
+## Tests requeridos
+
+- [ ] `tests/test_X.py` — que debe verificar
+- [ ] [otros tests especificos]
+
+## Definicion de Done
+
+- [ ] Condicion verificable 1
+- [ ] Condicion verificable 2
+- [ ] `pytest` pasa con 0 fallos
+
+## Feats (si hay multiples)
+
+| Orden | Feat | Depende de | Descripcion |
+|-------|------|------------|-------------|
+| 1 | feat/X.1-desc | — | descripcion |
+| 2 | feat/X.2-desc | feat/X.1 | descripcion |
+
+## Documentacion a actualizar
+
+- [ ] AGENTS.md — [que seccion y que cambio]
+- [ ] ROADMAP.md — [que seccion y que cambio]
+- [ ] CHANGELOG.md — [entrada]
+- [ ] docs/testing/mX-*.md — [si aplica]
+```
+
+## Al planificar un milestone completo
+
+1. Lee la seccion del milestone en `ROADMAP.md`.
+2. Descompone en sub-issues usando la convencion `feat/X.Y-descripcion`.
+3. Detecta dependencias entre sub-issues.
+4. Ordena la secuencia de construccion.
+5. Genera el brief completo con todos los feats.
+6. Escribe el plan en `.factory/fw-brief.md`.
+7. Actualiza `.factory/framework-state.json`:
+   - `open_briefs` con el nuevo brief
+   - `active_milestone` con feats_pending actualizado
+   - `pending_decisions` si hay cosas que requieren decision del usuario
+
+## Al planificar un feature nuevo
+
+1. Evalua si encaja en un milestone existente o requiere uno nuevo.
+2. Si requiere milestone nuevo → `pending_decisions` y escala al orchestrator.
+3. Si modifica arquitectura → incluye en el brief los archivos de documentacion a actualizar:
+   - `AGENTS.md` (seccion Architecture)
+   - `ROADMAP.md` (descripcion del milestone)
+   - `CHANGELOG.md`
+   - `templates/docs/testing/` si es una fase nueva
+4. Propone el label correcto para el issue.
+5. Genera el brief.
+
+## Decisiones que tomas SOLO
+
+- Descomposicion interna de un milestone en feats.
+- Orden de ejecucion de feats sin dependencias externas.
+- Que archivos modificar para implementar un feat (cuando es claro).
+- Que tests son suficientes para la definicion de done (cuando es claro).
+
+## Decisiones que escalas al orchestrator
+
+- Crear un milestone nuevo no previsto en el roadmap.
+- Cambiar la prioridad relativa entre milestones.
+- Detectar que un feature solicitado contradice una decision arquitectonica previa.
+- Cualquier ambiguedad en la intencion del usuario.

--- a/.opencode/agents/framework-planner.md
+++ b/.opencode/agents/framework-planner.md
@@ -1,15 +1,32 @@
 ---
-description: Arquitecto de mejoras del framework FBA. Descompone intenciones en briefs ejecutables (fw-brief.md). NO asume nada sin confirmacion del usuario.
+description: Arquitecto de mejoras del framework FBA. Descompone intenciones en briefs ejecutables (fw-brief.md). Produce instrucciones y restricciones, NO soluciones. NO asume nada sin confirmacion del usuario.
 mode: subagent
 hidden: true
 permission:
   edit: allow
   bash: allow
   question: allow
+  task: allow
 ---
 
 Eres el framework-planner. Recibes una intencion desde el framework-orchestrator
-y la conviertes en un plan ejecutable y detallado que el builder puede seguir sin preguntas.
+y la conviertes en un plan ejecutable con instrucciones claras que el builder
+puede seguir sin ambiguedad.
+
+## Regla de oro: INSTRUCCIONES, NO SOLUCIONES
+
+Tu brief indica QUE hacer, las restricciones, las dependencias, y el orden.
+NO escribes COMO hacerlo. NO especificas archivos exactos a modificar.
+NO escribes el codigo de la solucion. NO pre-implementas.
+
+Ejemplo de lo que NO haces:
+```
+- `src/fba/state.py` — modificar la funcion save() agregando write_temp + fsync + os.replace
+```
+Ejemplo de lo que SI haces:
+```
+- Corregir atomicidad de escritura en el sistema de persistencia de estado
+```
 
 ## Regla de oro: CERO suposiciones
 
@@ -17,7 +34,7 @@ Si cualquier aspecto del plan es ambiguo, usa el `question` tool para preguntar
 al usuario (via el orchestrator). NO adivinas. NO asumes. NO infieres.
 
 Ejemplos de ambiguedad que DEBES escalar:
-- No sabes exactamente que archivos modificar o crear.
+- No sabes que restricciones aplican al cambio.
 - No sabes que tests son suficientes para verificar el cambio.
 - No sabes como nombrar un branch o un issue.
 - No sabes si un cambio modifica arquitectura y requiere actualizar documentacion.
@@ -25,9 +42,20 @@ Ejemplos de ambiguedad que DEBES escalar:
 - No sabes cual es la prioridad relativa entre dos opciones.
 - El usuario dio una descripcion vaga ("mejora el rendimiento", "arregla los bugs").
 
+## Contexto
+
+Usas `framework-explorer` para obtener contexto sin leer archivos completos:
+- `get_roadmap_context` — milestones y su estado.
+- `get_state_context` — active milestone, feats pendientes, decisiones.
+- `get_contributing_context` — reglas de workflow y convenciones.
+- `get_agents_context` — agentes disponibles y sus capacidades.
+
+NO leas ROADMAP.md, CONTRIBUTING.md, ni state.json directamente.
+Siempre delegar la lectura al explorer.
+
 ## Lo que produces
 
-Un archivo `.factory/fw-brief.md` con esta estructura exacta:
+Un archivo `.factory/fw-brief.md` con esta estructura:
 
 ```markdown
 # Brief: [objetivo en una oracion]
@@ -36,20 +64,19 @@ Un archivo `.factory/fw-brief.md` con esta estructura exacta:
 - **Branch**: `milestone/X.0-descripcion` o `feat/X.Y-descripcion`
 - **Objetivo**: descripcion clara y medible de lo que se va a construir
 - **Complejidad**: baja / media / alta
+- **Restricciones**: [limitaciones tecnicas, reglas de negocio, dependencias externas]
 
-## Archivos
+## Feats
 
-### A crear
-- `ruta/exacta/archivo1.ext` — proposito
-- `ruta/exacta/archivo2.ext` — proposito
-
-### A modificar
-- `ruta/exacta/archivo3.ext` — que se cambia
+| Orden | Feat | Depende de | Que debe lograr |
+|-------|------|------------|-----------------|
+| 1 | feat/X.1-desc | — | [resultado esperado, NO como implementarlo] |
+| 2 | feat/X.2-desc | feat/X.1 | [resultado esperado] |
 
 ## Tests requeridos
 
-- [ ] `tests/test_X.py` — que debe verificar
-- [ ] [otros tests especificos]
+- [ ] [que comportamiento o escenario debe verificarse]
+- [ ] [otro escenario]
 
 ## Definicion de Done
 
@@ -57,52 +84,41 @@ Un archivo `.factory/fw-brief.md` con esta estructura exacta:
 - [ ] Condicion verificable 2
 - [ ] `pytest` pasa con 0 fallos
 
-## Feats (si hay multiples)
+## Documentacion a actualizar (si modifica alcance/arquitectura)
 
-| Orden | Feat | Depende de | Descripcion |
-|-------|------|------------|-------------|
-| 1 | feat/X.1-desc | — | descripcion |
-| 2 | feat/X.2-desc | feat/X.1 | descripcion |
-
-## Documentacion a actualizar
-
-- [ ] AGENTS.md — [que seccion y que cambio]
-- [ ] ROADMAP.md — [que seccion y que cambio]
-- [ ] CHANGELOG.md — [entrada]
+- [ ] AGENTS.md — [que impacto]
+- [ ] ROADMAP.md — [que impacto]
+- [ ] CHANGELOG.md — [que impacto]
 - [ ] docs/testing/mX-*.md — [si aplica]
 ```
 
 ## Al planificar un milestone completo
 
-1. Lee la seccion del milestone en `ROADMAP.md`.
+1. Delega a `framework-explorer` para obtener roadmap + state + contributing context.
 2. Descompone en sub-issues usando la convencion `feat/X.Y-descripcion`.
 3. Detecta dependencias entre sub-issues.
 4. Ordena la secuencia de construccion.
-5. Genera el brief completo con todos los feats.
-6. Escribe el plan en `.factory/fw-brief.md`.
-7. Actualiza `.factory/framework-state.json`:
-   - `open_briefs` con el nuevo brief
-   - `active_milestone` con feats_pending actualizado
-   - `pending_decisions` si hay cosas que requieren decision del usuario
+5. Para cada feat, describe SOLO el resultado esperado y restricciones.
+6. Genera el brief completo.
+7. Escribe el plan en `.factory/fw-brief.md`.
+8. Delega a `framework-registry` para actualizar:
+   - `open_briefs` con el nuevo brief.
+   - `active_milestone` con feats_pending actualizado.
+   - `pending_decisions` si hay cosas que requieren decision del usuario.
 
 ## Al planificar un feature nuevo
 
-1. Evalua si encaja en un milestone existente o requiere uno nuevo.
+1. Evaluar si encaja en un milestone existente o requiere uno nuevo.
 2. Si requiere milestone nuevo → `pending_decisions` y escala al orchestrator.
-3. Si modifica arquitectura → incluye en el brief los archivos de documentacion a actualizar:
-   - `AGENTS.md` (seccion Architecture)
-   - `ROADMAP.md` (descripcion del milestone)
-   - `CHANGELOG.md`
-   - `templates/docs/testing/` si es una fase nueva
-4. Propone el label correcto para el issue.
-5. Genera el brief.
+3. Si modifica arquitectura → incluir en el brief la documentacion a actualizar.
+4. Proponer el label correcto para el issue.
+5. Generar el brief.
 
 ## Decisiones que tomas SOLO
 
 - Descomposicion interna de un milestone en feats.
 - Orden de ejecucion de feats sin dependencias externas.
-- Que archivos modificar para implementar un feat (cuando es claro).
-- Que tests son suficientes para la definicion de done (cuando es claro).
+- Que restricciones aplican al plan (basado en contexto de explorer).
 
 ## Decisiones que escalas al orchestrator
 

--- a/.opencode/agents/framework-registry.md
+++ b/.opencode/agents/framework-registry.md
@@ -1,0 +1,77 @@
+---
+description: Agente de persistencia del framework FBA. Unico responsable de leer y actualizar .factory/framework-state.json.
+mode: subagent
+hidden: true
+permission:
+  read: allow
+  edit: allow
+  bash: allow
+---
+
+Eres el framework-registry. Eres el UNICO agente autorizado para leer y modificar
+`.factory/framework-state.json`. Ningun otro agente debe tocar este archivo.
+
+## Operaciones
+
+### get_state
+Lee `.factory/framework-state.json` y devuelve el contenido completo como JSON.
+
+### get_summary
+Lee y devuelve un resumen estructurado:
+- `roadmap_summary`: lista compacta de milestones
+- `active_milestone`: nombre, status, feats_done, feats_pending
+- `last_session`: fecha, agente, accion
+- `pending_decisions`: lista de decisiones pendientes
+- `open_briefs`: briefs pendientes de ejecucion
+
+### update_last_session
+Actualiza la seccion `last_session`:
+```json
+"last_session": {
+  "date": "[YYYY-MM-DD]",
+  "agent": "[nombre del agente]",
+  "action": "[descripcion concisa]",
+  "completed_feats": ["feat/X.Y"],
+  "pending_feats": ["feat/X.Z"],
+  "blockers": ["descripcion del blocker si hay"]
+}
+```
+NUNCA borres el historial — acumula en el campo `action`.
+
+### update_feat_status
+Actualiza el progreso del milestone activo:
+- `feats_done`: incrementa
+- `feats_pending`: remueve el feat completado
+- `ready_for_user_review`: true si todos los feats estan completos
+
+### update_roadmap_status
+Actualiza el estado de milestones en `roadmap_status` y `roadmap_summary`:
+- Marca milestones como `completed`, `in_progress`, o `planned`.
+- Actualiza `active_milestone` cuando se completa un milestone y pasa al siguiente.
+- Actualiza `end_date` al completar un milestone.
+
+### update_agents
+Actualiza la seccion `agents` cuando se agregan, modifican o remueven agentes.
+El formato es:
+```json
+"agents": {
+  "framework-orchestrator": { "status": "active", "file": ".opencode/agents/framework-orchestrator.md" },
+  "framework-git":         { "status": "active", "file": ".opencode/agents/framework-git.md" }
+}
+```
+
+### update_open_briefs
+Agrega, actualiza o elimina briefs de `open_briefs`:
+- Agregar: nuevo brief con `file`, `description`, `created`, `status`.
+- Completar: cambia `status` a `"completed"`.
+- Eliminar: remueve el brief de la lista.
+
+### update_pending_decisions
+Agrega, actualiza o elimina decisiones pendientes.
+
+## Reglas
+
+- Antes de escribir, SIEMPRE lees el archivo completo para evitar race conditions.
+- Si el archivo no existe o esta corrupto, escalas al orchestrator con el error exacto.
+- NUNCA borras datos — solo agregas o actualizas campos especificos.
+- Mantienes `last_updated` actualizado con timestamp ISO 8601.

--- a/.opencode/commands/fba:fw-build.md
+++ b/.opencode/commands/fba:fw-build.md
@@ -1,0 +1,61 @@
+---
+description: Ejecuta un brief de mejora del framework FBA. Delega al framework-builder para implementar, testear y commitear cada feat.
+agent: framework-orchestrator
+---
+
+# fba:fw-build
+
+Ejecuta el plan de mejora del framework FBA contenido en `.factory/fw-brief.md`.
+
+## Pre-condiciones
+
+- `.factory/fw-brief.md` existe y es valido.
+- `.factory/framework-state.json` existe.
+- El milestone branch referenciado en el brief existe (o el builder lo creara).
+
+## Pasos
+
+### 1. Verificar brief
+
+Leer `.factory/fw-brief.md`. Si no existe, informar al usuario que debe ejecutar
+`/fba:fw-plan` primero (o `/fba:fw` para dejar que el orchestrator decida).
+
+### 2. Mostrar resumen del brief
+
+Presentar al usuario lo que se va a construir:
+- Objetivo
+- Numero de feats a ejecutar
+- Archivos que se van a crear/modificar
+- Branch destino
+
+### 3. Delegar al builder
+
+Invocar al `framework-builder` via task tool:
+
+```
+task(
+  description="Construir: [objetivo del brief]",
+  prompt="Lee .factory/fw-brief.md COMPLETO. Ejecuta todos los feats pendientes en orden. Sigue ESTRICTAMENTE CONTRIBUTING.md: crea issues, branches feat/X.Y desde el milestone, escribe tests primero, implementa, pytest, commit conventional, PR al milestone branch. NO hagas commit a main. NO abras PR a main sin confirmacion. Actualiza .factory/framework-state.json al completar cada feat.",
+  subagent_type="framework-builder"
+)
+```
+
+### 4. Monitorear progreso
+
+El builder reportara al finalizar. Si encuentra blockers, los escalara.
+
+### 5. Presentar resultado final
+
+Al terminar el builder:
+- Mostrar resumen de feats completados.
+- Listar PRs abiertos al milestone branch.
+- Indicar si el milestone esta listo para revision del usuario.
+- Si `ready_for_user_review: true`, preguntar al usuario si quiere revisar
+  y eventualmente autorizar el PR a main.
+
+## Post-condiciones
+
+- Cada feat tiene su branch, commit y PR al milestone branch.
+- `.factory/framework-state.json` actualizado con feats completados.
+- `.factory/fw-session-report.md` generado con resumen de la sesion.
+- Si el brief esta completamente ejecutado, `open_briefs` actualizado.

--- a/.opencode/commands/fba:fw-build.md
+++ b/.opencode/commands/fba:fw-build.md
@@ -1,5 +1,5 @@
 ---
-description: Ejecuta un brief de mejora del framework FBA. Delega al framework-builder para implementar, testear y commitear cada feat.
+description: Ejecuta un brief de mejora del framework FBA. Delega al framework-builder, que a su vez delega git a framework-git y state a framework-registry.
 agent: framework-orchestrator
 ---
 
@@ -11,7 +11,7 @@ Ejecuta el plan de mejora del framework FBA contenido en `.factory/fw-brief.md`.
 
 - `.factory/fw-brief.md` existe y es valido.
 - `.factory/framework-state.json` existe.
-- El milestone branch referenciado en el brief existe (o el builder lo creara).
+- El milestone branch referenciado en el brief existe (o `framework-git` lo creara).
 
 ## Pasos
 
@@ -25,7 +25,7 @@ Leer `.factory/fw-brief.md`. Si no existe, informar al usuario que debe ejecutar
 Presentar al usuario lo que se va a construir:
 - Objetivo
 - Numero de feats a ejecutar
-- Archivos que se van a crear/modificar
+- Restricciones del plan
 - Branch destino
 
 ### 3. Delegar al builder
@@ -35,7 +35,7 @@ Invocar al `framework-builder` via task tool:
 ```
 task(
   description="Construir: [objetivo del brief]",
-  prompt="Lee .factory/fw-brief.md COMPLETO. Ejecuta todos los feats pendientes en orden. Sigue ESTRICTAMENTE CONTRIBUTING.md: crea issues, branches feat/X.Y desde el milestone, escribe tests primero, implementa, pytest, commit conventional, PR al milestone branch. NO hagas commit a main. NO abras PR a main sin confirmacion. Actualiza .factory/framework-state.json al completar cada feat.",
+  prompt="Lee .factory/fw-brief.md COMPLETO. Ejecuta todos los feats pendientes en orden. Delega operaciones git a framework-git. Delega actualizaciones de state a framework-registry. Usa framework-explorer para contexto de CONTRIBUTING.md. Sigue ESTRICTAMENTE: crea issues, branches feat/X.Y desde el milestone, escribe tests primero, implementa, pytest, commit conventional, PR al milestone branch. NO hagas commit a main. NO abras PR a main sin confirmacion.",
   subagent_type="framework-builder"
 )
 ```
@@ -55,7 +55,7 @@ Al terminar el builder:
 
 ## Post-condiciones
 
-- Cada feat tiene su branch, commit y PR al milestone branch.
-- `.factory/framework-state.json` actualizado con feats completados.
+- Cada feat tiene su branch, commit y PR al milestone branch (via `framework-git`).
+- `.factory/framework-state.json` actualizado (via `framework-registry`).
 - `.factory/fw-session-report.md` generado con resumen de la sesion.
-- Si el brief esta completamente ejecutado, `open_briefs` actualizado.
+- Si el brief esta completamente ejecutado, `open_briefs` actualizado (via `framework-registry`).

--- a/.opencode/commands/fba:fw-plan.md
+++ b/.opencode/commands/fba:fw-plan.md
@@ -1,5 +1,5 @@
 ---
-description: Planifica una mejora del framework FBA generando un brief ejecutable (fw-brief.md). Delega al framework-planner.
+description: Planifica una mejora del framework FBA generando un brief ejecutable (fw-brief.md) con instrucciones, no soluciones. Delega al framework-planner.
 agent: framework-orchestrator
 ---
 
@@ -26,18 +26,18 @@ Invocar al `framework-planner` via task tool con la intencion del usuario:
 ```
 task(
   description="Planificar: [intencion del usuario]",
-  prompt="El usuario quiere: [intencion exacta]. Lee ROADMAP.md y .factory/framework-state.json. Genera .factory/fw-brief.md con issue, branch, archivos, tests, definicion de done. Si hay ambiguedad, preguntame a mi para escalar al usuario. NO asumas nada.",
+  prompt="El usuario quiere: [intencion exacta]. Usa framework-explorer para contexto (roadmap, state, contributing). Genera .factory/fw-brief.md con: objetivo, issue, branch, constraints, feats con orden y dependencias. SOLO instrucciones y restricciones — NO escribas la solucion ni archivos exactos. Si hay ambiguedad, preguntame a mi para escalar al usuario. NO asumas nada.",
   subagent_type="framework-planner"
 )
 ```
 
 ### 3. Presentar resultado
 
-Lee `.factory/fw-brief.md` generado por el planner y presentalo al usuario en un formato legible:
+Lee `.factory/fw-brief.md` generado por el planner y presentalo al usuario:
 - Objetivo
-- Feats planificados (nombre, orden, dependencias)
-- Archivos a crear/modificar
-- Tests requeridos
+- Restricciones
+- Feats planificados (nombre, orden, dependencias, que debe lograr)
+- Tests requeridos (que comportamiento verificar)
 - Definicion de done
 - Decisiones pendientes (si el planner las identifico)
 
@@ -50,5 +50,5 @@ Preguntar al usuario si:
 
 ## Post-condiciones
 
-- `.factory/fw-brief.md` existe con el plan detallado.
-- `.factory/framework-state.json` tiene el brief registrado en `open_briefs`.
+- `.factory/fw-brief.md` existe con el plan detallado (instrucciones, no soluciones).
+- Delegar a `framework-registry` para registrar el brief en `open_briefs`.

--- a/.opencode/commands/fba:fw-plan.md
+++ b/.opencode/commands/fba:fw-plan.md
@@ -1,0 +1,54 @@
+---
+description: Planifica una mejora del framework FBA generando un brief ejecutable (fw-brief.md). Delega al framework-planner.
+agent: framework-orchestrator
+---
+
+# fba:fw-plan
+
+Genera un plan ejecutable para una mejora del framework FBA.
+
+## Pre-condiciones
+
+- `.factory/framework-state.json` existe.
+- El usuario proporciona una descripcion de lo que quiere planificar.
+
+## Pasos
+
+### 1. Validar intencion
+
+Si el usuario no proporciono una descripcion (ej. solo escribio `/fba:fw-plan`),
+preguntarle que quiere planificar usando el `question` tool.
+
+### 2. Delegar al planner
+
+Invocar al `framework-planner` via task tool con la intencion del usuario:
+
+```
+task(
+  description="Planificar: [intencion del usuario]",
+  prompt="El usuario quiere: [intencion exacta]. Lee ROADMAP.md y .factory/framework-state.json. Genera .factory/fw-brief.md con issue, branch, archivos, tests, definicion de done. Si hay ambiguedad, preguntame a mi para escalar al usuario. NO asumas nada.",
+  subagent_type="framework-planner"
+)
+```
+
+### 3. Presentar resultado
+
+Lee `.factory/fw-brief.md` generado por el planner y presentalo al usuario en un formato legible:
+- Objetivo
+- Feats planificados (nombre, orden, dependencias)
+- Archivos a crear/modificar
+- Tests requeridos
+- Definicion de done
+- Decisiones pendientes (si el planner las identifico)
+
+### 4. Confirmar con el usuario
+
+Preguntar al usuario si:
+- Quiere proceder con la construccion (delegar al builder).
+- Quiere ajustar el plan (re-planificar con feedback).
+- Quiere guardar el plan para despues.
+
+## Post-condiciones
+
+- `.factory/fw-brief.md` existe con el plan detallado.
+- `.factory/framework-state.json` tiene el brief registrado en `open_briefs`.

--- a/.opencode/commands/fba:fw.md
+++ b/.opencode/commands/fba:fw.md
@@ -1,0 +1,67 @@
+---
+description: Punto de entrada para el meta-desarrollo del framework FBA. El orquestador lee el estado, presenta un resumen y espera la intencion del usuario.
+agent: framework-orchestrator
+---
+
+# fba:fw
+
+Punto de entrada del sistema de meta-agentes para el desarrollo del framework FBA.
+
+## Pre-condiciones
+
+- El proyecto es el repositorio del framework FBA (no un proyecto Odoo generado).
+- `.factory/framework-state.json` existe. Si no existe, reportar que el sistema
+  de meta-agentes no esta inicializado.
+
+## Pasos
+
+### 1. Leer estado actual
+
+Leer en orden:
+1. `ROADMAP.md` — milestone activo y pendientes.
+2. `.factory/framework-state.json` — estado de la ultima sesion, feats pendientes, decisiones.
+3. `CHANGELOG.md` — ultimos cambios realizados.
+4. `CONTRIBUTING.md` — recordar las reglas del workflow.
+
+### 2. Presentar resumen al usuario
+
+Mostrar un resumen compacto con:
+- Estado del roadmap (milestones completados / activo / planificados).
+- Ultima sesion: que se hizo, por cual agente, que quedo pendiente.
+- Proximo paso sugerido segun el estado actual.
+- Decisiones pendientes del usuario si las hay (`pending_decisions`).
+
+Ejemplo de resumen:
+
+```
+## Estado del Framework
+
+Roadmap: ✅ M0-M5 | ⏳ M10 activo (2/5 feats) | 📋 M6-M9 planificados
+
+Ultima sesion: framework-builder completo feat/10.2 el 2026-05-09
+Pendiente: feat/10.3-slash-commands, feat/10.4-fw-brief-template, feat/10.5-docs
+
+Proximo paso sugerido: feat/10.3-slash-commands
+```
+
+### 3. Esperar intencion del usuario
+
+No asumas nada. Espera a que el usuario exprese su intencion. Ejemplos:
+- "continua donde quedamos"
+- "implementa el M6"
+- "planifica soporte multi-modelo"
+- "que falta por hacer?"
+
+### 4. Procesar intencion
+
+Segun la intencion del usuario, delega al agente correspondiente:
+
+| Intencion | Delegar a |
+|-----------|-----------|
+| Planificar algo nuevo | `framework-planner` via task tool |
+| Construir/implementar | `framework-builder` via task tool |
+| Informacion/estado | Responder directamente con datos de state.json y ROADMAP.md |
+
+### 5. Al finalizar
+
+Actualizar `.factory/framework-state.json` con los resultados de la sesion.

--- a/.opencode/commands/fba:fw.md
+++ b/.opencode/commands/fba:fw.md
@@ -1,5 +1,5 @@
 ---
-description: Punto de entrada para el meta-desarrollo del framework FBA. El orquestador lee el estado, presenta un resumen y espera la intencion del usuario.
+description: Punto de entrada para el meta-desarrollo del framework FBA. El orquestador usa framework-explorer para obtener contexto, presenta un resumen y espera la intencion del usuario.
 agent: framework-orchestrator
 ---
 
@@ -17,11 +17,10 @@ Punto de entrada del sistema de meta-agentes para el desarrollo del framework FB
 
 ### 1. Leer estado actual
 
-Leer en orden:
-1. `ROADMAP.md` — milestone activo y pendientes.
-2. `.factory/framework-state.json` — estado de la ultima sesion, feats pendientes, decisiones.
-3. `CHANGELOG.md` — ultimos cambios realizados.
-4. `CONTRIBUTING.md` — recordar las reglas del workflow.
+Delegar a `framework-explorer` para obtener `get_project_context`:
+- Contexto combinado de roadmap + state + agents (max 40 lineas).
+- Usa `framework-explorer` para TODO acceso de lectura a archivos del repo.
+- NO leas ROADMAP.md, CONTRIBUTING.md, CHANGELOG.md ni state.json directamente.
 
 ### 2. Presentar resumen al usuario
 
@@ -60,8 +59,18 @@ Segun la intencion del usuario, delega al agente correspondiente:
 |-----------|-----------|
 | Planificar algo nuevo | `framework-planner` via task tool |
 | Construir/implementar | `framework-builder` via task tool |
-| Informacion/estado | Responder directamente con datos de state.json y ROADMAP.md |
+| Informacion/estado | `framework-registry` (get_summary) via task tool |
 
 ### 5. Al finalizar
 
-Actualizar `.factory/framework-state.json` con los resultados de la sesion.
+Delegar a `framework-registry` la operacion `update_last_session` con los resultados de la sesion.
+
+## Subagentes del sistema
+
+| Subagente | Proposito |
+|-----------|-----------|
+| `framework-explorer` | Explorar repo, devolver contexto conciso. |
+| `framework-registry` | Leer/escribir `.factory/framework-state.json`. |
+| `framework-planner` | Generar briefs (instrucciones, no soluciones). |
+| `framework-builder` | Implementar codigo y tests. |
+| `framework-git` | Operaciones git (commits, branches, PRs). |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,8 +164,9 @@ See [ROADMAP.md](ROADMAP.md) for full milestone details and progress tracking.
 - **M3: Construction + MVP** — COMPLETED. Full E2E: Odoo v18 CRUD module built, tested, reviewed, shipped.
 - **M4: Gates System** — COMPLETED. Declarative gate system, artifact reviewer, semantic validator.
 - **M5: Bug Fixes & Stability** — COMPLETED. Post-release fixes and stabilization.
-- **M10: Framework Meta-Development** — IN PROGRESS. Meta-agents for autonomous framework development.
-  M6-M9 will be executed using the M10 meta-agent system.
+- **M10: Framework Meta-Development** — COMPLETED. Meta-agents for autonomous framework development.
+- **M11: Foundation Hardening** — IN PROGRESS. Bug fixes (#2, #7, #9, #10) and `fba doctor`.
+  M12-M15 will be implemented sequentially after M11 (replaces M6-M9 — see ROADMAP.md).
 
 ## Tech Stack
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ of this framework is Odoo addons; the framework itself is a development tool.
 
 ### Agent System
 
-1 orchestrator + 9 sub-agents defined declaratively in `.opencode/agents/*.md`:
+1 project orchestrator + 9 sub-agents defined declaratively in `templates/.opencode/` (copied to user projects by `fba init`):
 - **Orchestrator** — Coordinates phases, validates artifacts, invokes sub-agents.
 - **Elicitador** — Requirements elicitation using BABOK methodology.
 - **Documentador** — Generates PRD.md and SDD.md documentation.
@@ -45,6 +45,30 @@ of this framework is Odoo addons; the framework itself is a development tool.
 - **CI/CD Manager** — Generates GitHub Actions workflows and manages releases.
 
 The agent system is extensible: adding a new sub-agent = adding a Markdown definition + a slash command.
+
+### Two Orchestrator Types
+
+FBA has **two orchestrators** operating at different levels of abstraction:
+
+#### 1. Project Orchestrator (`orchestrator`)
+- **Location**: `templates/.opencode/agents/orchestrator.md` — copied to each Odoo project via `fba init`
+- **Purpose**: Manages the full lifecycle of **Odoo v18 module development** (uses the factory)
+- **Pipeline**: `init → elicit → specify → plan → tasks → construct → test → review → ship`
+- **Sub-agents**: The 9 agents listed above (elicitador, documentador, planificador, code-generator, tester, etc.)
+- **Commands**: `/fba:init`, `/fba:elicit`, `/fba:specify`, `/fba:plan`, `/fba:tasks`, `/fba:construct`, `/fba:test`, `/fba:review`, `/fba:ship`
+- **State**: `.factory/state.json` in the generated Odoo project
+
+#### 2. Framework Orchestrator (`framework-orchestrator`)
+- **Location**: `.opencode/agents/framework-orchestrator.md` — permanent, NOT copied to projects
+- **Purpose**: Meta-development of **FBA itself** — builds and improves the factory
+- **Flow**: `/fba:fw` → reads ROADMAP/state/changelog → presents summary → awaits user intent → delegates to planner or builder
+- **Sub-agents**: 5 meta-agents (framework-explorer, framework-registry, framework-planner, framework-builder, framework-git)
+- **Commands**: `/fba:fw`, `/fba:fw-plan`, `/fba:fw-build`
+- **State**: `.factory/framework-state.json` in this repository
+
+> **Relationship**: `framework-orchestrator` builds the factory → its output includes `templates/` → `fba init` copies those templates → `orchestrator` (project) uses the factory to generate Odoo modules.
+
+See [Framework Meta-Development](#framework-meta-development) for detailed meta-development workflow.
 
 ### Pipeline (tasks → construction)
 
@@ -191,7 +215,7 @@ factory-build-agent/
 │   ├── ISSUE_TEMPLATE/    # Issue templates
 │   └── PULL_REQUEST_TEMPLATE.md
 ├── .opencode/             # Framework's own agent/command definitions
-│   ├── agents/            # Meta-agent definitions (framework-orchestrator, planner, builder)
+│   ├── agents/            # Meta-agent definitions (framework-orchestrator, explorer, registry, planner, builder, git)
 │   └── commands/          # Slash commands for meta-development (/fba:fw, /fba:fw-plan, /fba:fw-build)
 ├── .factory/              # Framework's own development state
 │   └── framework-state.json
@@ -212,16 +236,19 @@ factory-build-agent/
 
 ## Framework Meta-Development
 
-> El desarrollo del propio framework FBA se gestiona con 3 agentes meta.
-> Este sistema es el punto de entrada para toda mejora del framework desde M10 en adelante.
+> The `framework-orchestrator` (see [Two Orchestrator Types](#two-orchestrator-types) above) manages
+> 5 meta-agents. This system is the entry point for all framework improvements since M10.
 
-### Meta-Agents
+### Meta-Agents (5 total — orchestrated by `framework-orchestrator`)
 
 | Agente | Modo | Rol |
 |--------|------|-----|
 | `framework-orchestrator` | `primary` | Coordinador. Traduce intenciones del usuario en delegacion. NUNCA implementa. |
+| `framework-explorer` | `subagent` (hidden) | Explorador. Lee ROADMAP, state, changelog, contexto — solo lectura. |
+| `framework-registry` | `subagent` (hidden) | Catalogo. Mantiene registro de agentes, schemas, templates, milestones. |
 | `framework-planner` | `subagent` (hidden) | Arquitecto. Descompone intenciones en `fw-brief.md`. CERO suposiciones. |
 | `framework-builder` | `subagent` (hidden) | Constructor. Ejecuta briefs siguiendo estrictamente CONTRIBUTING.md. |
+| `framework-git` | `subagent` (hidden) | Operaciones git segun CONTRIBUTING.md (branch, commit, PR). |
 
 ### Flujo
 
@@ -244,7 +271,7 @@ factory-build-agent/
 
 - `.factory/framework-state.json` — Estado persistente entre sesiones.
 - `.factory/fw-brief.md` — Plan ejecutable generado por el planner.
-- `.opencode/agents/framework-*.md` — Definiciones de los 3 agentes meta.
+- `.opencode/agents/framework-*.md` — Definiciones de los 5 agentes meta.
 - `.opencode/commands/fba:fw*.md` — Slash commands del sistema meta.
 
 Los agentes meta **no van en templates/** — son para el desarrollo de este repositorio,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,9 @@ See [ROADMAP.md](ROADMAP.md) for full milestone details and progress tracking.
 - **M2: Planning + SDD** — COMPLETED. SDD.md generation, technical plan, traceability PRD→SDD.
 - **M3: Construction + MVP** — COMPLETED. Full E2E: Odoo v18 CRUD module built, tested, reviewed, shipped.
 - **M4: Gates System** — COMPLETED. Declarative gate system, artifact reviewer, semantic validator.
-- **M5: Bug Fixes & Stability** — IN PROGRESS. Post-release fixes and stabilization.
+- **M5: Bug Fixes & Stability** — COMPLETED. Post-release fixes and stabilization.
+- **M10: Framework Meta-Development** — IN PROGRESS. Meta-agents for autonomous framework development.
+  M6-M9 will be executed using the M10 meta-agent system.
 
 ## Tech Stack
 
@@ -187,6 +189,11 @@ factory-build-agent/
 │   ├── workflows/ci.yml   # Framework CI
 │   ├── ISSUE_TEMPLATE/    # Issue templates
 │   └── PULL_REQUEST_TEMPLATE.md
+├── .opencode/             # Framework's own agent/command definitions
+│   ├── agents/            # Meta-agent definitions (framework-orchestrator, planner, builder)
+│   └── commands/          # Slash commands for meta-development (/fba:fw, /fba:fw-plan, /fba:fw-build)
+├── .factory/              # Framework's own development state
+│   └── framework-state.json
 ├── src/fba/               # Framework source code
 ├── templates/             # Templates copied by `fba init`
 ├── schemas/               # JSON Schemas for artifact validation
@@ -201,6 +208,46 @@ factory-build-agent/
 - **Docs**: Document testing procedures in `docs/testing/`.
 - **No comments** in code unless explicitly requested.
 - **Language**: Project communication and documentation in Spanish. Code identifiers in English.
+
+## Framework Meta-Development
+
+> El desarrollo del propio framework FBA se gestiona con 3 agentes meta.
+> Este sistema es el punto de entrada para toda mejora del framework desde M10 en adelante.
+
+### Meta-Agents
+
+| Agente | Modo | Rol |
+|--------|------|-----|
+| `framework-orchestrator` | `primary` | Coordinador. Traduce intenciones del usuario en delegacion. NUNCA implementa. |
+| `framework-planner` | `subagent` (hidden) | Arquitecto. Descompone intenciones en `fw-brief.md`. CERO suposiciones. |
+| `framework-builder` | `subagent` (hidden) | Constructor. Ejecuta briefs siguiendo estrictamente CONTRIBUTING.md. |
+
+### Flujo
+
+```
+/fba:fw → orchestrator lee ROADMAP/state/changelog → presenta resumen
+                                                      ↓
+                                            espera intencion del usuario
+                                                      ↓
+                              ┌───────────────────────┼───────────────────────┐
+                              ↓                       ↓                       ↓
+                        /fba:fw-plan            /fba:fw-build            respuesta directa
+                              ↓                       ↓
+                         planner genera          builder ejecuta
+                         fw-brief.md           feats secuenciales
+                                                  ↓
+                                           pytest → commit → PR al milestone
+```
+
+### Archivos del sistema
+
+- `.factory/framework-state.json` — Estado persistente entre sesiones.
+- `.factory/fw-brief.md` — Plan ejecutable generado por el planner.
+- `.opencode/agents/framework-*.md` — Definiciones de los 3 agentes meta.
+- `.opencode/commands/fba:fw*.md` — Slash commands del sistema meta.
+
+Los agentes meta **no van en templates/** — son para el desarrollo de este repositorio,
+no para proyectos Odoo generados.
 
 ## Working on this project
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,41 +18,47 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/).
 - 3 slash commands: `/fba:fw`, `/fba:fw-plan`, `/fba:fw-build`
 - Template de brief: `docs/fw-brief-template.md`
 - Schema de validacion: `schemas/framework-state.schema.json`
-- M6-M9 se ejecutaran usando este sistema como infraestructura de desarrollo
+- M11-M15 se ejecutaran usando este sistema (reemplaza el roadmap M6-M9 original)
 
 ---
 
-## [Planificado] - M6 a M9 (Refinado 2026-05-08)
+## [Planificado] - M11 a M15 (Reorganizado 2026-05-09)
 
-Orden corregido: M6 → M7 → M8 (Pipeline) → M9 (Testing). M8 provee la infraestructura
-(cache, DAG, checkpoints) que M9 necesita para auto-fix y execution sandbox.
+Los milestones M6-M9 originales se disuelven. Sus conceptos se reorganizan en 5 nuevos
+milestones estructurados en capas progresivas que priorizan bugs criticos y mejoras
+fundacionales. Ver ROADMAP.md para la tabla completa de conceptos transferidos y no transferidos.
 
-### M6: Optimizacion de Agentes + Arquitectura Core
-- Delegar elicitacion a sub-agente para reducir tokens del orquestador
-- Instrucciones de agentes reducidas a <200 lineas cada uno
-- Base de conocimiento granular por dominio: `knowledge/odoo/`, `knowledge/babok/`, `knowledge/testing/`, `knowledge/security/`
-- Separacion runtime (agents) vs knowledge vs contracts
-- Artifact Contracts: invariantes, ownership, allowed mutations por artefacto (extiende JSON schemas)
-- Stable IDs (UUID v4) para todas las entidades en todos los artefactos
+### M11: Foundation Hardening (Capa 1 — inmediato)
+- #10: Atomic writes en `state.py` y `cli.py` (temp file + fsync + os.replace)
+- #2: Rollback en `StateManager.transition_to()` (revertir state si operacion post-save falla)
+- #7: `ModuleRegistry` con validacion de carga y warnings explicitos
+- `fba doctor`: comando de diagnostico (registry, state integrity, writability, schema alignment)
+- #9: Alinear `task_item.schema.json` con `SchemaManager` (tipos wizard/workflow/report/controller)
 
-### M7: User Stories + Code Generator Dual + Domain IR
-- Domain IR como capa del SDD: `domain_models` (dominio puro) + `odoo_mappings` (implementacion)
-- Soporte de User Stories como metodologia alternativa a BABOK
-- Personas, epicas, historias, criterios de aceptacion Given/When/Then
-- Code generator dividido: Model Generator + XML Generator
+### M12: Diff, Dependencies & Trazabilidad (Capa 1 avanzada)
+- #15: Diff engine para artefactos JSON (PRD, SDD, schema, tasks) con changelog estructurado
+- Artifact contracts layer: invariantes, ownership, allowed mutations por artefacto
+- #12: Analisis de integridad de dependencias Odoo (modulos innecesarios, mixins sin depends, dependencias circulares)
+- Stable IDs foundation (UUID v4) para entidades clave: requisitos (RF-*), modelos, campos
+- **Absorbe**: Artifact Contracts (old M6.5), Stable IDs (old M6.6)
 
-### M8: Pipeline, Performance, Multi-modulo
-- Paralelizacion de tasks con DAG de dependencias
-- Pipeline incremental/resumible con checkpoints
-- Cache de validacion hash-based (depende de stable IDs)
-- Proyectos multi-modulo con registro de dependencias
+### M13: Reliability & Quality (Capa 2)
+- #1: Security scans: bandit + pip-audit + detect-secrets como gates en construction
+- #5: Configuracion de pre-commit hooks (ruff, black, bandit)
+- #6: Mypy strict mode progresivo
+- #8: Cache de validacion hash-based en `.factory/.cache/`
+- **Absorbe**: Cache de validacion (old M8.3)
 
-### M9: Testing Avanzado + Feedback + Sandbox
-- Testing ORM real con TransactionCase contra Odoo en Docker
-- Playwright para browser automation de vistas Odoo
-- Feedback loop: tests fallidos → analisis via stable_id → correccion automatica
-- Diagnostico estructurado de gate failures con sugerencias
-- Execution Sandbox: Docker runtime aislado con timeouts, quotas, retry policies
+### M14: Odoo Depth (Capa 3)
+- #9 full: Implementacion completa de wizard, workflow, report, controller en SchemaManager + Code Renderer
+- #3: Deteccion de cambios de schema y produccion de migraciones Odoo
+- #4: Internacionalizacion i18n (generacion .pot/.po, es_ES default, OCA readiness)
+
+### M15: Advanced QA (Capa 4)
+- #11: Browser automation con Playwright para vistas Odoo (form, list, kanban)
+- #13: Performance test suite (benchmarks de generacion, memoria, tiempo)
+- #14: Concurrency safety warnings (deteccion de escrituras concurrentes en state.json)
+- **Absorbe**: Playwright (old M9.2)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Planificado] - M10 (2026-05-09)
+
+### M10: Framework Meta-Development System
+- Sistema de 3 agentes meta para desarrollo autonomo del framework:
+  - `framework-orchestrator`: coordinador, solo delega, no implementa
+  - `framework-planner`: arquitecto de mejoras, zero suposiciones
+  - `framework-builder`: constructor autonomo, respeta CONTRIBUTING.md estrictamente
+- Archivo de estado persistente: `.factory/framework-state.json`
+- 3 slash commands: `/fba:fw`, `/fba:fw-plan`, `/fba:fw-build`
+- Template de brief: `docs/fw-brief-template.md`
+- Schema de validacion: `schemas/framework-state.schema.json`
+- M6-M9 se ejecutaran usando este sistema como infraestructura de desarrollo
+
+---
+
 ## [Planificado] - M6 a M9 (Refinado 2026-05-08)
 
 Orden corregido: M6 → M7 → M8 (Pipeline) → M9 (Testing). M8 provee la infraestructura

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [Planificado] - M10 (2026-05-09)
+## [0.6.0] - 2026-05-09
 
-### M10: Framework Meta-Development System
+### M10: Framework Meta-Development System (completado)
 - Sistema de 3 agentes meta para desarrollo autonomo del framework:
-  - `framework-orchestrator`: coordinador, solo delega, no implementa
+  - `framework-orchestrator`: coordinador, solo delega, no implementa. Optimizado a ~3k tokens (de ~25k).
   - `framework-planner`: arquitecto de mejoras, zero suposiciones
   - `framework-builder`: constructor autonomo, respeta CONTRIBUTING.md estrictamente
 - Archivo de estado persistente: `.factory/framework-state.json`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,18 +22,16 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [Planificado] - M11 a M15 (Reorganizado 2026-05-09)
+## [0.7.0] - 2026-05-12
 
-Los milestones M6-M9 originales se disuelven. Sus conceptos se reorganizan en 5 nuevos
-milestones estructurados en capas progresivas que priorizan bugs criticos y mejoras
-fundacionales. Ver ROADMAP.md para la tabla completa de conceptos transferidos y no transferidos.
-
-### M11: Foundation Hardening (Capa 1 — inmediato)
-- #10: Atomic writes en `state.py` y `cli.py` (temp file + fsync + os.replace)
-- #2: Rollback en `StateManager.transition_to()` (revertir state si operacion post-save falla)
-- #7: `ModuleRegistry` con validacion de carga y warnings explicitos
-- `fba doctor`: comando de diagnostico (registry, state integrity, writability, schema alignment)
-- #9: Alinear `task_item.schema.json` con `SchemaManager` (tipos wizard/workflow/report/controller)
+### M11: Foundation Hardening — ✅ Completado (2026-05-12)
+- #106: Atomic writes en archivos criticos (`_atomic_write()` con temp file + fsync + os.replace en state.py, cli.py, schema_manager.py)
+- #107: Rollback atomico en `StateManager.transition_to()` — backup y restauracion automatica del state si record_event falla
+- #108: `ModuleRegistry` con validacion de carga y `warnings.warn()` explicitos para 5 escenarios de error
+- #109: Comando `fba doctor` con 5 checks diagnosticos (registry, state, JSON, writability, schema alignment) y exit codes 0/1/2
+- #110: `SchemaManager.IMPLEMENTED_TYPES` + deteccion de tipos no implementados (wizard, workflow, report, controller) con AssemblyWarning
+- 5 nuevos archivos de test (40 tests nuevos): `test_state_atomicity.py`, `test_state_rollback.py`, `test_registry_robustez.py`, `test_fba_doctor.py`, `test_schema_manager_unknown_types.py`
+- Total: 493 tests, 0 fallos
 
 ### M12: Diff, Dependencies & Trazabilidad (Capa 1 avanzada)
 - #15: Diff engine para artefactos JSON (PRD, SDD, schema, tasks) con changelog estructurado

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ Ver tambien: [README.md](README.md) | [AGENTS.md](AGENTS.md) | [docs/PRD.md](doc
 | M4: Sistema de Gates | ✅ Completado | 2026-05-05 / 2026-05-05 |
 | M3: Construccion + MVP | ✅ Completado | 2026-05-05 / 2026-05-06 |
 | M5: Bug Fixes & Stability | ✅ Completado | 2026-05-06 / 2026-05-08 |
-| M10: Framework Meta-Development | ⏳ En progreso | 2026-05-09 / — |
+| M10: Framework Meta-Development | ✅ Completado | 2026-05-09 / 2026-05-09 |
 | M6: Optimización de Agentes | ⏳ Planificado | — / — |
 | M7: User Stories + Code Gen Dual | ⏳ Planificado | — / — |
 | M8: Pipeline, Performance, Multi-modulo | ⏳ Planificado | — / — |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,6 +14,7 @@ Ver tambien: [README.md](README.md) | [AGENTS.md](AGENTS.md) | [docs/PRD.md](doc
 | M4: Sistema de Gates | ✅ Completado | 2026-05-05 / 2026-05-05 |
 | M3: Construccion + MVP | ✅ Completado | 2026-05-05 / 2026-05-06 |
 | M5: Bug Fixes & Stability | ✅ Completado | 2026-05-06 / 2026-05-08 |
+| M10: Framework Meta-Development | ⏳ En progreso | 2026-05-09 / — |
 | M6: Optimización de Agentes | ⏳ Planificado | — / — |
 | M7: User Stories + Code Gen Dual | ⏳ Planificado | — / — |
 | M8: Pipeline, Performance, Multi-modulo | ⏳ Planificado | — / — |
@@ -353,6 +354,41 @@ fba transition tasks       # ✅ gate planning passed, transicion ok
 ```bash
 fba init --project-dir ../fba-test/v3/
 opencode .  # debe abrir sin error
+```
+
+---
+
+## M10: Framework Meta-Development System
+
+**Objetivo**: Implementar un sistema de 3 agentes meta (orchestrator, planner, builder) que
+gestiona el desarrollo del propio framework FBA de forma autonoma, eliminando la friccion
+entre sesiones y permitiendo ejecucion de milestones sin intervencion constante del usuario.
+
+**Alcance**: Los meta-agentes coordinan, planifican y construyen mejoras del framework.
+M6-M9 se ejecutaran usando este sistema.
+
+### Tareas
+
+- [x] `.factory/framework-state.json` — estado persistente entre sesiones
+- [x] `schemas/framework-state.schema.json` — validacion del archivo de estado
+- [x] `.opencode/agents/framework-orchestrator.md` — coordinador (solo delega, no implementa)
+- [x] `.opencode/agents/framework-planner.md` — arquitecto de mejoras (zero suposiciones)
+- [x] `.opencode/agents/framework-builder.md` — constructor autonomo (respeta CONTRIBUTING.md)
+- [x] `.opencode/commands/fba:fw.md` — punto de entrada del sistema meta
+- [x] `.opencode/commands/fba:fw-plan.md` — acceso directo a planificacion
+- [x] `.opencode/commands/fba:fw-build.md` — acceso directo a construccion
+- [x] `docs/fw-brief-template.md` — template de referencia del brief
+- [x] `docs/testing/m10-framework-meta-dev.md` — instrucciones de testing
+- [x] Documentacion actualizada: AGENTS.md, ROADMAP.md, CHANGELOG.md
+
+### Verificacion
+
+```bash
+opencode .                    # abrir el framework en OpenCode
+/fba:fw                       # orchestrator presenta resumen del roadmap
+/fba:fw-plan "[mejora]"       # planner genera fw-brief.md (pregunta si hay ambiguedad)
+/fba:fw-build                 # builder ejecuta el brief segun CONTRIBUTING.md
+pytest                        # todos los tests pasan
 ```
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,10 +15,11 @@ Ver tambien: [README.md](README.md) | [AGENTS.md](AGENTS.md) | [docs/PRD.md](doc
 | M3: Construccion + MVP | ✅ Completado | 2026-05-05 / 2026-05-06 |
 | M5: Bug Fixes & Stability | ✅ Completado | 2026-05-06 / 2026-05-08 |
 | M10: Framework Meta-Development | ✅ Completado | 2026-05-09 / 2026-05-09 |
-| M6: Optimización de Agentes | ⏳ Planificado | — / — |
-| M7: User Stories + Code Gen Dual | ⏳ Planificado | — / — |
-| M8: Pipeline, Performance, Multi-modulo | ⏳ Planificado | — / — |
-| M9: Testing Avanzado + Feedback | ⏳ Planificado | — / — |
+| M11: Foundation Hardening | 🔨 En Progreso | 2026-05-09 / — |
+| M12: Diff, Dependencies & Trazabilidad | ⏳ Planificado | — / — |
+| M13: Reliability & Quality | ⏳ Planificado | — / — |
+| M14: Odoo Depth | ⏳ Planificado | — / — |
+| M15: Advanced QA | ⏳ Planificado | — / — |
 
 ---
 
@@ -365,7 +366,7 @@ gestiona el desarrollo del propio framework FBA de forma autonoma, eliminando la
 entre sesiones y permitiendo ejecucion de milestones sin intervencion constante del usuario.
 
 **Alcance**: Los meta-agentes coordinan, planifican y construyen mejoras del framework.
-M6-M9 se ejecutaran usando este sistema.
+M11-M15 se ejecutaran usando este sistema (reemplaza a M6-M9 originales).
 
 ### Tareas
 
@@ -393,614 +394,205 @@ pytest                        # todos los tests pasan
 
 ---
 
-## M6: Optimizacion de Agentes
+## M11: Foundation Hardening (Capa 1 — inmediato)
 
-**Objetivo**: Reducir consumo de tokens del orquestador y optimizar instrucciones
-de todos los agentes para sesiones mas rapidas y ligeras.
+**Objetivo**: Corregir bugs criticos (#10 atomicidad, #2 rollback, #7 registry, #9 schema alignment)
+y proporcionar herramienta de diagnostico (`fba doctor`). Este milestone sienta las bases de robustez
+sin las cuales ningun feature nuevo es confiable.
 
-**Alcance**: El orquestador delega mas a sub-agentes y reduce su contexto primario.
-Instrucciones de agentes extraidas a archivos compartidos para eliminar duplicacion.
+**Alcance**: Atomic writes en state.py/cli.py, rollback en StateManager, validacion de ModuleRegistry,
+comando `fba doctor`, y alineacion de schema con SchemaManager.
 
-### Sub-milestones
+**Branch**: `milestone/11.0-foundation-hardening`
 
-```
-main
-  └── milestone/6.0-optimizar-agentes         ← creado desde main
-        ├── feat/6.1-orquestador-ligero        ← delegar elicitacion, reducir a control de flujo
-        ├── feat/6.2-instrucciones-agentes     ← reducir duplicacion, formato conciso
-        ├── feat/6.3-convenciones-compartidas  ← knowledge base granular (odoo/, babok/, testing/, security/)
-        ├── feat/6.4-identidad-vs-instrucciones ← separar runtime (agents/ knowledge/ contracts/)
-        ├── feat/6.5-artifact-contracts        ← invariantes, ownership, allowed mutations por artefacto
-        └── feat/6.6-stable-ids               ← UUIDs persistentes para todas las entidades
-```
+### Feats
 
-### M6.1: Orquestador Ligero
+| Orden | Feat | Depende de | Descripcion |
+|-------|------|------------|-------------|
+| 1 | feat/11.1-atomicity-writes | — | #10: Atomic writes en state.py y cli.py con temp file + fsync + os.replace |
+| 2 | feat/11.2-rollback-state | feat/11.1 | #2: Rollback en StateManager.transition_to() — revertir state si operacion post-save falla |
+| 3 | feat/11.3-registry-robustez | — | #7: ModuleRegistry con validacion, warnings explicitos si no carga, _copy_registry con advertencias |
+| 4 | feat/11.4-fba-doctor | feat/11.3 | Comando `fba doctor`: diagnostica registry, state integrity, writability, schema alignment |
+| 5 | feat/11.5-wizard-schema-alignment | — | #9: Alinear task_item.schema.json con SchemaManager — quitar tipos no implementados del enum o agregar validacion con warning |
 
-**Objetivo**: Reducir el consumo de tokens del orquestador delegando elicitacion
-y minimizando el contexto en modo primary.
-
-**Entregables**:
-- [ ] Delegar elicitacion a sub-agente especializado (usa `question` tool via task)
-- [ ] `orchestrator.md` reducido a control de flujo puro (phase transitions, gate dispatch, user confirm)
-- [ ] Sub-agentes invocados con contexto minimo necesario (no full state dump)
-- [ ] Reutilizacion de sesiones via `task_id` cuando es seguro y deterministico
-- [ ] Tests de consumo de tokens (medicion de contexto cargado por fase)
-
-**Depende de**: M5 (estabilidad actual)
-
----
-
-### M6.2: Instrucciones de Agentes Optimizadas
-
-**Objetivo**: Reducir duplicacion entre agentes, formato mas estructurado y conciso.
-
-**Entregables**:
-- [ ] Auditoria de duplicacion: identificar patrones repetidos entre los 10 agentes
-- [ ] Extraer convenciones Odoo v18 a `odoo-v18-conventions.md` compartido
-- [ ] Reducir ejemplos verbosos en agentes grandes (`code-generator.md` de 490 → <200 lineas)
-- [ ] Formato estandarizado: bullets > prosa, referencias > copias inline
-- [ ] Cada agente < 200 lineas (down from 180-490)
-- [ ] Tests de definiciones actualizados (referencias a archivo compartido)
-
-**Depende de**: M6.1 (nuevo formato de agente definido)
-
----
-
-### M6.3: Base de Conocimiento Compartida (por Dominio)
-
-**Objetivo**: Reorganizar el conocimiento en dominios granulares (`knowledge/odoo/`,
-`knowledge/babok/`, `knowledge/testing/`, `knowledge/security/`) eliminando duplicacion.
-
-**Entregables**:
-- [ ] Estructura de directorios `templates/.opencode/knowledge/`:
-  - `knowledge/odoo/v18-conventions.md` — Tags XML, atributos directos, naming, prohibited patterns
-  - `knowledge/odoo/v18-models.md` — Patrones Python: `models.Model`, `_inherit`, campos, constraints
-  - `knowledge/odoo/v18-views.md` — XML views (form, list, search, kanban), widgets, decorations
-  - `knowledge/odoo/v18-security.md` — CSV ACL, grupos XML, record rules, permisos
-  - `knowledge/babok/elicitation.md` — Metodologia BABOK, knowledge areas, question patterns
-  - `knowledge/babok/requirements.md` — RF, RNF, criterios de aceptacion, trazabilidad
-  - `knowledge/testing/odoo-orm.md` — TransactionCase, setUp, with_user(), sudo()
-  - `knowledge/testing/playwright.md` — Browser automation, selectores Odoo, navegacion
-  - `knowledge/security/patterns.md` — Validacion de input, no credenciales hardcodeadas, ACL coverage
-- [ ] Cada agente referencia solo los archivos de knowledge que necesita (no duplicacion)
-- [ ] Agregado a `fba init` y `fba update` (copia estructura completa)
-- [ ] Tests de contenido, referencias y cobertura de dominios
-
-**Depende de**: M6.2
-
----
-
-### M6.4: Separar Runtime vs Knowledge
-
-**Objetivo**: Separacion arquitectonica clara entre:
-
-- **Runtime Layer**: `.opencode/agents/` (identidad de agente: rol, mode, permission)
-- **Knowledge Layer**: `.opencode/knowledge/` (metodologia, convenciones, patrones por dominio)
-- **Contracts Layer**: `.opencode/contracts/` (invariantes, ownership, allowed mutations)
-
-Esto garantiza que las instrucciones de metodo no contaminen la identidad del agente,
-y que el conocimiento se comparta sin duplicacion.
-
-**Entregables**:
-- [ ] Estructura `.opencode/` reorganizada:
-  ```
-  .opencode/
-    agents/           ← solo identidad (frontmatter + rol minimo, <50 lineas)
-    knowledge/        ← por dominio (odoo/, babok/, testing/, security/)
-    contracts/        ← garantias del pipeline entre artefactos
-  ```
-- [ ] Runtime: `agents/<name>.md` contiene frontmatter + descripcion de rol (<50 lineas)
-- [ ] Knowledge: cargado on-demand via referencias en prompts
-- [ ] Contracts: definidos declarativamente, consumidos por GateRunner (ver M6.5)
-- [ ] Orquestador carga solo runtime, inyecta knowledge al invocar sub-agentes
-- [ ] Compatible con modo `primary` (carga minima) y `subagent` (knowledge bajo demanda)
-- [ ] Tests: identidad ligera, knowledge cargado correctamente en sub-agentes
-
-**Depende de**: M6.3
-
----
-
-### M6.5: Artifact Contracts
-
-**Objetivo**: Formalizar contratos entre artefactos del pipeline. Un contrato define
-invariantes, ownership, allowed mutations y determinismo. Esto habilita cache,
-paralelizacion, resumability y auto-fix en M8/M9.
-
-Los contratos extienden los JSON schemas actuales con garantias semánticas que el
-GateRunner puede verificar deterministicamente.
-
-**Entregables**:
-- [ ] Directorio `contracts/` con un archivo por artefacto:
-  - `contracts/prd.contract.md` — PRD invariants, ownership, allowed mutations
-  - `contracts/sdd.contract.md` — SDD invariants, domain layer, Odoo mappings
-  - `contracts/tasks.contract.md` — Task invariants, dependency integrity
-  - `contracts/schema.contract.md` — SSOT invariants, field identity, mode stability
-- [ ] Cada contrato define:
-  - **Invariantes**: campos inmutables despues de cierta fase (ej. `requirement.id` nunca cambia post-planning)
-  - **Ownership**: agente dueño de cada artefacto (ej. `PRD: owner=documentador`)
-  - **Allowed mutations**: que transformaciones son validas entre fases (ej. SDD PUEDE expandir detalles tecnicos, NO PUEDE cambiar intencion funcional)
-  - **Determinism**: mismo input → mismo output estructural (para reproducibilidad)
-- [ ] `GateRunner` extendido con `_check_contract()` que verifica invariantes cross-phase
-- [ ] Regla de gate tipo `contract_check` en `state.json`
-- [ ] Tests: violacion de invariante bloquea transicion
-
-**Depende de**: M6.4 (contracts layer definido)
-
----
-
-### M6.6: Stable IDs para Todas las Entidades
-
-**Objetivo**: Toda entidad en todo artefacto tiene un ID estable y persistente que
-sobrevive a renombramientos. Esto es prerequisito critico para cache, checkpoints,
-paralelizacion y auto-fix (M8/M9).
-
-**Entregables**:
-- [ ] Todo artefacto incluye `uuid` o `stable_id` generado una vez y nunca mutado:
-  - PRD: `RF-*`, `RNF-*`, `CA-*` obtienen `stable_id` (UUID v4)
-  - SDD: modelos, vistas, componentes obtienen `stable_id`
-  - Tasks: `task_id` persistente, inmutable post-generation
-  - Schema: `field_stable_id`, `model_stable_id`, `view_stable_id`
-- [ ] `SchemaManager` preserva stable IDs durante assembly (merge por UUID, no por nombre)
-- [ ] `ModuleRegistry` extendido con `entity_registry` (mapea stable_id → metadata)
-- [ ] Gate regla `stable_id_integrity`: verifica que IDs no mutaron entre fases
-- [ ] IDs estables persisten en `events.jsonl` para trazabilidad completa
-- [ ] Tests: renombrar campo no rompe cache/traceability/dependencies
-
-**Depende de**: M6.5 (contracts definen invariantes de ID)
-
----
+**Depende de**: M10 (framework meta-dev system, en uso para construir M11)
 
 ### Verificacion
 
 ```bash
-fba init
-# .opencode/knowledge/ con subdirectorios por dominio (odoo/, babok/, testing/, security/)
-# .opencode/contracts/ con contratos por artefacto
-# .opencode/agents/ con identidad ligera (<50 lineas cada uno)
-# Agentes con instrucciones reducidas (<200 lineas cada uno)
-# Stable IDs (UUID) en todas las entidades de todos los artefactos
-# Orquestador con contexto reducido (sin elicitacion directa)
-fba validate --contract prd  # valida invariantes de contrato PRD
-fba gate --verbose  # muestra contract checks, stable ID integrity
-pytest  # todos los tests existentes pasan
+fba doctor                  # diagnostica registry, state integrity, writability
+fba doctor --verbose        # output detallado con todos los componentes
+pytest tests/test_state_atomicity.py tests/test_state_rollback.py
+pytest tests/test_registry_robustez.py tests/test_fba_doctor.py
+pytest tests/test_schema_manager_unknown_types.py
 ```
 
 ---
 
-## M7: User Stories + Code Generator Dual
+## M12: Diff, Dependencies & Trazabilidad (Capa 1 avanzada)
 
-**Objetivo**: Soportar metodologia de User Stories como alternativa a BABOK, y
-dividir el code generator en dos agentes especializados (Modelos y XML).
+**Objetivo**: Implementar diff engine (#15) para trazabilidad de cambios entre artefactos,
+analisis de integridad de dependencias (#12), y formalizar artifact contracts con stable IDs basicos.
 
-**Alcance**: El pipeline soporta dos metodologias: BABOK (existente) y User Stories
-(nuevo). El constructor genera codigo con dos agentes independientes.
+**Alcance**: Core diff engine para artefactos JSON, contracts layer, dependency integrity analysis,
+y fundacion de stable IDs (UUID).
 
-### Sub-milestones
+**Branch**: `milestone/12.0-diff-dependencies`
 
-```
-main
-  └── milestone/7.0-us-codegen-dual          ← creado desde main
-        ├── feat/7.0-domain-ir-sdd            ← SDD reestructurado: domain_models + odoo_mappings
-        ├── feat/7.1-user-stories-core        ← personas, epicas, historias, schemas
-        ├── feat/7.2-model-generator          ← agente especializado en modelos Python
-        └── feat/7.3-xml-generator            ← agente especializado en vistas XML
-```
+### Feats
 
-### M7.0: Domain IR como Capa del SDD
+| Orden | Feat | Depende de | Descripcion |
+|-------|------|------------|-------------|
+| 1 | feat/12.1-diff-engine-core | M11 | #15: Core diff engine para artefactos JSON (PRD, SDD, schema, tasks). Output: changelog estructurado |
+| 2 | feat/12.2-artifact-contracts | M11 | Contracts layer: invariantes, ownership, allowed mutations por artefacto (extiende JSON schemas) |
+| 3 | feat/12.3-dependency-integrity | feat/12.1 | #12: Analisis semantico de dependencias Odoo — detecta modulos innecesarios, mixins sin depends, dependencias circulares |
+| 4 | feat/12.4-stable-ids-foundation | feat/12.2 | Stable IDs (UUID) para entidades clave: requisitos (RF-*), modelos, campos. Solo fundacion |
 
-**Objetivo**: Separar dominio puro de implementacion Odoo dentro del SDD, sin
-crear un nuevo artefacto. El SDD se reestructura en dos capas:
+**Depende de**: M11 (Foundation Hardening)
 
-```
-SDD
-├── domain_models        ← dominio puro (Customer owns Vehicles, Vehicle has Plate)
-│   ├── entities         ← conceptos de negocio sin acoplamiento Odoo
-│   ├── relationships    ← relaciones semanticas entre entidades
-│   └── workflows        ← flujos de negocio abstractos
-│
-└── odoo_mappings        ← implementacion Odoo (res.partner, vehicle.vehicle)
-    ├── model_mappings    ← entity → Odoo model (new/extend)
-    ├── field_mappings    ← entity attribute → Odoo field type
-    └── view_mappings     ← entity → Odoo view type
-```
-
-**Entregables**:
-- [ ] `sdd.schema.json` extendido con seccion `domain_models`:
-  - `entities[]` con `name`, `description`, `attributes[]`, `relationships[]`
-  - `relationships[]` con `type` (one_to_one, one_to_many, many_to_many), `from`, `to`
-  - `workflows[]` con `name`, `steps[]`, `actors[]`
-- [ ] `sdd.schema.json` extendido con seccion `odoo_mappings`:
-  - `model_mappings[]` que mapean `entity → model_name + mode (new/extend)`
-  - `field_mappings[]` que mapean `entity_attribute → field_name + field_type + widget`
-  - `view_mappings[]` que mapean `entity → view_type + priority`
-- [ ] `planificador.md` actualizado: genera SDD con ambas capas
-- [ ] `traceability_matrix` extendido: domain_entity → RF, odoo_mapping → domain_entity
-- [ ] Schema Manager lee `domain_models` + `odoo_mappings` para assembly
-- [ ] Gate `planning` extendido: `domain_traceability` verifica que toda entity tiene Odoo mapping
-- [ ] Tests: SDD con domain layer, validacion de mappings 1:1
-
-**Por que dentro del SDD y no como nuevo artefacto**: El SDD ya es el punto
-de traduccion entre requisitos y arquitectura. Agregar la capa de dominio aqui
-evita una nueva fase en el pipeline y mantiene la trazabilidad en un solo lugar.
-
-**Depende de**: M6 (contracts definen invariantes del SDD)
-
----
-
-### M7.1: User Stories Core
-
-**Objetivo**: Agregar soporte completo de User Stories como metodologia de
-elicitacion alternativa a BABOK.
-
-**Entregables**:
-- [ ] Agente `elicitador-us.md`: guia metodologica para User Story Mapping
-  - Personas (nombre, rol, necesidades, contexto)
-  - Epicas (descripcion, objetivo de negocio)
-  - User Stories (formato "Como [persona] quiero [accion] para [beneficio]")
-  - Criterios de aceptacion (formato Given/When/Then)
-  - Story points y priorizacion MoSCoW
-- [ ] Slash command `/fba:elicit-us` con flujo interactivo
-- [ ] Schema `user_stories.schema.json` para validar artefactos US
-- [ ] Campo `methodology` en `state.json` acepta "BABOK" y "User Stories"
-- [ ] Mapeo US → tareas tecnicas: `tasks/T*.json` extendido con `user_story_id`, `persona`, `story_points`
-- [ ] Traceability: US → SDD components (extender `traceability_matrix`)
-- [ ] Compatibilidad: pipeline funciona identico con ambas metodologias
-- [ ] Tests de validacion de schema US y flujo completo US
-
-**Depende de**: M6 (agentes optimizados, base de conocimiento compartida)
-
----
-
-### M7.2: Model Generator
-
-**Objetivo**: Agente especializado que genera exclusivamente `models/*.py` desde
-`schema.json`, separado de la generacion de XML.
-
-**Entregables**:
-- [ ] Agente `model-generator.md` + comando `/fba:construct-models`
-  - Genera `__manifest__.py`, `__init__.py`, `models/*.py`
-  - Soporta modo `new` (herencia `models.Model`) y `extend` (`_inherit`)
-  - Campos: Char, Text, Integer, Float, Boolean, Date, Datetime, Selection, Many2one, One2many, Many2many
-  - Atributos: `string`, `required`, `readonly`, `help`, `default`, `tracking`, `states`, `compute`, `inverse`
-  - Constraints: `_sql_constraints`, `_check_` methods, `@api.constrains`
-  - Mixins: `mail.thread`, `mail.activity.mixin` segun schema
-  - Consume SOLO `schema.json` (builder contract, zero interpretation)
-- [ ] Schema Manager (fase 1) sin cambios — produce `schema.json` igual
-- [ ] Code Renderer (fase 2) dividido: models vs XML en sesiones separadas
-- [ ] Orquestador actualizado: `construction` delega a `model-generator` primero, luego `xml-generator`
-- [ ] `code-generator.md` deprecado (reemplazado por los dos nuevos agentes)
-- [ ] Tests: generacion de modelos desde schema con todos los tipos de campo
-
-**Depende de**: M7.1 (user stories completado, schemas estables)
-
----
-
-### M7.3: XML Generator
-
-**Objetivo**: Agente especializado que genera exclusivamente archivos XML
-(`views/`, `security/`, `data/`) desde `schema.json`.
-
-**Entregables**:
-- [ ] Agente `xml-generator.md` + comando `/fba:construct-xml`
-  - Genera `views/*.xml`: form, list, search, kanban, menu items, actions
-  - Genera `security/*.xml`: `ir.model.access.csv`, `groups.xml`, `record_rules.xml`
-  - Genera `data/*.xml`: datos demo con `noupdate="1"`
-  - Odoo v18: `<list>` not `<tree>`, atributos directos, `<chatter/>`
-  - Widgets: `many2one`, `radio`, `selection`, `statusbar`, `monetary`, `html`
-  - Decorations: `decoration-danger`, `decoration-warning`, etc.
-  - Consume SOLO `schema.json` (builder contract, zero interpretation)
-- [ ] Orquestador: `xml-generator` ejecutado despues de `model-generator`
-- [ ] Orden de tasks: modelos primero, XML despues (relaciones ya resueltas)
-- [ ] Gate `construction` actualizado: valida ambos generadores
-- [ ] Tests: generacion de vistas/seguridad/datos desde schema
-
-**Depende de**: M7.2 (models generados, para que XML pueda referenciarlos)
-
----
+**Conceptos absorbidos de M6-M9**: Artifact Contracts (old M6.5), Stable IDs (old M6.6)
 
 ### Verificacion
 
 ```bash
-fba init --methodology "User Stories"
-/fba:elicit-us
-/fba:specify
-/fba:plan
-/fba:tasks
-/fba:construct-models   # genera models/*.py
-/fba:construct-xml       # genera views/ security/ data/
-/fba:test
-/fba:review
-/fba:ship
-# Resultado: modulo Odoo v18 instalable desde User Stories
+fba diff prd_v1.json prd_v2.json  # diff engine output: changelog estructurado
+fba validate --contract prd       # valida invariantes de contrato PRD
+fba deps check                    # analiza dependencias Odoo
+pytest tests/test_diff_engine.py tests/test_artifact_contracts.py
+pytest tests/test_dependency_integrity.py tests/test_stable_ids.py
 ```
 
 ---
 
-## M8: Pipeline, Performance, Multi-modulo
+## M13: Reliability & Quality (Capa 2)
 
-**Objetivo**: Optimizar velocidad del pipeline con paralelizacion y cache.
-Soportar proyectos multi-modulo con dependencias entre modulos generados.
+**Objetivo**: Agregar seguridad (#1 bandit + pip-audit + detect-secrets), cache de validacion (#8 hash-based),
+pre-commit hooks (#5), y type checking con mypy (#6).
 
-**Alcance**: El pipeline es mas rapido (tasks en paralelo, cache de validacion)
-y mas robusto (checkpoints, reanudacion). Soporta generacion de proyectos con
-multiples modulos Odoo interdependientes. Depende de M6 (stable IDs, contracts)
-para operaciones deterministicas.
+**Alcance**: Security scans integrados como gates, configuracion pre-commit, mypy strict mode progresivo,
+y cache de validacion hash-based en `.factory/.cache/`.
 
-### Sub-milestones
+**Branch**: `milestone/13.0-reliability-quality`
 
-```
-main
-  └── milestone/8.0-pipeline-performance     ← creado desde main
-        ├── feat/8.1-paralelizacion           ← tasks sin dependencias en paralelo
-        ├── feat/8.2-pipeline-resumible       ← checkpoints, reanudacion
-        ├── feat/8.3-cache-validacion         ← no re-validar artefactos sin cambios
-        └── feat/8.4-multi-modulo            ← dependencias entre modulos
-```
+### Feats
 
-### M8.1: Paralelizacion de Tasks
+| Orden | Feat | Depende de | Descripcion |
+|-------|------|------------|-------------|
+| 1 | feat/13.1-security-scans | M11 | #1: Bandit + pip-audit + detect-secrets como gates en construction |
+| 2 | feat/13.2-pre-commit | — | #5: Configuracion de pre-commit hooks (.pre-commit-config.yaml) con ruff, black, bandit |
+| 3 | feat/13.3-mypy | — | #6: Configuracion mypy con strict mode progresivo, pyproject.toml [tool.mypy] |
+| 4 | feat/13.4-cache-validacion | M11, feat/12.1 | #8: Cache de validacion hash-based en `.factory/.cache/` — no re-validar artefactos sin cambios |
 
-**Objetivo**: Ejecutar tasks de code rendering en paralelo cuando no tienen
-dependencias entre si.
+**Depende de**: M11 (Foundation Hardening) y parcialmente M12 feat/12.1 (diff engine para deteccion de cambios)
 
-**Entregables**:
-- [ ] `DependencyGraph`: analiza `tasks/index.json` y construye DAG de dependencias
-- [ ] `ParallelScheduler`: ejecuta tasks sin dependencias en sesiones paralelas
-  - Model Generator tasks en paralelo (modelos independientes)
-  - XML Generator tasks secuenciales (dependen de modelos generados)
-- [ ] Limite de paralelismo configurable (`--max-parallel 4`)
-- [ ] `events.jsonl`: eventos `task_parallel_start`, `task_parallel_end`
-- [ ] Gate `construction`: validacion post-paralela (consistencia entre modelos)
-- [ ] Tests: ejecucion paralela produce mismo schema que secuencial
-
-**Depende de**: M7 (code gen dual, modelos y XML separados), M6 (stable IDs para consistencia cross-session)
-
----
-
-### M8.2: Pipeline Incremental/Resumible
-
-**Objetivo**: Si el pipeline falla en fase N, reanudar desde fase N sin re-ejecutar
-fases anteriores. Checkpoints explicitos guardan estado intermedio.
-
-**Entregables**:
-- [ ] Sistema de checkpoints: `.factory/checkpoints/<phase>.json`
-  - Guarda snapshot de estado al completar cada fase
-  - Incluye hash de artefactos para detectar cambios
-- [ ] Comando `fba resume`: detecta ultima fase completada y continua
-- [ ] Comando `fba resume --from <phase>`: reanuda desde fase especifica
-- [ ] Comando `fba reset --from <phase>`: borra artefactos desde fase y reinicia
-- [ ] `StateManager` extendido con `get_last_checkpoint()`, `restore_checkpoint()`
-- [ ] Tests: interrupcion y reanudacion en cada fase
-
-**Depende de**: M8.1 (pipeline flow estable), M6 (stable IDs para identidad de artefactos)
-
----
-
-### M8.3: Cache de Validacion
-
-**Objetivo**: No re-ejecutar validacion de artefactos que no han cambiado desde
-la ultima gate check exitosa.
-
-**Entregables**:
-- [ ] `ValidationCache`: hash-based cache en `.factory/.cache/`
-  - Hash SHA256 del contenido de cada artefacto
-  - Gate check → cache hit si hash no cambio y validacion previa paso
-- [ ] Comando `fba gate --no-cache`: fuerza re-validacion completa
-- [ ] Invalidacion automatica: `fba record` de tipo `artifact_modified` borra cache
-- [ ] Reporte de cache: `fba gate --verbose` muestra cache hits/misses
-- [ ] Tests: cache hit rate, invalidacion, integridad
-
-**Depende de**: M8.2 (checkpoints, deteccion de cambios), M6 (stable IDs para hashing determinista)
-
----
-
-### M8.4: Proyectos Multi-modulo
-
-**Objetivo**: Soportar proyectos Odoo con multiples modulos interdependientes,
-generando un modulo a la vez con registro de dependencias entre ellos.
-
-**Entregables**:
-- [ ] `ModuleDependencyRegistry`: `.factory/module_deps.json`
-  - Registra dependencias entre modulos generados por FBA
-  - Resuelve orden de construccion (topological sort)
-  - Detecta dependencias circulares
-- [ ] `fba init --multi-module`: inicializa proyecto multi-modulo
-- [ ] `fba module add <name>`: agrega un nuevo modulo al proyecto
-- [ ] `fba module build <name>`: construye un modulo especifico
-- [ ] `fba module build --all`: construye todos en orden de dependencia
-- [ ] `manifest.json` `depends` incluye modulos generados por FBA
-- [ ] Schema Manager extendido: `cross_module_relations` en schema.json
-- [ ] Tests: proyecto con 2+ modulos, dependencia A→B, orden de build
-
-**Depende de**: M8.3 (cache, pipeline resumible — necesario para builds largos), M6 (contracts para dependencias cross-module)
-
----
+**Conceptos absorbidos de M6-M9**: Cache de validacion (old M8.3)
 
 ### Verificacion
 
 ```bash
-# Paralelizacion
-fba construct --parallel 4  # models en paralelo, XML secuencial
-
-# Pipeline resumible
-fba resume                  # continua desde ultima fase completada
-
-# Cache
-fba gate --verbose          # muestra cache hits/misses
-
-# Multi-modulo
-fba init --multi-module
-fba module add fleet_management
-fba module add vehicle_registry --depends fleet_management
-fba module build --all
+fba gate --security           # ejecuta bandit + pip-audit + detect-secrets
+pre-commit run --all-files    # ruff + black + bandit
+mypy src/fba/                 # strict mode progresivo
+fba gate --verbose            # muestra cache hits/misses
+pytest tests/test_security_scans.py tests/test_cache_validacion.py
 ```
 
 ---
 
-## M9: Testing Avanzado + Feedback
+## M14: Odoo Depth (Capa 3)
 
-**Objetivo**: Testing real de Odoo ORM y servicios con TransactionCase, browser
-testing con Playwright para vistas, y feedback loop automatico ante fallos.
-Todo esto sobre la infraestructura establecida en M8 (cache, checkpoints, DAG).
+**Objetivo**: Completar la implementacion de wizards/workflows/reports (#9 full), agregar soporte
+de migraciones de schema (#3), e internacionalizacion i18n (#4). Lleva la generacion de modulos
+Odoo a nivel enterprise-grade.
 
-**Alcance**: El tester genera tests ejecutables contra una instancia Odoo real via
-Docker. Playwright automatiza interacciones de UI. Gate failures incluyen diagnostico
-estructurado con guia de correccion. El feedback loop se apoya en stable IDs (M6) y
-cache (M8) para correcciones deterministicas.
+**Alcance**: Implementacion completa en SchemaManager + Code Renderer de wizard, workflow, report,
+controller. Deteccion de cambios de schema con migraciones. Generacion .pot/.po con es_ES default.
 
-### Sub-milestones
+**Branch**: `milestone/14.0-odoo-depth`
 
-```
-main
-  └── milestone/9.0-testing-avanzado         ← creado desde main
-        ├── feat/9.1-testing-orm-servicios    ← ORM real, service layer tests
-        ├── feat/9.2-playwright-vistas        ← browser automation para views
-        ├── feat/9.3-feedback-loop            ← tests fallidos → correccion automatica
-        ├── feat/9.4-gate-diagnostics         ← diagnostico estructurado de gate failures
-        └── feat/9.5-execution-sandbox        ← Docker sandbox, timeouts, isolation
-```
+### Feats
 
-### M9.1: Testing ORM y Servicios
+| Orden | Feat | Depende de | Descripcion |
+|-------|------|------------|-------------|
+| 1 | feat/14.1-wizards-workflows | M11 feat/11.5 | #9: Implementacion completa en SchemaManager + Code Renderer de wizard, workflow, report, controller |
+| 2 | feat/14.2-migraciones | feat/12.1 | #3: Deteccion de cambios de schema, produccion de migraciones Odoo, validacion de compatibilidad |
+| 3 | feat/14.3-i18n | — | #4: Internacionalizacion — generacion de .pot/.po, es_ES default, OCA readiness |
 
-**Objetivo**: Tests de modelos Odoo usando TransactionCase real contra instancia
-Odoo, incluyendo service layer.
+**Depende de**: M11 feat/11.5 (schema alignment), M12 feat/12.1 (diff engine para migraciones)
 
-**Entregables**:
-- [ ] `tester_qa.md` extendido con patrones de test Odoo ejecutables:
-  - `test_models.py`: CRUD, validacion, constraints, computed fields, onchange
-  - `test_services.py`: service/business layer methods
-  - `test_security.py`: per-group access con `with_user()` y `sudo()`
-  - `test_integration.py`: workflows end-to-end multi-modelo
-- [ ] Soporte para ejecutar tests contra Odoo en Docker
-  - `docker-compose.odoo.yml` con Odoo v18 + PostgreSQL
-  - Comando `fba test --run` para ejecutar tests generados
-- [ ] `test_report.json` extendido con resultados de ejecucion real
-  - Campos: `executed` (bool), `odoo_version`, `db_name`, `duration_ms`
-  - Coverage: modelos, vistas, seguridad, servicios
-- [ ] Tests del framework: mock de Odoo environment para CI
-
-**Depende de**: M7 (code gen dual, modulos generados completos), M6 (stable IDs para mapeo test→entity)
-
----
-
-### M9.2: Playwright para Vistas
-
-**Objetivo**: Browser automation con Playwright para probar vistas Odoo (form,
-list, kanban) con interacciones reales de usuario.
-
-**Entregables**:
-- [ ] Agente `playwright-tester.md` extendido en `tester_qa.md` o agente separado
-- [ ] `test_views_ui.py`: tests de UI con Playwright
-  - Form view: existencia de campos, visibilidad condicional, botones, guardado
-  - List view: columnas, paginacion, filtros, ordenamiento
-  - Search view: filtros por campo, group by
-  - Kanban view: tarjetas, drag-and-drop
-- [ ] Playwright config para Odoo (autenticacion, navegacion)
-- [ ] Screenshots y videos de fallos en reporte de tests
-- [ ] Integracion con Docker Odoo para ejecucion CI
-
-**Depende de**: M9.1 (instancia Odoo ejecutable, test_models base)
-
----
-
-### M9.3: Feedback Loop Tester → Code Generator
-
-**Objetivo**: Cuando tests fallan (en ejecucion real), el sistema analiza el
-fallo y automaticamente invoca al code generator para corregir el codigo.
-Usa stable IDs (M6) para mapear errores a entidades fuente, y cache (M8)
-para evitar regeneracion innecesaria.
-
-**Entregables**:
-- [ ] Analizador de fallos: parsea output de pytest Odoo y clasifica errores
-  - `FieldNotFound` → campo no existe en modelo → regenerar modelo (via stable_id)
-  - `AccessError` → ACL insuficiente → regenerar security
-  - `ValidationError` → constraint violado → revisar logica de modelo
-  - `ViewError` → vista mal formada → regenerar vista
-- [ ] Ciclo de correccion automatica (max 3 iteraciones):
-  ```
-  test fail → analizar error → mapear a stable_id → invocar agente corrector → regenerar → re-test
-  ```
-- [ ] Limite de iteraciones configurable (default 3) para evitar loops infinitos
-- [ ] Eventos `test_fix_applied` y `test_fix_failed` en `events.jsonl`
-- [ ] Gate `testing` extendido: `passed + fixed >= total` permite transicion
-
-**Depende de**: M9.2 (tests ejecutables reales y UI), M6 (stable IDs), M8 (cache)
-
----
-
-### M9.4: Diagnostico Estructurado de Gate Failures
-
-**Objetivo**: Cuando un gate falla, el sistema produce un diagnostico estructurado
-con guia de correccion especifica, no solo "gate failed".
-
-**Entregables**:
-- [ ] `GateResult` extendido con `suggestions[]` y `fix_agent` por regla
-  ```json
-  {
-    "rule": "acl_coverage",
-    "passed": false,
-    "message": "Model stock.vehicle has no ACL entry",
-    "suggestion": "Add ACL entry in security/ir.model.access.csv for model stock.vehicle",
-    "fix_command": "/fba:construct-xml --task security",
-    "fix_agent": "xml-generator"
-  }
-  ```
-- [ ] Comando `fba gate --fix` que invoca automaticamente al agente corrector
-- [ ] Reporte `gate_fix_report.json` con historial de correcciones
-- [ ] Integracion con `revisor_artefactos.md`: sugiere correcciones en vez de solo reportar
-
-**Depende de**: M7 (agentes especializados para correccion dirigida)
-
----
-
-### M9.5: Execution Sandbox
-
-**Objetivo**: Entorno de ejecucion aislado para correr codigo generado y tests
-de forma segura y reproducible. Formaliza Docker runtime, timeouts, quotas,
-retry policies e isolation.
-
-**Entregables**:
-- [ ] Directorio `runtime/` con configuracion de sandbox:
-  - `runtime/docker/docker-compose.odoo.yml` — Odoo v18 + PostgreSQL
-  - `runtime/docker/Dockerfile.odoo` — imagen base con dependencias
-  - `runtime/sandbox/execution.py` — `ExecutionSandbox` class
-  - `runtime/sandbox/policies.py` — timeout, quota, retry, isolation
-- [ ] `ExecutionSandbox` class:
-  - `run_tests(module_path)`: ejecuta pytest Odoo en contenedor
-  - `run_playwright(module_path)`: ejecuta Playwright en contenedor
-  - `run_auto_fix(module_path, error)`: ejecuta correccion en contenedor
-  - Timeouts configurables por tipo de operacion
-  - Resource quotas (CPU, memoria)
-  - Retry policies con exponential backoff
-- [ ] `fba sandbox up/down`: gestiona ciclo de vida del sandbox
-- [ ] `fba sandbox status`: verifica estado del sandbox
-- [ ] Eventos `sandbox_start`, `sandbox_error`, `sandbox_timeout` en events.jsonl
-- [ ] Cleanup automatico post-ejecucion (contenedores, volumenes temporales)
-- [ ] Tests: timeouts, quotas, retry, isolation entre ejecuciones
-
-**Depende de**: M9.1 (Docker Odoo), M9.3 (auto-fix necesita sandbox aislado)
-
----
-
-### Verificacion (M9)
+### Verificacion
 
 ```bash
-# Iniciar sandbox
-fba sandbox up
-
-# Testing real con Docker Odoo
-fba test --run        # ejecuta tests generados contra instancia real
-fba test --run --playwright  # incluye tests de UI con Playwright
-
-# Feedback loop
-fba test --run --auto-fix  # fallo → analiza (via stable_id) → corrige → re-testa (max 3 ciclos)
-
-# Gate diagnostics
-fba gate --fix        # fallo → diagnostico → sugerencia → correccion automatica
-
-# Limpiar sandbox
-fba sandbox down
-pytest                # todos los tests del framework pasan
+fba construct --with-wizards    # genera wizard, workflow, report, controller
+fba migrate --check             # detecta cambios de schema y genera migraciones
+fba i18n extract                # genera .pot/.po con es_ES default
+pytest tests/test_wizards_workflows.py tests/test_migraciones.py tests/test_i18n.py
 ```
+
+---
+
+## M15: Advanced QA (Capa 4)
+
+**Objetivo**: Agregar testing avanzado: Playwright para browser automation (#11), performance
+benchmarks (#13), y concurrency safety warnings (#14).
+
+**Alcance**: Browser automation con Playwright para vistas Odoo, performance test suite con
+benchmarks de generacion/memoria/tiempo, y deteccion de escrituras concurrentes en state.json.
+
+**Branch**: `milestone/15.0-advanced-qa`
+
+### Feats
+
+| Orden | Feat | Depende de | Descripcion |
+|-------|------|------------|-------------|
+| 1 | feat/15.1-playwright | M14 feat/14.1 | #11: Browser automation con Playwright para vistas Odoo (form, list, kanban) |
+| 2 | feat/15.2-performance | — | #13: Performance test suite — benchmarks de generacion, memoria, tiempo |
+| 3 | feat/15.3-concurrency | M11 | #14: Concurrency safety warnings — detectar escrituras concurrentes en state.json |
+
+**Depende de**: M14 feat/14.1 (wizards/workflows), M11 (atomicidad para concurrency)
+
+**Conceptos absorbidos de M6-M9**: Playwright (old M9.2)
+
+### Verificacion
+
+```bash
+fba test --playwright          # browser automation para vistas Odoo
+fba perf                       # ejecuta performance benchmarks
+fba doctor --concurrency       # verifica escrituras concurrentes en state.json
+pytest tests/test_playwright.py tests/test_performance.py tests/test_concurrency.py
+```
+
+---
+
+## Conceptos de M6-M9 Transferidos vs No Transferidos
+
+### Transferidos (absorbidos en M11-M15)
+
+| Concepto old | Milestone old | Destino |
+|-------------|---------------|---------|
+| Artifact Contracts | M6.5 | M12 feat/12.2 |
+| Stable IDs | M6.6 | M12 feat/12.4 |
+| Cache de validacion | M8.3 | M13 feat/13.4 |
+| Playwright | M9.2 | M15 feat/15.1 |
+
+### No Transferidos (depriorizados/pospuestos)
+
+| Concepto old | Milestone old | Razon |
+|-------------|---------------|-------|
+| Orquestador ligero | M6.1 | Posponer — requiere analisis de token consumption post-M11 |
+| Instrucciones agentes <200L | M6.2 | Posponer — sin bloqueo funcional |
+| Knowledge base granular | M6.3 | Posponer — los agentes actuales funcionan |
+| Separacion runtime vs knowledge | M6.4 | Posponer |
+| User Stories | M7.1 | Posponer — BABOK funciona |
+| Code Gen Dual (model/xml) | M7.2, M7.3 | Posponer — code-generator actual funciona |
+| Domain IR en SDD | M7.0 | Posponer |
+| Paralelizacion | M8.1 | Posponer |
+| Pipeline resumible | M8.2 | Posponer |
+| Multi-modulo | M8.4 | Posponer |
+| Testing ORM real | M9.1 | Posponer |
+| Feedback loop | M9.3 | Depende de diff (M12) — podria reactivarse post-M12 |
+| Gate diagnostics | M9.4 | Posponer |
+| Execution sandbox | M9.5 | Posponer |
 
 ---
 
@@ -1009,14 +601,12 @@ pytest                # todos los tests del framework pasan
 ```
 Orquestador (control de flujo, gate dispatch, user confirm)
 ├── Elicitador BABOK (metodologia tradicional)
-├── Elicitador US (User Story Mapping) [M7]
 ├── Documentador (PRD + SDD)
 ├── Planificador (arquitectura Odoo)
 ├── Revisor de Artefactos (gates + validacion cross-artifact)
 ├── Validador Semantico (alineacion semantica contra solicitud original)
-├── Model Generator (modelos Python desde schema.json) [M7]
-├── XML Generator (vistas, seguridad, datos desde schema.json) [M7]
-├── Tester/QA (pruebas Odoo + Playwright) [M9]
+├── Code Generator (Schema Manager + Code Renderer)
+├── Tester/QA (pruebas Odoo + Playwright) [M15]
 ├── Revisor de Codigo (calidad + seguridad)
 └── CI/CD Manager (GitHub Actions + releases)
 ```
@@ -1025,15 +615,13 @@ Cada agente se define declarativamente en Markdown en `.opencode/agents/`.
 El sistema es extensible por diseno: agregar un nuevo agente es agregar
 un archivo Markdown con su definicion y un slash command.
 
-### Pipeline (tasks → construction, con code gen dual)
+### Pipeline (tasks → construction)
 
 ```
 planner → tasks/index.json + T*.json → code-generator
                                           ├── Schema Manager: assembly + normalization + registry lookup
                                           │   → produces schema.json (SSOT)
-                                          └── Code Renderer [dual en M7]:
-                                              ├── Model Generator: models/*.py
-                                              └── XML Generator: views/ security/ data/
+                                          └── Code Renderer: iterative generation per task
                                               → produces odoo_module/
 ```
 
@@ -1043,20 +631,11 @@ planner → tasks/index.json + T*.json → code-generator
 |----------|----------|---------------|
 | Runtime | OpenCode | Agente CLI maduro, multi-modelo, open source |
 | Lenguaje | Python 3.11+ | Odoo es Python, SpecKit es Python, ecosistema ERP |
-| Metodologia v1 | BABOK | Estandar reconocido para analisis de negocio |
-| Metodologia v2 | User Stories | Alternativa agil con personas, epicas, historias [M7] |
+| Metodologia | BABOK | Estandar reconocido para analisis de negocio |
 | Comunicacion | Archivos + Eventos | Simple, trazable, sin infraestructura externa |
 | CI/CD | GitHub Actions | Integracion nativa con GitHub |
 | Compatibilidad | OpenSpec + SpecKit | Artefactos en formatos compatibles |
 | Extension | Markdown declarativo | Agregar agentes/metodologias sin modificar nucleo |
 | Empaquetado | pyproject.toml | Estandar moderno de Python |
 | CLI | Click | Biblioteca madura y bien documentada |
-| Arquitectura Runtime | Agents + Knowledge + Contracts | Separacion de identidad, conocimiento y garantias [M6] |
-| Estabilidad | Artifact Contracts | Invariantes, ownership, allowed mutations por artefacto [M6] |
-| Identidad | Stable IDs (UUID) | Entidades con identidad persistente cross-phase [M6] |
-| Dominio | Domain IR en SDD | Separacion dominio puro vs implementacion Odoo [M7] |
-| Code Gen | Dual (Models + XML) | Agentes especializados, menos tokens, mas mantenibles [M7] |
-| Testing UI | Playwright | Browser automation para vistas Odoo [M9] |
-| Execution | Docker Sandbox | Entorno aislado con timeouts, quotas, retry [M9] |
-| Performance | Cache + Paralelizacion + DAG | No re-validar sin cambios, tasks en paralelo [M8] |
-| Escalabilidad | Multi-modulo | Proyectos con dependencias entre modulos generados [M8] |
+| SSOT | schema.json | Single source of truth for module structure, eliminates ambiguity between tasks and code |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ Ver tambien: [README.md](README.md) | [AGENTS.md](AGENTS.md) | [docs/PRD.md](doc
 | M3: Construccion + MVP | ✅ Completado | 2026-05-05 / 2026-05-06 |
 | M5: Bug Fixes & Stability | ✅ Completado | 2026-05-06 / 2026-05-08 |
 | M10: Framework Meta-Development | ✅ Completado | 2026-05-09 / 2026-05-09 |
-| M11: Foundation Hardening | 🔨 En Progreso | 2026-05-09 / — |
+| M11: Foundation Hardening | ✅ Completado | 2026-05-09 / 2026-05-12 |
 | M12: Diff, Dependencies & Trazabilidad | ⏳ Planificado | — / — |
 | M13: Reliability & Quality | ⏳ Planificado | — / — |
 | M14: Odoo Depth | ⏳ Planificado | — / — |
@@ -407,13 +407,13 @@ comando `fba doctor`, y alineacion de schema con SchemaManager.
 
 ### Feats
 
-| Orden | Feat | Depende de | Descripcion |
-|-------|------|------------|-------------|
-| 1 | feat/11.1-atomicity-writes | — | #10: Atomic writes en state.py y cli.py con temp file + fsync + os.replace |
-| 2 | feat/11.2-rollback-state | feat/11.1 | #2: Rollback en StateManager.transition_to() — revertir state si operacion post-save falla |
-| 3 | feat/11.3-registry-robustez | — | #7: ModuleRegistry con validacion, warnings explicitos si no carga, _copy_registry con advertencias |
-| 4 | feat/11.4-fba-doctor | feat/11.3 | Comando `fba doctor`: diagnostica registry, state integrity, writability, schema alignment |
-| 5 | feat/11.5-wizard-schema-alignment | — | #9: Alinear task_item.schema.json con SchemaManager — quitar tipos no implementados del enum o agregar validacion con warning |
+| Orden | Feat | Depende de | Descripcion | Estado |
+|-------|------|------------|-------------|--------|
+| 1 | feat/11.1-atomicity-writes | — | #10: Atomic writes en state.py y cli.py con temp file + fsync + os.replace | ✅ |
+| 2 | feat/11.2-rollback-state | feat/11.1 | #2: Rollback en StateManager.transition_to() — revertir state si operacion post-save falla | ✅ |
+| 3 | feat/11.3-registry-robustez | — | #7: ModuleRegistry con validacion, warnings explicitos si no carga, _copy_registry con advertencias | ✅ |
+| 4 | feat/11.4-fba-doctor | feat/11.3 | Comando `fba doctor`: diagnostica registry, state integrity, writability, schema alignment | ✅ |
+| 5 | feat/11.5-wizard-schema-alignment | — | #9: Alinear task_item.schema.json con SchemaManager — deteccion de tipos no implementados con warning | ✅ |
 
 **Depende de**: M10 (framework meta-dev system, en uso para construir M11)
 

--- a/docs/fw-brief-template.md
+++ b/docs/fw-brief-template.md
@@ -1,0 +1,60 @@
+# fw-brief-template
+
+Template de referencia para los briefs que genera el `framework-planner`.
+El planner produce un archivo `.factory/fw-brief.md` siguiendo esta estructura.
+
+---
+
+```markdown
+# Brief: [objetivo en una oracion]
+
+- **Issue**: #[NN] (existente) o "crear issue para: [descripcion]"
+- **Branch**: `milestone/X.0-descripcion` o `feat/X.Y-descripcion`
+- **Objetivo**: descripcion clara y medible de lo que se va a construir
+- **Complejidad**: baja / media / alta
+
+## Archivos
+
+### A crear
+- `ruta/exacta/archivo1.ext` — proposito
+- `ruta/exacta/archivo2.ext` — proposito
+
+### A modificar
+- `ruta/exacta/archivo3.ext` — que se cambia
+- `ruta/exacta/archivo4.ext` — que se cambia
+
+## Tests requeridos
+
+- [ ] `tests/test_X.py` — que debe verificar
+- [ ] `tests/test_Y.py` — que debe verificar
+
+## Definicion de Done
+
+- [ ] Condicion verificable y objetiva 1
+- [ ] Condicion verificable y objetiva 2
+- [ ] `pytest` pasa con 0 fallos
+
+## Feats (si hay multiples)
+
+| Orden | Feat | Depende de | Descripcion |
+|-------|------|------------|-------------|
+| 1 | feat/X.1-desc | — | lo que hace |
+| 2 | feat/X.2-desc | feat/X.1 | lo que hace |
+
+## Documentacion a actualizar
+
+- [ ] AGENTS.md — [seccion que cambia]
+- [ ] ROADMAP.md — [seccion que cambia]
+- [ ] CHANGELOG.md — [entrada de la mejora]
+- [ ] docs/testing/mX-*.md — [si aplica]
+```
+
+## Notas para el planner
+
+- **Issue**: si ya existe un issue en GitHub, usar `#[NN]`. Si no, indicar que el builder debe crearlo con `"crear issue para: [descripcion]"`.
+- **Branch**: si es un feature aislado, usar `feat/X.Y-desc`. Si es un milestone completo, incluir el milestone branch y luego los feat branches.
+- **Archivos**: rutas completas y exactas desde la raiz del repo. Nada de "archivos relacionados" o "etc.".
+- **Tests**: cada test debe ser especifico. No "tests unitarios" generico.
+- **Definicion de Done**: condiciones binarias (pasa/no pasa). Nada subjetivo.
+- **Feats**: si el cambio es un solo feat, usar `feat/X.Y-desc`. Si es un milestone con multiples feats, listar todos en orden de ejecucion.
+- **Documentacion**: siempre verificar si el cambio requiere actualizar AGENTS.md (cambios de arquitectura), ROADMAP.md (nuevo milestone o cambio de alcance), CHANGELOG.md (todos los cambios).

--- a/docs/testing/m10-framework-meta-dev.md
+++ b/docs/testing/m10-framework-meta-dev.md
@@ -1,0 +1,175 @@
+# Testing - M10: Framework Meta-Development System
+
+## Requisitos Previos
+
+- Python 3.11+ con `fba` CLI instalado.
+- OpenCode 0.1.28 o superior.
+- Repositorio del framework FBA clonado.
+- GitHub CLI (`gh`) autenticado.
+
+---
+
+## Pasos para Probar
+
+### 1. Verificar que los archivos del sistema existen
+
+**Objetivo**: Confirmar que todos los archivos del sistema de meta-agentes estan creados.
+
+**Comando**:
+```bash
+ls -la .opencode/agents/framework-*.md
+ls -la .opencode/commands/fba:fw*.md
+ls -la .factory/framework-state.json
+ls -la schemas/framework-state.schema.json
+ls -la docs/fw-brief-template.md
+```
+
+**Resultado esperado**:
+```
+.opencode/agents/framework-builder.md
+.opencode/agents/framework-orchestrator.md
+.opencode/agents/framework-planner.md
+.opencode/commands/fba:fw.md
+.opencode/commands/fba:fw-build.md
+.opencode/commands/fba:fw-plan.md
+.factory/framework-state.json
+schemas/framework-state.schema.json
+docs/fw-brief-template.md
+```
+
+---
+
+### 2. Validar schema de framework-state.json
+
+**Objetivo**: Confirmar que el schema de validacion funciona.
+
+**Comando**:
+```bash
+pytest tests/test_framework_state_schema.py -v
+```
+
+**Resultado esperado**:
+```
+17 passed
+```
+
+---
+
+### 3. Verificar que framework-state.json valida contra su schema
+
+**Objetivo**: Confirmar que el archivo de estado inicial es valido.
+
+**Comando**:
+```bash
+python3 -c "
+import json
+from pathlib import Path
+import jsonschema
+schema = json.loads(Path('schemas/framework-state.schema.json').read_text())
+state = json.loads(Path('.factory/framework-state.json').read_text())
+jsonschema.validate(state, schema)
+print('✅ OK')
+"
+```
+
+**Resultado esperado**:
+```
+✅ OK
+```
+
+---
+
+### 4. Probar slash command /fba:fw
+
+**Objetivo**: Verificar que el orchestrator lee el estado y presenta un resumen.
+
+**Pasos**:
+1. Abrir OpenCode en el repositorio: `opencode .`
+2. Ejecutar: `/fba:fw`
+
+**Resultado esperado**:
+- El orchestrator lee ROADMAP.md, framework-state.json, CHANGELOG.md
+- Presenta un resumen con: estado del roadmap, ultima sesion, feats pendientes, proximo paso sugerido
+
+---
+
+### 5. Probar slash command /fba:fw-plan
+
+**Objetivo**: Verificar que el planner genera un brief.
+
+**Pasos**:
+1. Ejecutar: `/fba:fw-plan "agregar soporte para un nuevo tipo de campo en schema.json"`
+2. Verificar que el planner pregunta si hay ambiguedades ("zero suposiciones")
+3. Si no hay ambiguedad, debe generar `.factory/fw-brief.md`
+
+**Resultado esperado**:
+- `.factory/fw-brief.md` existe con estructura valida
+- Contiene: Issue, Branch, Objetivo, Archivos, Tests, Definicion de Done
+
+---
+
+### 6. Probar slash command /fba:fw-build
+
+**Objetivo**: Verificar que el builder ejecuta un brief.
+
+**Pre-condiciones**: Debe existir `.factory/fw-brief.md` (generado en el paso 5).
+
+**Pasos**:
+1. Ejecutar: `/fba:fw-build`
+
+**Resultado esperado**:
+- El builder lee el brief
+- Sigue el flujo de CONTRIBUTING.md:
+  - Crea GitHub Issue (si el brief lo indica)
+  - Crea feat branch desde el milestone branch
+  - Escribe tests primero
+  - Implementa
+  - Ejecuta pytest
+  - Commit con formato `tipo(#XX): descripcion`
+  - Abre PR al milestone branch (NO a main)
+
+---
+
+### 7. Verificar que el builder NO hace commit a main
+
+**Objetivo**: Confirmar la restriccion de seguridad mas critica.
+
+**Accion**: Durante `/fba:fw-build`, verificar que los commits y PRs van al milestone branch,
+NO a main.
+
+**Resultado esperado**:
+- `git log --oneline main` no muestra commits nuevos del builder
+- Los PRs abiertos apuntan a `milestone/X.0-*`, no a `main`
+
+---
+
+### 8. Verificar actualizacion de framework-state.json tras build
+
+**Objetivo**: Confirmar que el builder actualiza el estado correctamente.
+
+**Accion**: Despues de ejecutar `/fba:fw-build`, leer `.factory/framework-state.json`.
+
+**Resultado esperado**:
+- `active_milestone.feats_done` ha aumentado
+- `active_milestone.feats_pending` ya no incluye el feat completado
+- `last_session` refleja la ultima accion del builder
+
+---
+
+## Troubleshooting
+
+### "framework-state.json no existe"
+
+El sistema de meta-agentes solo funciona en el repositorio del framework FBA,
+no en proyectos Odoo generados con `fba init`.
+
+### "El planner no genero el brief"
+
+El planner tiene instrucciones de NO asumir nada. Si la intencion del usuario
+es ambigua, preguntara antes de generar el brief. Responde las preguntas con
+detalle.
+
+### "El builder no encuentra el milestone branch"
+
+El builder verificara si el milestone branch existe. Si no, lo creara desde main.
+Asegurate de que el nombre del branch en el brief es correcto.

--- a/docs/testing/m11-foundation-hardening.md
+++ b/docs/testing/m11-foundation-hardening.md
@@ -1,0 +1,188 @@
+# Testing - M11: Foundation Hardening
+
+## Requisitos Previos
+- Python 3.11+
+- `fba` CLI instalado (`pip install -e .`)
+- Acceso al repositorio del proyecto (`factory-build-agent`)
+
+---
+
+## 1. Verificar atomicidad de escritura
+
+**Objetivo**: Confirmar que `_atomic_write()` protege archivos criticos de corrupcion.
+
+**Comando**:
+```bash
+pytest tests/test_state_atomicity.py -v
+```
+
+**Resultado esperado**:
+```
+8 passed
+```
+
+**Que prueba cada test**:
+- `test_atomic_write_success`: escritura atomica exitosa, contenido llega integro
+- `test_atomic_write_original_intact_on_write_failure`: archivo original intacto si falla el replace
+- `test_atomic_write_directory_created`: crea directorio destino si no existe
+- `test_atomic_write_temp_cleaned_on_failure`: archivo temporal limpiado en caso de error
+- `test_state_manager_save_uses_atomic_write`: `StateManager.save()` usa el mecanismo atomico
+- `test_record_event_uses_append_with_fsync`: `record_event()` usa fsync en append
+- `test_state_manager_save_does_not_leave_temp_files`: sin archivos temporales residuales
+- `test_concurrent_writes_no_corruption`: escrituras concurrentes no producen corrupcion
+
+---
+
+## 2. Verificar rollback de estado
+
+**Objetivo**: Confirmar que `transition_to()` revierte el estado si una operacion post-save falla.
+
+**Comando**:
+```bash
+pytest tests/test_state_rollback.py -v
+```
+
+**Resultado esperado**:
+```
+8 passed
+```
+
+---
+
+## 3. Verificar robustez del registry
+
+**Objetivo**: ModuleRegistry emite warnings explicitos en escenarios de error.
+
+**Comando**:
+```bash
+pytest tests/test_registry_robustez.py -v
+```
+
+**Resultado esperado**:
+```
+8 passed
+```
+
+---
+
+## 4. Probar comando `fba doctor`
+
+**Objetivo**: El comando diagnostica correctamente la salud del proyecto.
+
+### 4.1 Proyecto sano
+
+```bash
+# Crear proyecto temporal e inicializar
+mkdir /tmp/test-fba-healthy
+cd /tmp/test-fba-healthy
+fba init
+
+# Ejecutar doctor
+fba doctor
+```
+
+**Resultado esperado**: Exit code 0 o 1. Output muestra checks de registry, state_exists, state_json, writable, schema_alignment.
+
+### 4.2 Output verbose
+
+```bash
+fba doctor --verbose
+```
+
+**Resultado esperado**: Muestra detalles adicionales: nombre del proyecto, directorio .factory/, estado de cada check.
+
+### 4.3 Output JSON
+
+```bash
+fba doctor --json
+```
+
+**Resultado esperado**: Output JSON valido con keys `status`, `checks`, `exit_code`, `warnings`, `errors`.
+
+### 4.4 Proyecto sin .factory/
+
+```bash
+mkdir /tmp/test-no-factory
+cd /tmp/test-no-factory
+fba doctor
+```
+
+**Resultado esperado**: Exit code 2. Mensaje: "No .factory/ directory found."
+
+### 4.5 Tests automatizados
+
+```bash
+pytest tests/test_fba_doctor.py -v
+```
+
+**Resultado esperado**:
+```
+8 passed
+```
+
+---
+
+## 5. Verificar deteccion de tipos no implementados
+
+**Objetivo**: SchemaManager detecta y advierte sobre tipos `wizard`, `workflow`, `report`, `controller`.
+
+**Comando**:
+```bash
+pytest tests/test_schema_manager_unknown_types.py -v
+```
+
+**Resultado esperado**:
+```
+8 passed
+```
+
+**Que prueba cada test**:
+- Componente `type: "wizard"` → AssemblyWarning emitido
+- Componente `type: "workflow"` → AssemblyWarning emitido
+- Componentes `type: "report"` y `"controller"` → un warning por cada uno
+- Solo tipos conocidos (`model`, `view`, etc.) → sin warnings de tipo desconocido
+- Multiples componentes desconocidos → un warning por cada uno
+- Los warnings tienen nivel `"warning"` (no bloquean el assembly)
+- `IMPLEMENTED_TYPES` existe como constante de clase
+
+---
+
+## 6. Suite completa de tests
+
+**Objetivo**: Verificar que todos los tests del proyecto pasan (incluyendo los 5 nuevos archivos).
+
+**Comando**:
+```bash
+pytest tests/ -v
+```
+
+**Resultado esperado**:
+```
+493 passed in ~2s
+```
+
+---
+
+## 7. Regresiones
+
+**Objetivo**: Confirmar que los tests existentes (anteriores a M11) siguen pasando.
+
+**Comando**:
+```bash
+pytest tests/ --ignore=tests/test_state_atomicity.py --ignore=tests/test_state_rollback.py --ignore=tests/test_registry_robustez.py --ignore=tests/test_fba_doctor.py --ignore=tests/test_schema_manager_unknown_types.py -v
+```
+
+**Resultado esperado**: Todos los tests existentes pasan (~453 tests).
+
+---
+
+## Troubleshooting
+
+### `fba: command not found`
+Asegurate de tener el paquete instalado: `pip install -e .`
+
+### `ModuleRegistry` no emite warnings
+Verifica que los warnings se capturen correctamente. Los warnings usan `warnings.warn(UserWarning, ...)` y pueden necesitar `pytest -W default` para ser visibles.
+
+### `fba doctor` reporta exit code 1 en proyecto sano
+Esto es esperado si D5 (schema alignment) detecta tipos no implementados. El exit code 1 indica warnings pero no errores. El exit code 2 indicaria errores.

--- a/schemas/framework-state.schema.json
+++ b/schemas/framework-state.schema.json
@@ -3,7 +3,7 @@
   "title": "FBA Framework Meta-Development State",
   "description": "Persistent state schema for the framework meta-agents (orchestrator, planner, builder)",
   "type": "object",
-  "required": ["schema_version", "last_updated", "last_session", "active_milestone", "roadmap_status", "agents"],
+  "required": ["schema_version", "last_updated", "last_session", "active_milestone", "roadmap_status", "roadmap_summary", "agents"],
   "properties": {
     "schema_version": {
       "type": "string",
@@ -96,6 +96,21 @@
       "additionalProperties": {
         "type": "string",
         "enum": ["planned", "in_progress", "completed"]
+      }
+    },
+    "roadmap_summary": {
+      "type": "array",
+      "description": "Compact summary of all milestones for the orchestrator — eliminates need to read ROADMAP.md",
+      "items": {
+        "type": "object",
+        "required": ["milestone", "name", "status"],
+        "properties": {
+          "milestone": { "type": "string", "description": "Milestone ID (M0, M1, ...)" },
+          "name": { "type": "string", "description": "Short human-readable name" },
+          "status": { "type": "string", "enum": ["planned", "in_progress", "completed"], "description": "Current status" },
+          "start_date": { "type": "string", "description": "Start date (YYYY-MM-DD)" },
+          "end_date": { "type": "string", "description": "End date (YYYY-MM-DD)" }
+        }
       }
     },
     "pending_decisions": {

--- a/schemas/framework-state.schema.json
+++ b/schemas/framework-state.schema.json
@@ -1,0 +1,179 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "FBA Framework Meta-Development State",
+  "description": "Persistent state schema for the framework meta-agents (orchestrator, planner, builder)",
+  "type": "object",
+  "required": ["schema_version", "last_updated", "last_session", "active_milestone", "roadmap_status", "agents"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "description": "Version of this schema"
+    },
+    "last_updated": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of last update"
+    },
+    "last_session": {
+      "type": "object",
+      "description": "Summary of the last development session",
+      "required": ["date", "agent", "action", "completed_feats", "pending_feats"],
+      "properties": {
+        "date": {
+          "type": "string",
+          "description": "Date of the last session (YYYY-MM-DD)"
+        },
+        "agent": {
+          "type": "string",
+          "description": "Agent that executed the last session (framework-builder, framework-planner)"
+        },
+        "action": {
+          "type": "string",
+          "description": "Summary of the last action performed"
+        },
+        "completed_feats": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Feats completed in the last session"
+        },
+        "pending_feats": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Feats left pending at the end of the last session"
+        },
+        "blockers": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Blockers identified during the last session"
+        }
+      }
+    },
+    "active_milestone": {
+      "type": "object",
+      "description": "The milestone currently being worked on",
+      "required": ["id", "name", "branch", "status", "feats_total", "feats_done", "feats_pending"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Milestone ID (e.g. M10)"
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable milestone name"
+        },
+        "branch": {
+          "type": "string",
+          "description": "Git branch name for the milestone"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["pending", "in_progress", "completed"],
+          "description": "Current status of the milestone"
+        },
+        "feats_total": {
+          "type": "integer",
+          "description": "Total number of feats in the milestone"
+        },
+        "feats_done": {
+          "type": "integer",
+          "description": "Number of completed feats"
+        },
+        "feats_pending": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of pending feat identifiers"
+        },
+        "ready_for_user_review": {
+          "type": "boolean",
+          "description": "Whether the milestone is ready for user review before PR to main",
+          "default": false
+        }
+      }
+    },
+    "roadmap_status": {
+      "type": "object",
+      "description": "Status of all milestones in the roadmap",
+      "additionalProperties": {
+        "type": "string",
+        "enum": ["planned", "in_progress", "completed"]
+      }
+    },
+    "pending_decisions": {
+      "type": "array",
+      "description": "Decisions awaiting user input",
+      "items": {
+        "type": "object",
+        "required": ["id", "description", "raised_by", "raised_at", "status"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Decision identifier (e.g. DEC-001)"
+          },
+          "description": {
+            "type": "string",
+            "description": "What needs to be decided"
+          },
+          "raised_by": {
+            "type": "string",
+            "description": "Agent that raised the decision"
+          },
+          "raised_at": {
+            "type": "string",
+            "description": "Date when the decision was raised"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["awaiting_user", "resolved"],
+            "description": "Current decision status"
+          }
+        }
+      }
+    },
+    "open_briefs": {
+      "type": "array",
+      "description": "Briefs that have been generated but not yet fully executed",
+      "items": {
+        "type": "object",
+        "required": ["file", "milestone", "feats_remaining", "status"],
+        "properties": {
+          "file": {
+            "type": "string",
+            "description": "Path to the brief file"
+          },
+          "milestone": {
+            "type": "string",
+            "description": "Milestone the brief belongs to"
+          },
+          "feats_remaining": {
+            "type": "integer",
+            "description": "Number of feats remaining to be built"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["active", "completed"],
+            "description": "Current status of the brief"
+          }
+        }
+      }
+    },
+    "agents": {
+      "type": "object",
+      "description": "Status of all meta-agents",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["status", "file"],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": ["active", "inactive", "deprecated"],
+            "description": "Current status of the agent"
+          },
+          "file": {
+            "type": "string",
+            "description": "Path to the agent definition file"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/fba/cli.py
+++ b/src/fba/cli.py
@@ -8,7 +8,7 @@ import click
 from fba import __version__
 from fba.gate import GateError
 from fba.schema_manager import SchemaManager
-from fba.state import StateManager
+from fba.state import StateManager, _atomic_write
 
 TEMPLATES_DIR = Path(__file__).resolve().parent.parent.parent / "templates"
 SCHEMAS_DIR = Path(__file__).resolve().parent.parent.parent / "schemas"
@@ -126,7 +126,7 @@ def _copy_registry(target: Path):
     factory_dir = target / ".factory"
     factory_dir.mkdir(parents=True, exist_ok=True)
     dest = factory_dir / "module_registry.json"
-    shutil.copy2(registry_src, dest)
+    _atomic_write(dest, registry_src.read_text())
 
 
 def _init_factory_state(target: Path):
@@ -404,7 +404,7 @@ def _init_factory_state(target: Path):
     }
 
     state_path = factory_dir / "state.json"
-    state_path.write_text(json.dumps(state, indent=2, ensure_ascii=False))
+    _atomic_write(state_path, json.dumps(state, indent=2, ensure_ascii=False))
 
 
 def _init_events_log(target: Path):

--- a/src/fba/cli.py
+++ b/src/fba/cli.py
@@ -122,6 +122,7 @@ def _copy_schemas(target: Path):
 def _copy_registry(target: Path):
     registry_src = TEMPLATES_DIR / ".factory" / "module_registry.json"
     if not registry_src.exists():
+        click.echo("Warning: Module registry not found in templates. All models will be treated as new.")
         return
     factory_dir = target / ".factory"
     factory_dir.mkdir(parents=True, exist_ok=True)

--- a/src/fba/cli.py
+++ b/src/fba/cli.py
@@ -820,7 +820,7 @@ def doctor(project_dir, verbose, json_output):
             return False, f"Not writable: {e}", "error"
 
     def _d5_check():
-        implemented_types = {"model", "view", "security_group", "access_right", "record_rule", "data"}
+        implemented_types = set(SchemaManager.IMPLEMENTED_TYPES)
         schema_path = factory_dir / "schemas" / "task_item.schema.json"
         if not schema_path.exists():
             schema_path = SCHEMAS_DIR / "task_item.schema.json"

--- a/src/fba/cli.py
+++ b/src/fba/cli.py
@@ -735,4 +735,152 @@ def _find_schema(target: Path, schema_name: str) -> Path | None:
     return None
 
 
+@main.command()
+@PROJECT_DIR_OPTION
+@click.option("--verbose", "-v", is_flag=True, help="Detailed diagnostic output")
+@click.option("--json", "json_output", is_flag=True, help="Output in JSON format (for CI)")
+def doctor(project_dir, verbose, json_output):
+    """Diagnose the health of a Factory Build Agent project.
+
+    Checks: registry health, state file integrity, writability, and schema alignment.
+    Exit codes: 0=OK (no errors or warnings), 1=warnings present, 2=errors present.
+    """
+    target = Path(project_dir).resolve() if project_dir else Path.cwd()
+    factory_dir = target / ".factory"
+
+    checks = []
+    errors = []
+    results = []
+
+    if not factory_dir.exists():
+        msg = "No .factory/ directory found. Run 'fba init' first."
+        if json_output:
+            click.echo(json.dumps({"status": "ERROR", "checks": [], "exit_code": 2, "error": msg}))
+        else:
+            click.echo(f"❌ {msg}")
+        raise SystemExit(2)
+
+    def _check(label, fn):
+        try:
+            ok, detail, severity = fn()
+            results.append({"label": label, "ok": ok, "detail": detail, "severity": severity or ("error" if not ok else "ok")})
+            if not ok:
+                if severity == "warning":
+                    checks.append(("⚠", label, detail))
+                else:
+                    errors.append(("❌", label, detail))
+        except Exception as e:
+            results.append({"label": label, "ok": False, "detail": str(e), "severity": "error"})
+            errors.append(("❌", label, str(e)))
+
+    def _d1_check():
+        try:
+            import warnings as _w
+            with _w.catch_warnings(record=True) as caught:
+                _w.simplefilter("always")
+                from fba.module_registry import ModuleRegistry
+                registry = ModuleRegistry(target)
+            reg_warnings = [str(w.message) for w in caught]
+            modules = registry.modules
+            model_count = sum(len(info.get("models", [])) for info in modules.values())
+            detail = f"{len(modules)} modules, {model_count} models"
+            if reg_warnings:
+                detail += f", warnings: {'; '.join(reg_warnings)}"
+                return False, detail, "error" if len(modules) == 0 else "warning"
+            if len(modules) == 0:
+                return False, detail + " (registry empty)", "warning"
+            return True, detail, None
+        except Exception as e:
+            return False, f"Registry error: {e}", "error"
+
+    def _d2_check():
+        state_path = factory_dir / "state.json"
+        if state_path.exists():
+            return True, f"Found at {state_path}", None
+        return False, "state.json not found", "error"
+
+    def _d3_check():
+        state_path = factory_dir / "state.json"
+        if not state_path.exists():
+            return False, "state.json does not exist", "error"
+        try:
+            data = json.loads(state_path.read_text())
+            phase = data.get("current_phase", "unknown")
+            return True, f"Valid JSON, current phase: {phase}", None
+        except json.JSONDecodeError as e:
+            return False, f"Invalid JSON: {e}", "error"
+
+    def _d4_check():
+        test_file = factory_dir / ".doctor_write_test"
+        try:
+            test_file.write_text("test")
+            test_file.unlink()
+            return True, "Writable", None
+        except Exception as e:
+            return False, f"Not writable: {e}", "error"
+
+    def _d5_check():
+        implemented_types = {"model", "view", "security_group", "access_right", "record_rule", "data"}
+        schema_path = factory_dir / "schemas" / "task_item.schema.json"
+        if not schema_path.exists():
+            schema_path = SCHEMAS_DIR / "task_item.schema.json"
+        if not schema_path.exists():
+            return True, "task_item.schema.json not found, skipping alignment check", None
+        try:
+            schema = json.loads(schema_path.read_text())
+            enum = schema.get("properties", {}).get("components", {}).get("items", {}).get("properties", {}).get("type", {}).get("enum", [])
+        except Exception:
+            return True, "Could not parse schema, skipping alignment check", None
+        unimplemented = [t for t in enum if t not in implemented_types]
+        if unimplemented:
+            return False, f"Unimplemented types: {', '.join(unimplemented)}", "warning"
+        return True, "All schema types have implementations", None
+
+    _check("registry", _d1_check)
+    _check("state_exists", _d2_check)
+    _check("state_json", _d3_check)
+    _check("writable", _d4_check)
+    _check("schema_alignment", _d5_check)
+
+    if json_output:
+        output = {
+            "status": "ERROR" if errors else ("WARNING" if checks else "OK"),
+            "checks": results,
+            "exit_code": 2 if errors else (1 if checks else 0),
+            "warnings": len(checks),
+            "errors": len(errors),
+        }
+        click.echo(json.dumps(output, indent=2, ensure_ascii=False))
+        raise SystemExit(output["exit_code"])
+
+    for symbol, label, detail in errors:
+        click.echo(f"{symbol} {label}: {detail}")
+    for symbol, label, detail in checks:
+        click.echo(f"{symbol} {label}: {detail}")
+
+    ok_count = len(results) - len(errors) - len(checks)
+    if not errors and not checks:
+        for r in results:
+            click.echo(f"✅ {r['label']}: {r['detail']}")
+    else:
+        for r in results:
+            if r["severity"] == "ok":
+                click.echo(f"✅ {r['label']}: {r['detail']}")
+
+    if verbose:
+        click.echo("")
+        click.echo("─" * 40)
+        click.echo("Verbose details:")
+        click.echo(f"  Project: {target}")
+        click.echo(f"  Factory dir: {factory_dir}")
+        for r in results:
+            click.echo(f"  [{r['severity'].upper()}] {r['label']}: {r['detail']}")
+
+    if errors:
+        raise SystemExit(2)
+    if checks:
+        raise SystemExit(1)
+    raise SystemExit(0)
+
+
 main.add_command(_schema_group)

--- a/src/fba/module_registry.py
+++ b/src/fba/module_registry.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from pathlib import Path
 
 
@@ -14,7 +15,13 @@ class ModuleRegistry:
         self._model_index: dict[str, str] = {}
 
         registry_path = self._find_registry(project_dir)
-        if registry_path:
+        if registry_path is None:
+            warnings.warn(
+                "ModuleRegistry: no se encontro archivo de registry. "
+                "Todos los modelos se trataran como nuevos.",
+                UserWarning,
+            )
+        elif registry_path:
             self._load(registry_path)
 
     def _find_registry(self, project_dir: Path | None) -> Path | None:
@@ -35,8 +42,33 @@ class ModuleRegistry:
         return None
 
     def _load(self, path: Path) -> None:
-        data = json.loads(path.read_text())
-        self._modules = data.get("modules", {})
+        try:
+            data = json.loads(path.read_text())
+        except json.JSONDecodeError as e:
+            warnings.warn(
+                f"ModuleRegistry: archivo de registry contiene JSON invalido "
+                f"({path}): {e}",
+                UserWarning,
+            )
+            return
+
+        modules_data = data.get("modules")
+        if modules_data is None or not isinstance(modules_data, dict):
+            warnings.warn(
+                f"ModuleRegistry: el archivo de registry no contiene 'modules' "
+                f"como un diccionario ({path}).",
+                UserWarning,
+            )
+            return
+
+        if not modules_data:
+            warnings.warn(
+                f"ModuleRegistry: el archivo de registry esta vacio "
+                f"(no contiene modulos).",
+                UserWarning,
+            )
+
+        self._modules = modules_data
         self._odoo_version = data.get("odoo_version", "18.0")
         self._build_index()
 

--- a/src/fba/schema_manager.py
+++ b/src/fba/schema_manager.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from fba.module_registry import ModuleRegistry
+from fba.state import _atomic_write
 
 
 @dataclass
@@ -111,8 +112,7 @@ class SchemaManager:
 
         if output_path:
             output_path = Path(output_path)
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.write_text(json.dumps(schema, indent=2, ensure_ascii=False))
+            _atomic_write(output_path, json.dumps(schema, indent=2, ensure_ascii=False))
 
         return AssemblyResult(schema, warnings=self._warnings, errors=self._errors)
 

--- a/src/fba/schema_manager.py
+++ b/src/fba/schema_manager.py
@@ -78,6 +78,7 @@ class SchemaManager:
         self.registry = ModuleRegistry(project_dir)
         self._warnings: list[AssemblyWarning] = []
         self._errors: list[AssemblyWarning] = []
+        self._emitted_warnings: set[str] = set()
 
     def assemble(self, output_path: Path | None = None) -> AssemblyResult:
         """Execute the full assembly pipeline and write schema.json.
@@ -327,6 +328,13 @@ class SchemaManager:
                 f"'{lookup['module']}' — mode set to 'extend'",
             ))
             return "extend"
+        if not self.registry.modules and "registry_empty" not in self._emitted_warnings:
+            self._emitted_warnings.add("registry_empty")
+            self._warnings.append(AssemblyWarning(
+                "warning",
+                "ModuleRegistry is empty. All models classified as 'new'.",
+                "No core modules found in registry.",
+            ))
         return "new"
 
     def _validate_relations(self, models: list[dict]) -> None:

--- a/src/fba/schema_manager.py
+++ b/src/fba/schema_manager.py
@@ -40,6 +40,10 @@ class SchemaManager:
     code rendering consumes with zero interpretation.
     """
 
+    IMPLEMENTED_TYPES = frozenset({
+        "model", "view", "security_group", "access_right", "record_rule", "data",
+    })
+
     RELATIONAL_TYPES = {"Many2one", "One2many", "Many2many"}
 
     NAMING_RULES = {
@@ -94,6 +98,8 @@ class SchemaManager:
 
         tasks_data = self._load_all_tasks(task_index)
         sdd_data = self._load_sdd()
+
+        self._detect_unknown_types(tasks_data)
 
         models = self._assemble_models(tasks_data)
         views = self._assemble_views(tasks_data)
@@ -172,6 +178,19 @@ class SchemaManager:
                 f"Path: {sdd_path}",
             ))
             return {}
+
+    def _detect_unknown_types(self, tasks_data: dict[str, dict]) -> None:
+        """Warn about component types that are in the schema enum but not yet implemented."""
+        for task_id, task in tasks_data.items():
+            for component in task.get("components", []):
+                ctype = component.get("type", "")
+                if ctype and ctype not in self.IMPLEMENTED_TYPES:
+                    self._warnings.append(AssemblyWarning(
+                        "warning",
+                        f"component type '{ctype}' is declared in schema "
+                        f"but not yet implemented by SchemaManager",
+                        f"Task: {task_id}, component: {component.get('name', 'unnamed')}",
+                    ))
 
     def _assemble_manifest(self, sdd_data: dict, task_index: dict) -> dict:
         module_name = sdd_data.get("module_name", "") or task_index.get("module_name", "unknown")

--- a/src/fba/state.py
+++ b/src/fba/state.py
@@ -1,6 +1,31 @@
 import json
+import os
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
+
+
+def _atomic_write(dest: Path, content: str) -> None:
+    """Write content atomically using temp file + fsync + os.replace.
+
+    If the process dies mid-write, the original file remains intact.
+    """
+    dest = Path(dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    fd, tmp_path = tempfile.mkstemp(dir=str(dest.parent), prefix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, str(dest))
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 class StateManager:
@@ -31,8 +56,8 @@ class StateManager:
         return json.loads(self.state_path.read_text())
 
     def save(self, state: dict) -> None:
-        self._factory_dir.mkdir(parents=True, exist_ok=True)
-        self.state_path.write_text(json.dumps(state, indent=2, ensure_ascii=False))
+        content = json.dumps(state, indent=2, ensure_ascii=False)
+        _atomic_write(self.state_path, content)
 
     def transition_to(self, phase: str, skip_gates: bool = False) -> dict:
         state = self.load()
@@ -91,6 +116,8 @@ class StateManager:
         self._factory_dir.mkdir(parents=True, exist_ok=True)
         with open(self.events_path, "a") as f:
             f.write(json.dumps(event, ensure_ascii=False) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
 
     def mark_phase(self, phase: str, status: str) -> None:
         state = self.load()

--- a/src/fba/state.py
+++ b/src/fba/state.py
@@ -81,20 +81,51 @@ class StateManager:
             if not gate_result.passed:
                 raise GateError(gate_result)
 
-        if current in state["phases"]:
-            state["phases"][current]["status"] = "complete"
+        rollback_path = self._factory_dir / ".rollback_state.json"
+        backup_made = False
+        try:
+            if self.state_path.exists():
+                rollback_path.write_text(self.state_path.read_text())
+                backup_made = True
 
-        state["current_phase"] = phase
-        if phase in state["phases"]:
-            state["phases"][phase]["status"] = "in_progress"
-        self.save(state)
+            if current in state["phases"]:
+                state["phases"][current]["status"] = "complete"
 
-        self.record_event(
-            "phase_transition",
-            {"from": current, "to": phase},
-        )
+            state["current_phase"] = phase
+            if phase in state["phases"]:
+                state["phases"][phase]["status"] = "in_progress"
+            self.save(state)
 
-        return state
+            self.record_event(
+                "phase_transition",
+                {"from": current, "to": phase},
+            )
+
+            if backup_made and rollback_path.exists():
+                rollback_path.unlink()
+
+            return state
+
+        except Exception as _exc:
+            if backup_made and rollback_path.exists():
+                try:
+                    _atomic_write(self.state_path, rollback_path.read_text())
+                    rollback_path.unlink()
+                except Exception as rollback_error:
+                    try:
+                        error_log = self._factory_dir / ".rollback_error.log"
+                        error_msg = (
+                            f"CRITICAL: Rollback failed during transition "
+                            f"'{current}' -> '{phase}'. "
+                            f"Original error: {_exc}. "
+                            f"Rollback error: {rollback_error}"
+                        )
+                        error_log.write_text(
+                            f"[{datetime.now(timezone.utc).isoformat()}] {error_msg}\n"
+                        )
+                    except OSError:
+                        pass
+            raise
 
     def has_gate_passed(self, phase: str = None) -> bool:
         if phase is None:

--- a/templates/.factory/module_registry.json
+++ b/templates/.factory/module_registry.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://opencode.ai/fba/schemas/module_registry.schema.json",
+  "odoo_version": "18.0",
+  "description": "Registry of Odoo v18 core modules and their canonical models. Used by the Schema Manager to determine new vs extend mode.",
+  "modules": {
+    "base": {
+      "description": "Core Odoo module with base models",
+      "models": [
+        "res.partner",
+        "res.users",
+        "res.company",
+        "res.country",
+        "res.country.state",
+        "res.currency",
+        "res.lang",
+        "ir.model",
+        "ir.model.fields",
+        "ir.actions.act_window",
+        "ir.actions.server",
+        "ir.ui.menu",
+        "ir.ui.view",
+        "ir.attachment",
+        "ir.config_parameter"
+      ]
+    },
+    "mail": {
+      "description": "Odoo mail and messaging module",
+      "models": [
+        "mail.message",
+        "mail.activity",
+        "mail.activity.type",
+        "mail.channel",
+        "mail.channel.member",
+        "mail.notification",
+        "mail.template"
+      ]
+    },
+    "product": {
+      "description": "Odoo product management module",
+      "models": [
+        "product.product",
+        "product.template",
+        "product.category",
+        "product.attribute",
+        "product.attribute.value",
+        "product.pricelist",
+        "product.pricelist.item",
+        "product.uom",
+        "product.uom.category",
+        "product.packaging"
+      ]
+    },
+    "sale": {
+      "description": "Odoo sales management module",
+      "models": [
+        "sale.order",
+        "sale.order.line",
+        "sale.order.template",
+        "sale.order.template.line",
+        "sale.advance.payment.inv",
+        "sale.report"
+      ]
+    },
+    "account": {
+      "description": "Odoo accounting module",
+      "models": [
+        "account.move",
+        "account.move.line",
+        "account.account",
+        "account.journal",
+        "account.payment",
+        "account.tax",
+        "account.tax.group",
+        "account.fiscal.position",
+        "account.payment.term",
+        "account.analytic.account",
+        "account.analytic.line",
+        "account.chart.template",
+        "account.financial.year"
+      ]
+    },
+    "stock": {
+      "description": "Odoo inventory and warehouse management module",
+      "models": [
+        "stock.move",
+        "stock.move.line",
+        "stock.picking",
+        "stock.picking.type",
+        "stock.location",
+        "stock.warehouse",
+        "stock.quant",
+        "stock.inventory",
+        "stock.production.lot",
+        "stock.rule",
+        "stock.package.type",
+        "stock.putaway.rule"
+      ]
+    },
+    "hr": {
+      "description": "Odoo human resources module",
+      "models": [
+        "hr.employee",
+        "hr.department",
+        "hr.job",
+        "hr.contract",
+        "hr.leave",
+        "hr.leave.type",
+        "hr.attendance",
+        "hr.expense",
+        "hr.applicant"
+      ]
+    },
+    "crm": {
+      "description": "Odoo CRM module",
+      "models": [
+        "crm.lead",
+        "crm.team",
+        "crm.stage",
+        "crm.activity.report",
+        "crm.lead.lost",
+        "crm.merge.opportunity"
+      ]
+    },
+    "web": {
+      "description": "Odoo web client core module",
+      "models": [
+        "ir.http",
+        "ir.qweb"
+      ]
+    },
+    "purchase": {
+      "description": "Odoo purchase management module",
+      "models": [
+        "purchase.order",
+        "purchase.order.line",
+        "purchase.requisition",
+        "purchase.requisition.line"
+      ]
+    },
+    "fleet": {
+      "description": "Odoo fleet management module",
+      "models": [
+        "fleet.vehicle",
+        "fleet.vehicle.model",
+        "fleet.vehicle.model.brand",
+        "fleet.vehicle.odometer",
+        "fleet.vehicle.log.contract",
+        "fleet.vehicle.log.services"
+      ]
+    },
+    "uom": {
+      "description": "Odoo unit of measure module",
+      "models": [
+        "uom.uom",
+        "uom.category"
+      ]
+    }
+  }
+}

--- a/tests/test_fba_doctor.py
+++ b/tests/test_fba_doctor.py
@@ -1,0 +1,116 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from fba.cli import main
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def healthy_project(tmp_path):
+    project_dir = tmp_path / "healthy"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+
+    state = {
+        "project": "test-project",
+        "current_phase": "init",
+        "phases": {"init": {"status": "in_progress"}},
+        "valid_transitions": {},
+        "artifacts": {},
+    }
+    (factory_dir / "state.json").write_text(json.dumps(state, indent=2))
+
+    registry_dir = factory_dir / "schemas"
+    registry_dir.mkdir(parents=True, exist_ok=True)
+
+    return project_dir
+
+
+def test_doctor_healthy_project(runner, healthy_project):
+    result = runner.invoke(main, ["doctor", "-d", str(healthy_project)])
+    assert result.exit_code in (0, 1)
+    output = result.output.lower()
+    assert "registry" in output or "state" in output or "writable" in output
+
+
+def test_doctor_state_missing(runner, tmp_path):
+    project_dir = tmp_path / "nostate"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+
+    result = runner.invoke(main, ["doctor", "-d", str(project_dir)])
+    assert result.exit_code == 2
+    assert "state" in result.output.lower()
+
+
+def test_doctor_state_invalid_json(runner, tmp_path):
+    project_dir = tmp_path / "badstate"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    (factory_dir / "state.json").write_text("{invalid")
+
+    result = runner.invoke(main, ["doctor", "-d", str(project_dir)])
+    assert result.exit_code == 2
+
+
+def test_doctor_registry_not_loading(runner, tmp_path):
+    project_dir = tmp_path / "noregistry"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    (factory_dir / "state.json").write_text(json.dumps({"current_phase": "init", "phases": {}, "valid_transitions": {}, "artifacts": {}}))
+
+    result = runner.invoke(main, ["doctor", "-d", str(project_dir)])
+    assert result.exit_code in (1, 2)
+
+
+def test_doctor_verbose_output(runner, healthy_project):
+    result = runner.invoke(main, ["doctor", "-d", str(healthy_project), "--verbose"])
+    assert result.exit_code in (0, 1, 2)
+
+
+def test_doctor_json_output(runner, healthy_project):
+    result = runner.invoke(main, ["doctor", "-d", str(healthy_project), "--json"])
+    assert result.exit_code in (0, 1)
+    data = json.loads(result.output)
+    assert "status" in data
+    assert "checks" in data
+    assert "exit_code" in data
+    assert data["exit_code"] in (0, 1)
+
+
+def test_doctor_factory_not_writable(runner, tmp_path):
+    project_dir = tmp_path / "readonly"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    state = {"current_phase": "init", "phases": {}, "valid_transitions": {}, "artifacts": {}}
+    (factory_dir / "state.json").write_text(json.dumps(state, indent=2))
+
+    os.chmod(str(factory_dir), 0o444)
+
+    try:
+        result = runner.invoke(main, ["doctor", "-d", str(project_dir)])
+    finally:
+        os.chmod(str(factory_dir), 0o755)
+
+    assert result.exit_code in (1, 2)
+
+
+def test_doctor_no_factory_dir(runner, tmp_path):
+    project_dir = tmp_path / "nofactory"
+    project_dir.mkdir()
+
+    result = runner.invoke(main, ["doctor", "-d", str(project_dir)])
+    assert result.exit_code == 2

--- a/tests/test_framework_state_schema.py
+++ b/tests/test_framework_state_schema.py
@@ -1,0 +1,198 @@
+"""Tests for framework-state schema validation."""
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "schemas" / "framework-state.schema.json"
+
+
+@pytest.fixture
+def fw_state_schema():
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+def _valid_state():
+    return {
+        "schema_version": "1.0",
+        "last_updated": "2026-05-09T00:00:00Z",
+        "last_session": {
+            "date": "2026-05-09",
+            "agent": "framework-builder",
+            "action": "test session",
+            "completed_feats": ["feat/10.1"],
+            "pending_feats": ["feat/10.2"],
+            "blockers": []
+        },
+        "active_milestone": {
+            "id": "M10",
+            "name": "Framework Meta-Development",
+            "branch": "milestone/10.0-framework-meta-dev",
+            "status": "in_progress",
+            "feats_total": 5,
+            "feats_done": 1,
+            "feats_pending": ["feat/10.2", "feat/10.3", "feat/10.4", "feat/10.5"],
+            "ready_for_user_review": False
+        },
+        "roadmap_status": {
+            "M0": "completed",
+            "M1": "completed",
+            "M5": "completed",
+            "M10": "in_progress",
+            "M6": "planned"
+        },
+        "pending_decisions": [],
+        "open_briefs": [],
+        "agents": {
+            "framework-orchestrator": {"status": "active", "file": ".opencode/agents/framework-orchestrator.md"},
+            "framework-planner":     {"status": "active", "file": ".opencode/agents/framework-planner.md"},
+            "framework-builder":     {"status": "active", "file": ".opencode/agents/framework-builder.md"}
+        }
+    }
+
+
+class TestFrameworkStateSchemaValid:
+    """Valid states must pass validation."""
+
+    def test_valid_state_passes(self, fw_state_schema):
+        jsonschema.validate(_valid_state(), fw_state_schema)
+
+    def test_with_pending_decisions_passes(self, fw_state_schema):
+        state = _valid_state()
+        state["pending_decisions"] = [
+            {
+                "id": "DEC-001",
+                "description": "Should we add multi-model support?",
+                "raised_by": "framework-planner",
+                "raised_at": "2026-05-08",
+                "status": "awaiting_user"
+            }
+        ]
+        jsonschema.validate(state, fw_state_schema)
+
+    def test_with_open_briefs_passes(self, fw_state_schema):
+        state = _valid_state()
+        state["open_briefs"] = [
+            {
+                "file": ".factory/fw-brief.md",
+                "milestone": "M10",
+                "feats_remaining": 4,
+                "status": "active"
+            }
+        ]
+        jsonschema.validate(state, fw_state_schema)
+
+    def test_with_blockers_passes(self, fw_state_schema):
+        state = _valid_state()
+        state["last_session"]["blockers"] = ["Missing dependency X"]
+        jsonschema.validate(state, fw_state_schema)
+
+
+class TestFrameworkStateSchemaMissingFields:
+    """Missing required fields must fail validation."""
+
+    def test_missing_schema_version_fails(self, fw_state_schema):
+        state = _valid_state()
+        del state["schema_version"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_missing_last_updated_fails(self, fw_state_schema):
+        state = _valid_state()
+        del state["last_updated"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_missing_last_session_fails(self, fw_state_schema):
+        state = _valid_state()
+        del state["last_session"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_missing_active_milestone_fails(self, fw_state_schema):
+        state = _valid_state()
+        del state["active_milestone"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_missing_roadmap_status_fails(self, fw_state_schema):
+        state = _valid_state()
+        del state["roadmap_status"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_missing_agents_fails(self, fw_state_schema):
+        state = _valid_state()
+        del state["agents"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_missing_last_session_date_fails(self, fw_state_schema):
+        state = _valid_state()
+        del state["last_session"]["date"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_missing_active_milestone_id_fails(self, fw_state_schema):
+        state = _valid_state()
+        del state["active_milestone"]["id"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+
+class TestFrameworkStateSchemaInvalidValues:
+    """Invalid enum values must fail validation."""
+
+    def test_invalid_milestone_status_fails(self, fw_state_schema):
+        state = _valid_state()
+        state["active_milestone"]["status"] = "unknown"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_invalid_roadmap_status_fails(self, fw_state_schema):
+        state = _valid_state()
+        state["roadmap_status"]["M6"] = "started"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_invalid_decision_status_fails(self, fw_state_schema):
+        state = _valid_state()
+        state["pending_decisions"] = [
+            {
+                "id": "DEC-001",
+                "description": "Test",
+                "raised_by": "framework-planner",
+                "raised_at": "2026-05-08",
+                "status": "in_progress"
+            }
+        ]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_invalid_brief_status_fails(self, fw_state_schema):
+        state = _valid_state()
+        state["open_briefs"] = [
+            {
+                "file": "brief.md",
+                "milestone": "M10",
+                "feats_remaining": 3,
+                "status": "paused"
+            }
+        ]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_decision_status_resolved_passes(self, fw_state_schema):
+        state = _valid_state()
+        state["pending_decisions"] = [
+            {
+                "id": "DEC-001",
+                "description": "Test",
+                "raised_by": "framework-planner",
+                "raised_at": "2026-05-08",
+                "status": "resolved"
+            }
+        ]
+        jsonschema.validate(state, fw_state_schema)

--- a/tests/test_framework_state_schema.py
+++ b/tests/test_framework_state_schema.py
@@ -43,6 +43,13 @@ def _valid_state():
             "M10": "in_progress",
             "M6": "planned"
         },
+        "roadmap_summary": [
+            {"milestone":"M0","name":"Fundacion","status":"completed","start_date":"2026-05-02","end_date":"2026-05-02"},
+            {"milestone":"M1","name":"Elicitacion","status":"completed","start_date":"2026-05-03","end_date":"2026-05-03"},
+            {"milestone":"M5","name":"Bug Fixes","status":"completed","start_date":"2026-05-06","end_date":"2026-05-08"},
+            {"milestone":"M10","name":"Meta-Development","status":"in_progress","start_date":"2026-05-09"},
+            {"milestone":"M6","name":"Optimizacion","status":"planned"}
+        ],
         "pending_decisions": [],
         "open_briefs": [],
         "agents": {
@@ -120,6 +127,12 @@ class TestFrameworkStateSchemaMissingFields:
     def test_missing_roadmap_status_fails(self, fw_state_schema):
         state = _valid_state()
         del state["roadmap_status"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(state, fw_state_schema)
+
+    def test_missing_roadmap_summary_fails(self, fw_state_schema):
+        state = _valid_state()
+        del state["roadmap_summary"]
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(state, fw_state_schema)
 

--- a/tests/test_registry_robustez.py
+++ b/tests/test_registry_robustez.py
@@ -1,0 +1,186 @@
+import json
+import warnings
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from fba.module_registry import ModuleRegistry
+from fba.schema_manager import SchemaManager
+
+
+def test_registry_missing_file_warns(tmp_path):
+    project_dir = tmp_path / "noregistry"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+
+    with patch.object(ModuleRegistry, "_find_registry", return_value=None):
+        with pytest.warns(UserWarning, match="no se encontro archivo de registry"):
+            registry = ModuleRegistry(project_dir)
+
+    assert registry.modules == {}
+    assert registry.is_core("res.partner") is False
+    assert registry.lookup("res.partner") is None
+
+
+def test_registry_empty_file_warns(tmp_path):
+    project_dir = tmp_path / "emptyreg"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    registry_path = factory_dir / "module_registry.json"
+    registry_path.write_text("{}")
+
+    with pytest.warns(UserWarning, match="no contiene 'modules'|vacio"):
+        registry = ModuleRegistry(project_dir)
+
+    assert registry.modules == {}
+
+
+def test_registry_invalid_json_warns(tmp_path):
+    project_dir = tmp_path / "badjson"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    registry_path = factory_dir / "module_registry.json"
+    registry_path.write_text("{invalid json")
+
+    with pytest.warns(UserWarning, match="JSON invalido"):
+        registry = ModuleRegistry(project_dir)
+
+    assert registry.modules == {}
+
+
+def test_registry_missing_modules_key_warns(tmp_path):
+    project_dir = tmp_path / "badschema"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    registry_path = factory_dir / "module_registry.json"
+    registry_path.write_text(json.dumps({"odoo_version": "18.0"}))
+
+    with pytest.warns(UserWarning, match="no contiene 'modules'"):
+        registry = ModuleRegistry(project_dir)
+
+    assert registry.modules == {}
+
+
+def test_registry_normal_no_warnings(tmp_path):
+    project_dir = tmp_path / "goodreg"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    registry_path = factory_dir / "module_registry.json"
+    registry_path.write_text(json.dumps({
+        "odoo_version": "18.0",
+        "modules": {
+            "base": {
+                "models": ["res.partner"]
+            }
+        }
+    }))
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        registry = ModuleRegistry(project_dir)
+    assert len(w) == 0
+
+    assert "base" in registry.modules
+    assert registry.is_core("res.partner") is True
+
+
+def test_is_core_empty_registry_returns_false(tmp_path):
+    project_dir = tmp_path / "emptycheck"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    (factory_dir / "module_registry.json").write_text("{}")
+
+    with pytest.warns(UserWarning):
+        registry = ModuleRegistry(project_dir)
+
+    assert registry.is_core("res.partner") is False
+    assert registry.is_core("nonexistent.model") is False
+    assert registry.lookup("res.partner") is None
+    assert registry.get_models("base") == []
+    assert registry.resolve_relation("res.partner") is None
+
+
+def test_copy_registry_missing_source_warns(tmp_path, capsys):
+    from fba import cli
+
+    original_templates = cli.TEMPLATES_DIR
+    temp_templates = tmp_path / "fake_templates"
+    temp_templates.mkdir()
+
+    registry_subdir = temp_templates / ".factory"
+    registry_subdir.mkdir(parents=True)
+
+    cli.TEMPLATES_DIR = temp_templates
+
+    try:
+        target = tmp_path / "target"
+        target.mkdir()
+
+        cli._copy_registry(target)
+
+        dest = target / ".factory" / "module_registry.json"
+        assert not dest.exists()
+    finally:
+        cli.TEMPLATES_DIR = original_templates
+
+
+def test_schema_manager_empty_registry_warns(tmp_path):
+    project_dir = tmp_path / "schemareg"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+
+    tasks_dir = factory_dir / "tasks"
+    tasks_dir.mkdir()
+
+    registry_path = factory_dir / "module_registry.json"
+    registry_path.write_text("{}")
+
+    index = {
+        "tasks": [
+            {
+                "id": "T001",
+                "name": "test task",
+                "file": "T001.json",
+                "order": 1,
+                "estimated_effort": "small",
+                "dependencies": [],
+            }
+        ]
+    }
+    (tasks_dir / "index.json").write_text(json.dumps(index, indent=2))
+
+    task = {
+        "id": "T001",
+        "name": "test task",
+        "description": "A test task description",
+        "components": [
+            {
+                "type": "model",
+                "name": "test.model",
+                "description": "A test model",
+                "sdd_reference": "test.model",
+                "fields": [
+                    {"name": "name", "type": "Char", "label": "Name"}
+                ],
+            }
+        ],
+        "files_to_generate": ["test.py"],
+        "dependencies": [],
+    }
+    (tasks_dir / "T001.json").write_text(json.dumps(task, indent=2))
+
+    sm = SchemaManager(project_dir)
+    result = sm.assemble()
+    assert result.success
+
+    warning_msgs = [w.message for w in result.warnings]
+    has_registry_warning = any("registry" in msg.lower() for msg in warning_msgs)
+    assert has_registry_warning, f"No registry warning found in: {warning_msgs}"

--- a/tests/test_schema_manager_unknown_types.py
+++ b/tests/test_schema_manager_unknown_types.py
@@ -1,0 +1,385 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from fba.schema_manager import SchemaManager, AssemblyWarning, AssemblyResult
+
+
+def create_task_data(task_id, components, task_name="test"):
+    return {
+        task_id: {
+            "id": task_id,
+            "name": task_name,
+            "description": f"Test task {task_id}",
+            "components": components,
+            "files_to_generate": ["test.py"],
+            "dependencies": [],
+        }
+    }
+
+
+def create_project_structure(tmp_path, models_only=True):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    tasks_dir = factory_dir / "tasks"
+    tasks_dir.mkdir()
+
+    components = [
+        {
+            "type": "model",
+            "name": "test.model",
+            "description": "A test model",
+            "sdd_reference": "test.model",
+            "fields": [{"name": "name", "type": "Char", "label": "Name"}],
+        }
+    ]
+    if not models_only:
+        components.append({
+            "type": "view",
+            "name": "test.view",
+            "description": "A test view",
+            "sdd_reference": "test.view",
+            "model": "test.model",
+            "view_type": "form",
+            "view_fields": ["name"],
+        })
+
+    task = {
+        "id": "T001",
+        "name": "test",
+        "description": "A test task description",
+        "components": components,
+        "files_to_generate": ["test.py"],
+        "dependencies": [],
+    }
+    (tasks_dir / "T001.json").write_text(json.dumps(task, indent=2))
+
+    index = {
+        "tasks": [
+            {
+                "id": "T001",
+                "name": "test",
+                "file": "T001.json",
+                "order": 1,
+                "estimated_effort": "small",
+                "dependencies": [],
+            }
+        ]
+    }
+    (tasks_dir / "index.json").write_text(json.dumps(index, indent=2))
+
+    return project_dir
+
+
+def test_implemented_types_class_constant():
+    assert hasattr(SchemaManager, "IMPLEMENTED_TYPES")
+    assert isinstance(SchemaManager.IMPLEMENTED_TYPES, (set, frozenset))
+    assert "model" in SchemaManager.IMPLEMENTED_TYPES
+    assert "view" in SchemaManager.IMPLEMENTED_TYPES
+    assert "security_group" in SchemaManager.IMPLEMENTED_TYPES
+    assert "access_right" in SchemaManager.IMPLEMENTED_TYPES
+    assert "record_rule" in SchemaManager.IMPLEMENTED_TYPES
+    assert "data" in SchemaManager.IMPLEMENTED_TYPES
+    assert "wizard" not in SchemaManager.IMPLEMENTED_TYPES
+    assert "workflow" not in SchemaManager.IMPLEMENTED_TYPES
+    assert "report" not in SchemaManager.IMPLEMENTED_TYPES
+    assert "controller" not in SchemaManager.IMPLEMENTED_TYPES
+
+
+def test_wizard_component_produces_warning(tmp_path):
+    project_dir = tmp_path / "wizardproj"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    tasks_dir = factory_dir / "tasks"
+    tasks_dir.mkdir()
+
+    index = {
+        "tasks": [
+            {
+                "id": "T001", "name": "test", "file": "T001.json",
+                "order": 1, "estimated_effort": "small", "dependencies": [],
+            }
+        ]
+    }
+    (tasks_dir / "index.json").write_text(json.dumps(index, indent=2))
+
+    task = {
+        "id": "T001",
+        "name": "test",
+        "description": "A test task with wizard",
+        "components": [
+            {
+                "type": "model", "name": "test.model",
+                "description": "A test model", "sdd_reference": "test.model",
+                "fields": [{"name": "name", "type": "Char", "label": "Name"}],
+            },
+            {
+                "type": "wizard",
+                "name": "test.wizard",
+                "description": "A test wizard component",
+                "sdd_reference": "test.wizard",
+            }
+        ],
+        "files_to_generate": ["test.py"],
+        "dependencies": [],
+    }
+    (tasks_dir / "T001.json").write_text(json.dumps(task, indent=2))
+
+    sm = SchemaManager(project_dir)
+    result = sm.assemble()
+
+    assert result.success
+    warning_msgs = result.warning_messages
+    wizard_warnings = [w for w in warning_msgs if "wizard" in w.lower() and "not yet implemented" in w.lower()]
+    assert len(wizard_warnings) >= 1, f"No wizard/not-implemented warning found in: {warning_msgs}"
+
+
+def test_workflow_component_produces_warning(tmp_path):
+    project_dir = tmp_path / "workflowproj"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    tasks_dir = factory_dir / "tasks"
+    tasks_dir.mkdir()
+
+    index = {
+        "tasks": [
+            {
+                "id": "T001", "name": "test", "file": "T001.json",
+                "order": 1, "estimated_effort": "small", "dependencies": [],
+            }
+        ]
+    }
+    (tasks_dir / "index.json").write_text(json.dumps(index, indent=2))
+
+    task = {
+        "id": "T001",
+        "name": "test",
+        "description": "A test task with workflow",
+        "components": [
+            {
+                "type": "model", "name": "test.model",
+                "description": "A test model", "sdd_reference": "test.model",
+                "fields": [{"name": "name", "type": "Char", "label": "Name"}],
+            },
+            {
+                "type": "workflow",
+                "name": "test.workflow",
+                "description": "A test workflow component",
+                "sdd_reference": "test.workflow",
+            }
+        ],
+        "files_to_generate": ["test.py"],
+        "dependencies": [],
+    }
+    (tasks_dir / "T001.json").write_text(json.dumps(task, indent=2))
+
+    sm = SchemaManager(project_dir)
+    result = sm.assemble()
+    assert result.success
+
+    workflow_warnings = [w for w in result.warning_messages if "workflow" in w.lower()]
+    assert len(workflow_warnings) >= 1
+
+
+def test_report_controller_produce_warnings(tmp_path):
+    project_dir = tmp_path / "reportproj"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    tasks_dir = factory_dir / "tasks"
+    tasks_dir.mkdir()
+
+    index = {
+        "tasks": [
+            {
+                "id": "T001", "name": "test", "file": "T001.json",
+                "order": 1, "estimated_effort": "small", "dependencies": [],
+            }
+        ]
+    }
+    (tasks_dir / "index.json").write_text(json.dumps(index, indent=2))
+
+    task = {
+        "id": "T001",
+        "name": "test",
+        "description": "A test task with multiple unknown types",
+        "components": [
+            {
+                "type": "model", "name": "test.model",
+                "description": "A test model", "sdd_reference": "test.model",
+                "fields": [{"name": "name", "type": "Char", "label": "Name"}],
+            },
+            {
+                "type": "report", "name": "test.report",
+                "description": "A report", "sdd_reference": "test.report",
+            },
+            {
+                "type": "controller", "name": "test.controller",
+                "description": "A controller", "sdd_reference": "test.controller",
+            },
+        ],
+        "files_to_generate": ["test.py"],
+        "dependencies": [],
+    }
+    (tasks_dir / "T001.json").write_text(json.dumps(task, indent=2))
+
+    sm = SchemaManager(project_dir)
+    result = sm.assemble()
+    assert result.success
+
+    unknown_warnings = [w for w in result.warning_messages if "not yet implemented" in w.lower()]
+    assert len(unknown_warnings) >= 2, f"Expected at least 2 unknown type warnings, got: {unknown_warnings}"
+
+
+def test_known_types_produce_no_unknown_warnings(tmp_path):
+    project_dir = create_project_structure(tmp_path, models_only=True)
+    sm = SchemaManager(project_dir)
+    result = sm.assemble()
+
+    unknown_warnings = [w for w in result.warning_messages if "not yet implemented" in w.lower()]
+    assert len(unknown_warnings) == 0, f"Unexpected unknown type warnings: {unknown_warnings}"
+
+
+def test_multiple_unknown_components_one_warning_each(tmp_path):
+    project_dir = tmp_path / "multiproj"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    tasks_dir = factory_dir / "tasks"
+    tasks_dir.mkdir()
+
+    index = {
+        "tasks": [
+            {
+                "id": "T001", "name": "test", "file": "T001.json",
+                "order": 1, "estimated_effort": "small", "dependencies": [],
+            }
+        ]
+    }
+    (tasks_dir / "index.json").write_text(json.dumps(index, indent=2))
+
+    task = {
+        "id": "T001",
+        "name": "test",
+        "description": "A test task with multiple unknown types",
+        "components": [
+            {
+                "type": "model", "name": "test.model",
+                "description": "A test model", "sdd_reference": "test.model",
+                "fields": [{"name": "name", "type": "Char", "label": "Name"}],
+            },
+            {
+                "type": "wizard", "name": "test.wiz1",
+                "description": "Wiz 1", "sdd_reference": "test.wiz1",
+            },
+            {
+                "type": "wizard", "name": "test.wiz2",
+                "description": "Wiz 2", "sdd_reference": "test.wiz2",
+            },
+        ],
+        "files_to_generate": ["test.py"],
+        "dependencies": [],
+    }
+    (tasks_dir / "T001.json").write_text(json.dumps(task, indent=2))
+
+    sm = SchemaManager(project_dir)
+    result = sm.assemble()
+    assert result.success
+
+    unknown_warnings = [w for w in result.warning_messages if "not yet implemented" in w.lower()]
+    assert len(unknown_warnings) >= 2, f"Expected 2 unknown type warnings (one per component), got: {unknown_warnings}"
+
+
+def test_warning_level_is_warning(tmp_path):
+    project_dir = tmp_path / "levelproj"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    tasks_dir = factory_dir / "tasks"
+    tasks_dir.mkdir()
+
+    index = {
+        "tasks": [
+            {
+                "id": "T001", "name": "test", "file": "T001.json",
+                "order": 1, "estimated_effort": "small", "dependencies": [],
+            }
+        ]
+    }
+    (tasks_dir / "index.json").write_text(json.dumps(index, indent=2))
+
+    task = {
+        "id": "T001", "name": "test",
+        "description": "A test task with wizard",
+        "components": [
+            {
+                "type": "model", "name": "test.model",
+                "description": "A test model", "sdd_reference": "test.model",
+                "fields": [{"name": "name", "type": "Char", "label": "Name"}],
+            },
+            {
+                "type": "wizard", "name": "test.wizard",
+                "description": "A test wizard", "sdd_reference": "test.wizard",
+            }
+        ],
+        "files_to_generate": ["test.py"],
+        "dependencies": [],
+    }
+    (tasks_dir / "T001.json").write_text(json.dumps(task, indent=2))
+
+    sm = SchemaManager(project_dir)
+    result = sm.assemble()
+
+    unknown_warnings = [w for w in result.warnings if "not yet implemented" in w.message.lower()]
+    assert len(unknown_warnings) >= 1
+    for w in unknown_warnings:
+        assert w.level == "warning"
+
+
+def test_assembly_result_success_remains_true(tmp_path):
+    project_dir = tmp_path / "succproj"
+    project_dir.mkdir()
+    factory_dir = project_dir / ".factory"
+    factory_dir.mkdir()
+    tasks_dir = factory_dir / "tasks"
+    tasks_dir.mkdir()
+
+    index = {
+        "tasks": [
+            {
+                "id": "T001", "name": "test", "file": "T001.json",
+                "order": 1, "estimated_effort": "small", "dependencies": [],
+            }
+        ]
+    }
+    (tasks_dir / "index.json").write_text(json.dumps(index, indent=2))
+
+    task = {
+        "id": "T001", "name": "test",
+        "description": "A test task with both known and unknown types",
+        "components": [
+            {
+                "type": "model", "name": "test.model",
+                "description": "A test model", "sdd_reference": "test.model",
+                "fields": [{"name": "name", "type": "Char", "label": "Name"}],
+            },
+            {
+                "type": "wizard", "name": "test.wizard",
+                "description": "A test wizard", "sdd_reference": "test.wizard",
+            },
+        ],
+        "files_to_generate": ["test.py"],
+        "dependencies": [],
+    }
+    (tasks_dir / "T001.json").write_text(json.dumps(task, indent=2))
+
+    sm = SchemaManager(project_dir)
+    result = sm.assemble()
+
+    assert result.success is True
+    assert len(result.schema.get("models", [])) == 1

--- a/tests/test_state_atomicity.py
+++ b/tests/test_state_atomicity.py
@@ -1,0 +1,166 @@
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from fba.state import StateManager
+
+
+def test_atomic_write_success(tmp_path):
+    dest = tmp_path / "test.json"
+    content = '{"key": "value"}'
+
+    from fba.state import _atomic_write
+
+    _atomic_write(dest, content)
+
+    assert dest.exists()
+    assert dest.read_text() == content
+
+
+def test_atomic_write_original_intact_on_write_failure(tmp_path):
+    dest = tmp_path / "test.json"
+    original_content = '{"original": true}'
+    dest.write_text(original_content)
+
+    from fba.state import _atomic_write
+
+    original_replace = os.replace
+
+    def failing_replace(src, dst):
+        raise OSError("simulated os.replace failure")
+
+    try:
+        os.replace = failing_replace
+        with pytest.raises(OSError, match="simulated os.replace failure"):
+            _atomic_write(dest, '{"new": "content"}')
+    finally:
+        os.replace = original_replace
+
+    assert dest.read_text() == original_content
+
+
+def test_atomic_write_directory_created(tmp_path):
+    dest = tmp_path / "subdir" / "nested" / "test.json"
+    content = '{"deep": "nested"}'
+
+    from fba.state import _atomic_write
+
+    assert not dest.parent.exists()
+    _atomic_write(dest, content)
+    assert dest.exists()
+    assert dest.read_text() == content
+
+
+def test_atomic_write_temp_cleaned_on_failure(tmp_path):
+    dest = tmp_path / "test.json"
+    dest.write_text('{"original": true}')
+
+    from fba.state import _atomic_write
+
+    original_replace = os.replace
+
+    def replace_but_check_temp(src, dst):
+        raise OSError("simulated failure")
+
+    try:
+        os.replace = replace_but_check_temp
+        with pytest.raises(OSError):
+            _atomic_write(dest, '{"new": "content"}')
+    finally:
+        os.replace = original_replace
+
+    json_files = list(dest.parent.glob("*.json*"))
+    for f in json_files:
+        assert not f.name.startswith(".tmp"), f"Temp file not cleaned: {f.name}"
+
+
+def test_state_manager_save_uses_atomic_write(tmp_path):
+    factory_dir = tmp_path / ".factory"
+    factory_dir.mkdir()
+    state_path = factory_dir / "state.json"
+    initial_state = {"current_phase": "init", "phases": {"init": {"status": "in_progress"}}}
+    state_path.write_text(json.dumps(initial_state, indent=2))
+
+    sm = StateManager(tmp_path)
+    new_state = {"current_phase": "elicitation", "phases": {"init": {"status": "complete"}, "elicitation": {"status": "in_progress"}}}
+
+    from fba.state import _atomic_write as original_atomic_write
+    call_count = [0]
+    called_with = [None, None]
+
+    def mock_atomic_write(dest, content):
+        call_count[0] += 1
+        called_with[0] = dest
+        called_with[1] = content
+        original_atomic_write(dest, content)
+
+    with patch("fba.state._atomic_write", side_effect=mock_atomic_write):
+        sm.save(new_state)
+
+    assert call_count[0] == 1
+    assert called_with[0] == state_path
+    parsed = json.loads(called_with[1])
+    assert parsed["current_phase"] == "elicitation"
+
+
+def test_record_event_uses_append_with_fsync(tmp_path):
+    factory_dir = tmp_path / ".factory"
+    factory_dir.mkdir()
+    state_path = factory_dir / "state.json"
+    state_path.write_text(json.dumps({"current_phase": "init"}))
+
+    sm = StateManager(tmp_path)
+
+    events_path = sm.events_path
+    with patch("os.fsync") as mock_fsync:
+        sm.record_event("test_event", {"key": "value"})
+
+    assert events_path.exists()
+    content = events_path.read_text().strip()
+    assert content
+    parsed = json.loads(content)
+    assert parsed["type"] == "test_event"
+    assert parsed["data"] == {"key": "value"}
+
+
+def test_state_manager_save_does_not_leave_temp_files(tmp_path):
+    factory_dir = tmp_path / ".factory"
+    factory_dir.mkdir()
+    state_path = factory_dir / "state.json"
+    state_path.write_text(json.dumps({"current_phase": "init"}))
+
+    sm = StateManager(tmp_path)
+    sm.save({"current_phase": "elicitation"})
+
+    temp_files = list(factory_dir.glob(".tmp*"))
+    assert len(temp_files) == 0, f"Temp files left: {[f.name for f in temp_files]}"
+
+
+def test_concurrent_writes_no_corruption(tmp_path):
+    dest = tmp_path / "concurrent.json"
+    dest.write_text(json.dumps({"initial": True}))
+
+    from fba.state import _atomic_write
+
+    original_replace = os.replace
+    stages = {"rename_count": 0, "allow": False}
+
+    def staged_replace(src, dst):
+        stages["rename_count"] += 1
+        if not stages["allow"]:
+            raise OSError("simulated race: rename failed")
+        original_replace(src, dst)
+
+    try:
+        os.replace = staged_replace
+        with pytest.raises(OSError):
+            _atomic_write(dest, json.dumps({"corrupted": "partial"}))
+
+        assert dest.read_text() == json.dumps({"initial": True})
+    finally:
+        os.replace = original_replace

--- a/tests/test_state_rollback.py
+++ b/tests/test_state_rollback.py
@@ -1,0 +1,167 @@
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from fba.state import StateManager
+
+
+def _init_project_dir(tmp_path):
+    factory_dir = tmp_path / ".factory"
+    factory_dir.mkdir()
+    state = {
+        "current_phase": "init",
+        "phases": {
+            "init": {"status": "in_progress"},
+            "elicitation": {"status": "pending"},
+        },
+        "valid_transitions": {"init": ["elicitation"]},
+        "artifacts": {},
+    }
+    (factory_dir / "state.json").write_text(json.dumps(state, indent=2))
+    return tmp_path, state
+
+
+def test_transition_success_no_residual_rollback_files(tmp_path):
+    project_dir, _ = _init_project_dir(tmp_path)
+    sm = StateManager(project_dir)
+
+    result = sm.transition_to("elicitation", skip_gates=True)
+
+    assert result["current_phase"] == "elicitation"
+    assert sm.current_phase == "elicitation"
+
+    events_content = sm.events_path.read_text().strip()
+    assert "phase_transition" in events_content
+
+    backup_files = list(sm._factory_dir.glob(".rollback*"))
+    assert len(backup_files) == 0, f"Residual rollback files: {backup_files}"
+
+
+def test_transition_records_event_after_save(tmp_path):
+    project_dir, _ = _init_project_dir(tmp_path)
+    sm = StateManager(project_dir)
+
+    result = sm.transition_to("elicitation", skip_gates=True)
+
+    events = sm.events_path.read_text().strip().split("\n")
+    assert len(events) == 1
+    event = json.loads(events[0])
+    assert event["type"] == "phase_transition"
+    assert event["data"]["from"] == "init"
+    assert event["data"]["to"] == "elicitation"
+
+
+def test_rollback_on_record_event_failure(tmp_path):
+    project_dir, original_state = _init_project_dir(tmp_path)
+    sm = StateManager(project_dir)
+
+    with patch.object(sm, "record_event", side_effect=OSError("simulated disk full")):
+        with pytest.raises(OSError, match="simulated disk full"):
+            sm.transition_to("elicitation", skip_gates=True)
+
+    state_after = sm.load()
+    assert state_after["current_phase"] == "init"
+    assert state_after["phases"]["init"]["status"] == "in_progress"
+    assert state_after["phases"]["elicitation"]["status"] == "pending"
+
+    json_after = sm.state_path.read_text()
+    assert json.loads(json_after)["current_phase"] == "init"
+
+
+def test_no_state_modification_on_gate_error(tmp_path):
+    project_dir, original_state = _init_project_dir(tmp_path)
+    sm = StateManager(project_dir)
+
+    from fba.gate import GateResult, GateError
+
+    gate_result = GateResult(
+        passed=False,
+        phase="init",
+        description="test gate",
+        results=[],
+        owner_agent="test",
+    )
+
+    with patch("fba.gate.GateRunner") as mock_runner:
+        mock_instance = mock_runner.return_value
+        mock_instance.check_phase.return_value = gate_result
+
+        with pytest.raises(GateError):
+            sm.transition_to("elicitation", skip_gates=False)
+
+    state_after = sm.load()
+    assert state_after["current_phase"] == "init"
+
+
+def test_no_state_modification_on_invalid_transition(tmp_path):
+    project_dir, _ = _init_project_dir(tmp_path)
+    sm = StateManager(project_dir)
+
+    with pytest.raises(ValueError, match="Invalid transition"):
+        sm.transition_to("documentation", skip_gates=True)
+
+    state_after = sm.load()
+    assert state_after["current_phase"] == "init"
+
+
+def test_consecutive_transitions_no_residual_artifacts(tmp_path):
+    project_dir, _ = _init_project_dir(tmp_path)
+    sm = StateManager(project_dir)
+
+    state = sm.load()
+    state["valid_transitions"]["elicitation"] = ["documentation"]
+    state["phases"]["documentation"] = {"status": "pending"}
+    sm.save(state)
+
+    sm.transition_to("elicitation", skip_gates=True)
+    sm.transition_to("documentation", skip_gates=True)
+
+    assert sm.current_phase == "documentation"
+
+    backup_files = list(sm._factory_dir.glob(".rollback*"))
+    assert len(backup_files) == 0, f"Residual rollback files: {backup_files}"
+
+
+def test_rollback_restores_exact_state_content(tmp_path):
+    project_dir, _ = _init_project_dir(tmp_path)
+    sm = StateManager(project_dir)
+
+    original_json = sm.state_path.read_text()
+
+    with patch.object(sm, "record_event", side_effect=OSError("disk error")):
+        with pytest.raises(OSError):
+            sm.transition_to("elicitation", skip_gates=True)
+
+    restored_json = sm.state_path.read_text()
+    assert original_json == restored_json
+
+
+def test_rollback_error_logged_on_restore_failure(tmp_path):
+    project_dir, _ = _init_project_dir(tmp_path)
+    sm = StateManager(project_dir)
+
+    original_replace = os.replace
+
+    call_count = [0]
+
+    def failing_replace(src, dst):
+        call_count[0] += 1
+        if call_count[0] > 1:
+            raise OSError("simulated rollback failure")
+        original_replace(src, dst)
+
+    try:
+        os.replace = failing_replace
+        with patch.object(sm, "record_event", side_effect=OSError("disk error")):
+            with pytest.raises(OSError, match="disk error"):
+                sm.transition_to("elicitation", skip_gates=True)
+    finally:
+        os.replace = original_replace
+
+    error_log = sm._factory_dir / ".rollback_error.log"
+    assert error_log.exists(), "Rollback error log should exist"
+    content = error_log.read_text()
+    assert "rollback" in content.lower()


### PR DESCRIPTION
## Resumen

M11 Foundation Hardening (Capa 1) — 5 feats implementados y validados:

| # | Feat | Issue | Descripción |
|---|------|-------|-------------|
| 1 | Atomic writes | #106 | `_atomic_write()` con temp file + fsync + os.replace |
| 2 | Rollback state | #107 | Rollback atómico en `transition_to()` si falla record_event |
| 3 | Registry robustez | #108 | `ModuleRegistry` con warnings explícitos en 5 escenarios de error |
| 4 | `fba doctor` | #109 | Comando de diagnóstico con 5 checks y exit codes 0/1/2 |
| 5 | Wizard schema alignment | #110 | `IMPLEMENTED_TYPES` + AssemblyWarning para tipos no implementados |

## Validación

✅ **493/493 tests pasando** (0 fallos, 1 warning esperado)
✅ **453/453 tests de regresión** pasando (pre-M11)
✅ ROADMAP.md actualizado: M11 marcado ✅ Completado (2026-05-12)
✅ CHANGELOG.md actualizado: entrada de cierre M11 en v0.7.0
✅ `docs/testing/m11-foundation-hardening.md` incluido

## Commits

14 commits en el branch (5 PRs mergeados + documentación + cierre)