### PR TITLE
feat(#118): Diff Engine Core para artefactos JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,8 +189,9 @@ See [ROADMAP.md](ROADMAP.md) for full milestone details and progress tracking.
 - **M4: Gates System** — COMPLETED. Declarative gate system, artifact reviewer, semantic validator.
 - **M5: Bug Fixes & Stability** — COMPLETED. Post-release fixes and stabilization.
 - **M10: Framework Meta-Development** — COMPLETED. Meta-agents for autonomous framework development.
-- **M11: Foundation Hardening** — IN PROGRESS. Bug fixes (#2, #7, #9, #10) and `fba doctor`.
-  M12-M15 will be implemented sequentially after M11 (replaces M6-M9 — see ROADMAP.md).
+- **M11: Foundation Hardening** — COMPLETED. Atomic writes, rollback, registry robustness, `fba doctor`, schema alignment.
+- **M12: Diff, Dependencies & Trazabilidad** — IN PROGRESS. Diff engine for JSON artifacts, artifact contracts with invariants, Odoo dependency integrity analysis, stable IDs (UUID v4) foundation.
+  M13-M15 will be implemented sequentially after M12 (replaces M6-M9 — see ROADMAP.md).
 
 ## Tech Stack
 

--- a/src/fba/cli.py
+++ b/src/fba/cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import click
 
 from fba import __version__
+from fba.diff_engine import DiffEngine, DiffError
 from fba.gate import GateError
 from fba.schema_manager import SchemaManager
 from fba.state import StateManager, _atomic_write
@@ -881,6 +882,29 @@ def doctor(project_dir, verbose, json_output):
     if checks:
         raise SystemExit(1)
     raise SystemExit(0)
+
+
+@main.command()
+@click.argument("file_v1", type=click.Path(exists=True, path_type=Path))
+@click.argument("file_v2", type=click.Path(exists=True, path_type=Path))
+@click.option("--format", "-f", "output_format", type=click.Choice(["text", "json"]), default="text", help="Output format (text or json)")
+def diff(file_v1, file_v2, output_format):
+    """Compare two JSON artifact versions and produce a structured changelog.
+
+    FILE_V1 is the older version, FILE_V2 is the newer version.
+    Supports PRD, SDD, schema.json, tasks/index.json, and T*.json artifacts.
+
+    \b
+    Examples:
+      fba diff v1/prd.json v2/prd.json
+      fba diff old/sdd.json new/sdd.json --format json
+    """
+    try:
+        result = DiffEngine.diff(file_v1, file_v2, output_format=output_format)
+        click.echo(result)
+    except DiffError as e:
+        click.echo(f"Error: {e}", err=True)
+        raise SystemExit(1)
 
 
 main.add_command(_schema_group)

--- a/src/fba/diff_engine.py
+++ b/src/fba/diff_engine.py
@@ -1,0 +1,290 @@
+"""Diff engine for comparing JSON artifacts from the FBA pipeline.
+
+Compares two versions of an artifact (PRD, SDD, schema.json, tasks/index.json,
+T*.json) and produces a structured changelog listing additions, deletions, and
+modifications with field/section granularity.
+"""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+
+class DiffError(Exception):
+    """Raised when diff comparison fails."""
+
+
+class DiffEngine:
+    """Compares two JSON artifacts and produces deterministic changelogs.
+
+    Supports PRD, SDD, schema.json, tasks/index.json, and T*.json artifacts.
+    Output formats: text (human-readable) and json (machine-readable).
+
+    Usage:
+        engine = DiffEngine()
+        changelog = engine.diff(Path("v1/prd.json"), Path("v2/prd.json"))
+        print(changelog)
+    """
+
+    ARTIFACT_SIGNATURES = {
+        "prd": ["vision", "stakeholders", "functional_requirements"],
+        "sdd": ["module_name", "models", "traceability_matrix"],
+        "schema": ["manifest", "models", "views"],
+        "tasks_index": ["tasks", "generated_at"],
+    }
+
+    @staticmethod
+    def detect_artifact_type(data: dict) -> str:
+        """Detect the artifact type from its top-level keys.
+
+        Returns one of: prd, sdd, schema, tasks_index, task_item, unknown.
+        """
+        if not isinstance(data, dict):
+            return "unknown"
+        keys = set(data.keys())
+
+        if keys >= {"vision", "stakeholders", "functional_requirements"}:
+            return "prd"
+        if keys >= {"module_name", "architecture", "models"}:
+            return "sdd"
+        if keys >= {"manifest", "models"} and ("views" in keys or "security" in keys):
+            return "schema"
+        if keys >= {"tasks", "generated_at"}:
+            return "tasks_index"
+        if "component" in keys and "task_id" in keys:
+            return "task_item"
+
+        return "unknown"
+
+    @staticmethod
+    def diff(
+        file_v1: Path,
+        file_v2: Path,
+        output_format: str = "text",
+    ) -> str:
+        """Compare two artifact files and return a structured changelog.
+
+        Args:
+            file_v1: Path to the older version of the artifact (JSON).
+            file_v2: Path to the newer version of the artifact (JSON).
+            output_format: 'text' for human-readable or 'json' for machine-readable.
+
+        Returns:
+            Formatted changelog string.
+
+        Raises:
+            DiffError: If a file does not exist or contains invalid JSON.
+        """
+        if not file_v1.exists():
+            raise DiffError(f"File not found: {file_v1}")
+        if not file_v2.exists():
+            raise DiffError(f"File not found: {file_v2}")
+
+        try:
+            data_v1 = json.loads(file_v1.read_text())
+        except json.JSONDecodeError as e:
+            raise DiffError(f"Invalid JSON in {file_v1}: {e}")
+
+        try:
+            data_v2 = json.loads(file_v2.read_text())
+        except json.JSONDecodeError as e:
+            raise DiffError(f"Invalid JSON in {file_v2}: {e}")
+
+        artifact_type = DiffEngine.detect_artifact_type(data_v2) or DiffEngine.detect_artifact_type(data_v1)
+
+        changes = DiffEngine._deep_diff(data_v1, data_v2)
+
+        added = changes["added"]
+        removed = changes["removed"]
+        modified = changes["modified"]
+
+        changelog = {
+            "artifact_type": artifact_type,
+            "version_old": str(file_v1),
+            "version_new": str(file_v2),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "changes": {
+                "added": added,
+                "removed": removed,
+                "modified": modified,
+            },
+            "summary": {
+                "total_changes": len(added) + len(removed) + len(modified),
+                "added_count": len(added),
+                "removed_count": len(removed),
+                "modified_count": len(modified),
+            },
+        }
+
+        if output_format == "json":
+            return DiffEngine._format_json(changelog)
+        return DiffEngine._format_text(changelog)
+
+    @staticmethod
+    def _deep_diff(
+        old: Any,
+        new: Any,
+        path: str = "$",
+    ) -> dict:
+        """Recursively compare two JSON values.
+
+        Returns a dict with 'added', 'removed', and 'modified' lists.
+        Each change entry has a 'path' (JSONPath-like) and relevant values.
+
+        For arrays of objects, matches elements by 'id' field when available,
+        otherwise compares by index.
+        """
+        result: dict[str, list] = {"added": [], "removed": [], "modified": []}
+
+        if type(old) != type(new):
+            result["modified"].append({
+                "path": path,
+                "old_value": old,
+                "new_value": new,
+            })
+            return result
+
+        if isinstance(old, dict):
+            old_keys = set(old.keys())
+            new_keys = set(new.keys())
+
+            for key in old_keys - new_keys:
+                result["removed"].append({
+                    "path": f"{path}.{key}" if path != "$" else f"$.{key}",
+                    "value": old[key],
+                })
+
+            for key in new_keys - old_keys:
+                result["added"].append({
+                    "path": f"{path}.{key}" if path != "$" else f"$.{key}",
+                    "value": new[key],
+                })
+
+            for key in old_keys & new_keys:
+                child_path = f"{path}.{key}" if path != "$" else f"$.{key}"
+                child_changes = DiffEngine._deep_diff(old[key], new[key], child_path)
+                result["added"].extend(child_changes["added"])
+                result["removed"].extend(child_changes["removed"])
+                result["modified"].extend(child_changes["modified"])
+
+        elif isinstance(old, list):
+            old_indexed = DiffEngine._index_array(old)
+            new_indexed = DiffEngine._index_array(new)
+
+            old_ids = set(old_indexed.keys())
+            new_ids = set(new_indexed.keys())
+
+            for idx in old_ids - new_ids:
+                result["removed"].append({
+                    "path": f"{path}[{idx}]",
+                    "value": old_indexed[idx]["value"],
+                })
+
+            for idx in new_ids - old_ids:
+                result["added"].append({
+                    "path": f"{path}[{idx}]",
+                    "value": new_indexed[idx]["value"],
+                })
+
+            for idx in old_ids & new_ids:
+                old_idx = old_indexed[idx]["index"]
+                new_idx = new_indexed[idx]["index"]
+                child_path = f"{path}[{old_idx}]"
+                child_changes = DiffEngine._deep_diff(
+                    old[old_idx], new[new_idx], child_path
+                )
+                result["added"].extend(child_changes["added"])
+                result["removed"].extend(child_changes["removed"])
+                result["modified"].extend(child_changes["modified"])
+
+        else:
+            if old != new:
+                result["modified"].append({
+                    "path": path,
+                    "old_value": old,
+                    "new_value": new,
+                })
+
+        return result
+
+    @staticmethod
+    def _index_array(arr: list) -> dict:
+        """Index an array for comparison.
+
+        Arrays of dicts with an 'id' field are indexed by id.
+        Other arrays are indexed by position (0, 1, 2, ...).
+        """
+        indexed = {}
+        for i, item in enumerate(arr):
+            if isinstance(item, dict) and "id" in item:
+                key = str(item["id"])
+            else:
+                key = str(i)
+            indexed[key] = {"index": i, "value": item}
+        return indexed
+
+    @staticmethod
+    def _format_text(changelog: dict) -> str:
+        """Format changelog as human-readable text."""
+        lines = []
+        lines.append(f"=== Diff: {changelog['artifact_type']} ===")
+        lines.append(f"Old: {changelog['version_old']}")
+        lines.append(f"New: {changelog['version_new']}")
+        lines.append(f"Time: {changelog['timestamp']}")
+        lines.append("")
+
+        changes = changelog["changes"]
+        if changes["added"]:
+            lines.append("Added:")
+            for entry in changes["added"]:
+                value_str = DiffEngine._truncate_value(entry["value"])
+                lines.append(f"  + {entry['path']}: {value_str}")
+            lines.append("")
+
+        if changes["removed"]:
+            lines.append("Removed:")
+            for entry in changes["removed"]:
+                value_str = DiffEngine._truncate_value(entry["value"])
+                lines.append(f"  - {entry['path']}: {value_str}")
+            lines.append("")
+
+        if changes["modified"]:
+            lines.append("Modified:")
+            for entry in changes["modified"]:
+                old_str = DiffEngine._truncate_value(entry["old_value"])
+                new_str = DiffEngine._truncate_value(entry["new_value"])
+                lines.append(f"  ~ {entry['path']}: {old_str} → {new_str}")
+            lines.append("")
+
+        summary = changelog["summary"]
+        total = summary["total_changes"]
+        if total == 0:
+            lines.append("No changes detected.")
+        else:
+            parts = []
+            if summary["added_count"]:
+                parts.append(f"{summary['added_count']} added")
+            if summary["removed_count"]:
+                parts.append(f"{summary['removed_count']} removed")
+            if summary["modified_count"]:
+                parts.append(f"{summary['modified_count']} modified")
+            lines.append(f"Summary: {total} changes ({', '.join(parts)})")
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def _format_json(changelog: dict) -> str:
+        """Format changelog as a deterministic JSON string."""
+        return json.dumps(changelog, indent=2, ensure_ascii=False, sort_keys=True)
+
+    @staticmethod
+    def _truncate_value(value: Any, max_len: int = 60) -> str:
+        """Truncate a value for display in text output."""
+        if isinstance(value, (dict, list)):
+            s = json.dumps(value, ensure_ascii=False)
+        else:
+            s = str(value)
+        if len(s) > max_len:
+            return s[: max_len - 3] + "..."
+        return s

--- a/tests/test_diff_engine.py
+++ b/tests/test_diff_engine.py
@@ -1,0 +1,527 @@
+"""Tests for the DiffEngine — JSON artifact comparison and changelog generation."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from fba.diff_engine import DiffEngine, DiffError
+
+
+def _write_json(path: Path, data: dict):
+    path.write_text(json.dumps(data))
+
+
+def _make_prd(requirements=None, stakeholders=None):
+    """Create a minimal PRD artifact."""
+    return {
+        "vision": "A test product.",
+        "stakeholders": stakeholders if stakeholders is not None else [
+            {"name": "Alice", "role": "PM", "interest": "Success"},
+        ],
+        "objectives": ["Obj 1"],
+        "functional_requirements": requirements if requirements is not None else [
+            {"id": "RF-001", "description": "Login screen"},
+        ],
+        "non_functional_requirements": [],
+        "acceptance_criteria": [],
+        "glossary": [],
+    }
+
+
+def _make_sdd(models=None):
+    """Create a minimal SDD artifact."""
+    return {
+        "module_name": "test_module",
+        "module_display_name": "Test Module",
+        "version": "18.0.1.0.0",
+        "architecture": {"description": "A test architecture."},
+        "models": models if models is not None else [
+            {"name": "test.model", "description": "A test model."},
+        ],
+        "views": [],
+        "security": {},
+        "dependencies": [],
+        "file_structure": [],
+        "traceability_matrix": {"mappings": []},
+    }
+
+
+def _make_schema(models=None):
+    """Create a minimal Odoo schema.json artifact."""
+    return {
+        "manifest": {
+            "name": "test_module",
+            "version": "18.0.1.0.0",
+            "depends": ["base"],
+        },
+        "models": models if models is not None else [
+            {"name": "test.model", "fields": [{"name": "name", "type": "char"}]},
+        ],
+        "views": [],
+        "security": {"groups": [], "access_rights": [], "record_rules": []},
+        "data": [],
+    }
+
+
+def _make_tasks_index(tasks=None):
+    """Create a minimal tasks/index.json artifact."""
+    return {
+        "tasks": tasks if tasks is not None else [
+            {"id": "T001", "task_id": "T001", "phase": "construction", "status": "pending"},
+        ],
+        "generated_at": "2026-01-01T00:00:00Z",
+        "total_tasks": len(tasks) if tasks is not None else 1,
+    }
+
+
+class TestDiffEngineIdentical:
+    """Tests for comparing identical artifacts."""
+
+    def test_identical_prd_empty_changelog(self, tmp_path):
+        prd = _make_prd()
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, prd)
+        _write_json(v2, prd)
+
+        result = DiffEngine.diff(v1, v2, output_format="text")
+
+        assert "No changes detected" in result
+        assert "Diff: prd" in result
+
+    def test_identical_sdd_empty_changelog(self, tmp_path):
+        sdd = _make_sdd()
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, sdd)
+        _write_json(v2, sdd)
+
+        result = DiffEngine.diff(v1, v2, output_format="text")
+
+        assert "No changes detected" in result
+        assert "Diff: sdd" in result
+
+    def test_identical_schema_empty_changelog(self, tmp_path):
+        schema = _make_schema()
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, schema)
+        _write_json(v2, schema)
+
+        result = DiffEngine.diff(v1, v2, output_format="text")
+
+        assert "No changes detected" in result
+        assert "Diff: schema" in result
+
+    def test_identical_json_output(self, tmp_path):
+        prd = _make_prd()
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, prd)
+        _write_json(v2, prd)
+
+        result = DiffEngine.diff(v1, v2, output_format="json")
+        data = json.loads(result)
+
+        assert data["summary"]["total_changes"] == 0
+        assert data["artifact_type"] == "prd"
+        assert data["changes"]["added"] == []
+        assert data["changes"]["removed"] == []
+        assert data["changes"]["modified"] == []
+
+
+class TestDiffEngineAdditions:
+    """Tests for detecting additions."""
+
+    def test_prd_requirement_added(self, tmp_path):
+        prd_v1 = _make_prd(requirements=[{"id": "RF-001", "description": "Login"}])
+        prd_v2 = _make_prd(requirements=[
+            {"id": "RF-001", "description": "Login"},
+            {"id": "RF-002", "description": "Logout"},
+        ])
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, prd_v1)
+        _write_json(v2, prd_v2)
+
+        result = DiffEngine.diff(v1, v2, output_format="text")
+
+        assert "Added:" in result
+        assert "RF-002" in result
+        assert "Logout" in result
+
+    def test_sdd_model_added(self, tmp_path):
+        sdd_v1 = _make_sdd(models=[{"name": "model.one", "description": "First"}])
+        sdd_v2 = _make_sdd(models=[
+            {"name": "model.one", "description": "First"},
+            {"name": "model.two", "description": "Second"},
+        ])
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, sdd_v1)
+        _write_json(v2, sdd_v2)
+
+        result = DiffEngine.diff(v1, v2, output_format="text")
+
+        assert "Added:" in result
+        assert "model.two" in result
+
+    def test_tasks_index_task_added(self, tmp_path):
+        idx_v1 = _make_tasks_index(tasks=[
+            {"id": "T001", "task_id": "T001", "phase": "construction", "status": "pending"},
+        ])
+        idx_v2 = _make_tasks_index(tasks=[
+            {"id": "T001", "task_id": "T001", "phase": "construction", "status": "pending"},
+            {"id": "T002", "task_id": "T002", "phase": "construction", "status": "pending"},
+        ])
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, idx_v1)
+        _write_json(v2, idx_v2)
+
+        result = DiffEngine.diff(v1, v2, output_format="text")
+
+        assert "Added:" in result
+        assert "T002" in result
+
+
+class TestDiffEngineRemovals:
+    """Tests for detecting removals."""
+
+    def test_prd_requirement_removed(self, tmp_path):
+        prd_v1 = _make_prd(requirements=[
+            {"id": "RF-001", "description": "Login"},
+            {"id": "RF-002", "description": "Logout"},
+        ])
+        prd_v2 = _make_prd(requirements=[{"id": "RF-001", "description": "Login"}])
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, prd_v1)
+        _write_json(v2, prd_v2)
+
+        result = DiffEngine.diff(v1, v2, output_format="text")
+
+        assert "Removed:" in result
+        assert "RF-002" in result
+
+    def test_prd_stakeholder_removed(self, tmp_path):
+        prd_v1 = _make_prd(stakeholders=[
+            {"name": "Alice", "role": "PM", "interest": "Success"},
+            {"name": "Bob", "role": "Dev", "interest": "Code"},
+        ])
+        prd_v2 = _make_prd(stakeholders=[{"name": "Alice", "role": "PM", "interest": "Success"}])
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, prd_v1)
+        _write_json(v2, prd_v2)
+
+        result = DiffEngine.diff(v1, v2, output_format="text")
+
+        assert "Removed:" in result
+        assert "Bob" in result
+
+
+class TestDiffEngineModifications:
+    """Tests for detecting modifications."""
+
+    def test_prd_requirement_modified(self, tmp_path):
+        prd_v1 = _make_prd(requirements=[{"id": "RF-001", "description": "Login"}])
+        prd_v2 = _make_prd(requirements=[{"id": "RF-001", "description": "Login with SSO"}])
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, prd_v1)
+        _write_json(v2, prd_v2)
+
+        result = DiffEngine.diff(v1, v2, output_format="text")
+
+        assert "Modified:" in result
+        assert "SSO" in result
+
+    def test_schema_field_type_changed(self, tmp_path):
+        schema_v1 = _make_schema(models=[
+            {"name": "test.model", "fields": [{"name": "age", "type": "integer"}]},
+        ])
+        schema_v2 = _make_schema(models=[
+            {"name": "test.model", "fields": [{"name": "age", "type": "float"}]},
+        ])
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, schema_v1)
+        _write_json(v2, schema_v2)
+
+        result = DiffEngine.diff(v1, v2, output_format="text")
+
+        assert "Modified:" in result
+        assert "integer" in result.replace('"integer"', '"integer"') or "integer" in result
+        assert "float" in result
+
+    def test_prd_vision_modified(self, tmp_path):
+        prd_v1 = _make_prd()
+        prd_v1["vision"] = "Old vision"
+        prd_v2 = _make_prd()
+        prd_v2["vision"] = "New vision"
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, prd_v1)
+        _write_json(v2, prd_v2)
+
+        result = DiffEngine.diff(v1, v2, output_format="text")
+
+        assert "Modified:" in result
+        assert "Old vision" in result
+        assert "New vision" in result
+
+
+class TestDiffEngineOutputFormats:
+    """Tests for output format options."""
+
+    def test_text_output_format(self, tmp_path):
+        prd_v1 = _make_prd(requirements=[{"id": "RF-001", "description": "Login"}])
+        prd_v2 = _make_prd(requirements=[{"id": "RF-001", "description": "Login"}, {"id": "RF-002", "description": "Logout"}])
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, prd_v1)
+        _write_json(v2, prd_v2)
+
+        result = DiffEngine.diff(v1, v2, output_format="text")
+
+        assert "=== Diff: prd ===" in result
+        assert "Added:" in result
+        assert "Summary:" in result
+        assert "1 added" in result
+
+    def test_json_output_format(self, tmp_path):
+        prd_v1 = _make_prd(requirements=[{"id": "RF-001", "description": "Login"}])
+        prd_v2 = _make_prd(requirements=[{"id": "RF-001", "description": "Login"}, {"id": "RF-002", "description": "Logout"}])
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, prd_v1)
+        _write_json(v2, prd_v2)
+
+        result = DiffEngine.diff(v1, v2, output_format="json")
+        data = json.loads(result)
+
+        assert data["artifact_type"] == "prd"
+        assert data["summary"]["total_changes"] == 1
+        assert data["summary"]["added_count"] == 1
+        assert len(data["changes"]["added"]) == 1
+        assert data["changes"]["added"][0]["path"].startswith("$.")
+        assert "RF-002" in data["changes"]["added"][0]["path"]
+
+    def test_json_output_is_valid_json(self, tmp_path):
+        prd = _make_prd()
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, prd)
+        _write_json(v2, prd)
+
+        result = DiffEngine.diff(v1, v2, output_format="json")
+
+        data = json.loads(result)
+        assert "artifact_type" in data
+        assert "timestamp" in data
+        assert "changes" in data
+        assert "summary" in data
+
+
+class TestDiffEngineErrorHandling:
+    """Tests for error handling."""
+
+    def test_non_existent_file(self, tmp_path):
+        v1 = tmp_path / "does_not_exist.json"
+        v2 = tmp_path / "exists.json"
+        _write_json(v2, _make_prd())
+
+        with pytest.raises(DiffError, match="File not found"):
+            DiffEngine.diff(v1, v2)
+
+    def test_malformed_json(self, tmp_path):
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        v1.write_text('{"valid": true}')
+        v2.write_text('{"invalid": }')
+
+        with pytest.raises(DiffError, match="Invalid JSON"):
+            DiffEngine.diff(v1, v2)
+
+    def test_non_json_content_raises_differror(self, tmp_path):
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        v1.write_text("not json at all")
+        v2.write_text('{"valid": true}')
+
+        with pytest.raises(DiffError, match="Invalid JSON"):
+            DiffEngine.diff(v1, v2)
+
+    def test_empty_file_raises_differror(self, tmp_path):
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        v1.write_text("")
+        v2.write_text('{"valid": true}')
+
+        with pytest.raises(DiffError, match="Invalid JSON"):
+            DiffEngine.diff(v1, v2)
+
+
+class TestDiffEngineEdgeCases:
+    """Tests for edge cases and array handling."""
+
+    def test_arrays_without_id_indexed_by_position(self, tmp_path):
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        data_v1 = {"items": ["a", "b", "c"]}
+        data_v2 = {"items": ["a", "x", "c"]}
+        _write_json(v1, data_v1)
+        _write_json(v2, data_v2)
+
+        result = DiffEngine.diff(v1, v2, output_format="text")
+
+        assert "Modified:" in result
+        assert "b" in result or "x" in result
+
+    def test_arrays_with_id_matched_by_id(self, tmp_path):
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        data_v1 = {"reqs": [{"id": "A", "val": 1}, {"id": "B", "val": 2}]}
+        data_v2 = {"reqs": [{"id": "B", "val": 2}, {"id": "A", "val": 10}]}
+        _write_json(v1, data_v1)
+        _write_json(v2, data_v2)
+
+        result = DiffEngine.diff(v1, v2, output_format="text")
+
+        assert "Modified:" in result
+        assert "Modified:" in result
+
+    def test_top_level_key_added(self, tmp_path):
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, {"a": 1})
+        _write_json(v2, {"a": 1, "b": 2})
+
+        result = DiffEngine.diff(v1, v2, output_format="text")
+
+        assert "Added:" in result
+        assert "b" in result
+
+    def test_top_level_key_removed(self, tmp_path):
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, {"a": 1, "b": 2})
+        _write_json(v2, {"a": 1})
+
+        result = DiffEngine.diff(v1, v2, output_format="text")
+
+        assert "Removed:" in result
+        assert "b" in result
+
+    def test_summary_counts_correct(self, tmp_path):
+        prd_v1 = _make_prd(
+            requirements=[
+                {"id": "RF-001", "description": "A"},
+                {"id": "RF-002", "description": "B"},
+            ],
+            stakeholders=[{"name": "Alice", "role": "PM", "interest": "X"}],
+        )
+        prd_v2 = _make_prd(
+            requirements=[
+                {"id": "RF-001", "description": "A++"},
+            ],
+            stakeholders=[],
+        )
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, prd_v1)
+        _write_json(v2, prd_v2)
+
+        result = DiffEngine.diff(v1, v2, output_format="json")
+        data = json.loads(result)
+
+        assert data["summary"]["removed_count"] >= 2
+        assert data["summary"]["modified_count"] >= 1
+        assert data["summary"]["total_changes"] >= 3
+
+
+class TestDiffEngineDetectArtifactType:
+    """Tests for artifact type detection."""
+
+    def test_detect_prd(self):
+        assert DiffEngine.detect_artifact_type(_make_prd()) == "prd"
+
+    def test_detect_sdd(self):
+        assert DiffEngine.detect_artifact_type(_make_sdd()) == "sdd"
+
+    def test_detect_schema(self):
+        assert DiffEngine.detect_artifact_type(_make_schema()) == "schema"
+
+    def test_detect_tasks_index(self):
+        assert DiffEngine.detect_artifact_type(_make_tasks_index()) == "tasks_index"
+
+    def test_detect_unknown(self):
+        assert DiffEngine.detect_artifact_type({"foo": "bar"}) == "unknown"
+
+    def test_detect_non_dict(self):
+        assert DiffEngine.detect_artifact_type([1, 2, 3]) == "unknown"
+
+
+class TestDiffEngineCli:
+    """Tests for the fba diff CLI command."""
+
+    def test_diff_cli_text_output(self, tmp_path):
+        from click.testing import CliRunner
+        from fba.cli import main
+
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        prd_v1 = _make_prd(requirements=[{"id": "RF-001", "description": "Login"}])
+        prd_v2 = _make_prd(requirements=[{"id": "RF-001", "description": "Login v2"}])
+        _write_json(v1, prd_v1)
+        _write_json(v2, prd_v2)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["diff", str(v1), str(v2)])
+
+        assert result.exit_code == 0
+        assert "=== Diff: prd ===" in result.output
+        assert "Modified:" in result.output
+
+    def test_diff_cli_json_output(self, tmp_path):
+        from click.testing import CliRunner
+        from fba.cli import main
+
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, _make_prd())
+        _write_json(v2, _make_prd())
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["diff", str(v1), str(v2), "--format", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["artifact_type"] == "prd"
+        assert data["summary"]["total_changes"] == 0
+
+    def test_diff_cli_file_not_found(self, tmp_path):
+        from click.testing import CliRunner
+        from fba.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["diff", str(tmp_path / "nope.json"), str(tmp_path / "nope2.json")])
+
+        assert result.exit_code != 0
+        assert "Error" in result.output or "error" in result.output.lower()
+
+    def test_diff_cli_malformed_json(self, tmp_path):
+        from click.testing import CliRunner
+        from fba.cli import main
+
+        v1 = tmp_path / "v1.json"
+        v2 = tmp_path / "v2.json"
+        _write_json(v1, _make_prd())
+        v2.write_text("not valid {{")
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["diff", str(v1), str(v2)])
+
+        assert result.exit_code == 1


### PR DESCRIPTION
## Summary
- New DiffEngine class in `src/fba/diff_engine.py`: compares two JSON artifact versions
- New CLI command: `fba diff <file_v1> <file_v2> [--format text|json]`
- Output: structured changelog with additions, removals, modifications
- Artifact type auto-detection (PRD, SDD, schema, tasks_index, task_item)
- 34 tests covering: identical, additions, removals, modifications, output formats, error handling, CLI
- AGENTS.md: corrected M11 status, added M12 entry

## Verification
```
pytest tests/test_diff_engine.py -v  → 34 passed
pytest                                 → 527 passed, 0 failures
```

Closes #118