### PR TITLE
feat(#119): Artifact Contracts — invariantes, ownership y mutaciones permitidas

### DIFF
--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -1,22 +1,22 @@
 {
   "schema_version": "1.0",
-  "last_updated": "2026-05-12T23:30:00Z",
+  "last_updated": "2026-05-12T23:55:00Z",
   "last_session": {
     "date": "2026-05-12",
     "agent": "framework-orchestrator",
-    "action": "Apertura de PR de M11 a main",
-    "completed_feats": ["11.1", "11.2", "11.3", "11.4", "11.5"],
-    "pending_feats": [],
+    "action": "Apertura de PR de M11 a main | feat/12.1 completado: diff engine core implementado",
+    "completed_feats": ["12.1"],
+    "pending_feats": ["12.2", "12.3", "12.4"],
     "blockers": []
   },
   "active_milestone": {
     "id": "M12",
     "name": "Diff, Dependencies & Trazabilidad",
     "branch": "milestone/12.0-diff-deps-traza",
-    "status": "planned",
-    "feats_total": 0,
-    "feats_done": 0,
-    "feats_pending": [],
+    "status": "in_progress",
+    "feats_total": 4,
+    "feats_done": 1,
+    "feats_pending": ["12.2", "12.3", "12.4"],
     "ready_for_user_review": false,
     "end_date": null
   },
@@ -29,7 +29,7 @@
     "M5": "completed",
     "M10": "completed",
     "M11": "completed",
-    "M12": "planned",
+    "M12": "in_progress",
     "M13": "planned",
     "M14": "planned",
     "M15": "planned"
@@ -43,7 +43,7 @@
     {"milestone":"M5","name":"Bug Fixes & Stability","status":"completed","start_date":"2026-05-06","end_date":"2026-05-08"},
     {"milestone":"M10","name":"Framework Meta-Development","status":"completed","start_date":"2026-05-09","end_date":"2026-05-09"},
     {"milestone":"M11","name":"Foundation Hardening (Capa 1)","status":"completed","start_date":"2026-05-10","end_date":"2026-05-12","caps":"Bugs criticos + fba doctor + atomicidad + rollback + wizard schema alignment"},
-    {"milestone":"M12","name":"Diff, Dependencies & Trazabilidad (Capa 1 avanzada)","status":"planned","caps":"Diff engine + dependency integrity + artifact contracts + stable IDs"},
+    {"milestone":"M12","name":"Diff, Dependencies & Trazabilidad (Capa 1 avanzada)","status":"in_progress","caps":"Diff engine + dependency integrity + artifact contracts + stable IDs"},
     {"milestone":"M13","name":"Reliability & Quality (Capa 2)","status":"planned","caps":"Security scans + cache + pre-commit + mypy"},
     {"milestone":"M14","name":"Odoo Depth (Capa 3)","status":"planned","caps":"Wizards/workflows + migraciones + i18n"},
     {"milestone":"M15","name":"Advanced QA (Capa 4)","status":"planned","caps":"Playwright + performance benchmarks + concurrency"}

--- a/schemas/contracts/prd.contract.json
+++ b/schemas/contracts/prd.contract.json
@@ -1,0 +1,64 @@
+{
+  "artifact_type": "prd",
+  "version": "1.0",
+  "description": "Contract for Product Requirements Document (PRD) artifacts.",
+  "invariants": [
+    {
+      "id": "prd-has-vision",
+      "description": "PRD must have a non-empty vision statement",
+      "check": {"field": "vision", "op": "min_length", "value": 10}
+    },
+    {
+      "id": "prd-has-stakeholders",
+      "description": "PRD must have at least one stakeholder",
+      "check": {"field": "stakeholders", "op": "min_items", "value": 1}
+    },
+    {
+      "id": "prd-has-objectives",
+      "description": "PRD must have at least one objective",
+      "check": {"field": "objectives", "op": "min_items", "value": 1}
+    },
+    {
+      "id": "prd-has-functional-requirements",
+      "description": "PRD must have at least one functional requirement",
+      "check": {"field": "functional_requirements", "op": "min_items", "value": 1}
+    },
+    {
+      "id": "prd-requirements-have-ids",
+      "description": "All functional requirements must have an id field",
+      "check": {"field": "functional_requirements", "op": "all_items_have_field", "value": "id"}
+    },
+    {
+      "id": "prd-stakeholders-have-required-fields",
+      "description": "All stakeholders must have name, role, and interest fields",
+      "check": {"field": "stakeholders", "op": "all_items_have_fields", "value": ["name", "role", "interest"]}
+    }
+  ],
+  "ownership": {
+    "vision": {"agent": "elicitador", "phase": "elicitation"},
+    "stakeholders": {"agent": "elicitador", "phase": "elicitation"},
+    "objectives": {"agent": "elicitador", "phase": "elicitation"},
+    "functional_requirements": {"agent": "elicitador", "phase": "elicitation"},
+    "non_functional_requirements": {"agent": "elicitador", "phase": "elicitation"},
+    "acceptance_criteria": {"agent": "elicitador", "phase": "elicitation"},
+    "glossary": {"agent": "documentador", "phase": "documentation"}
+  },
+  "allowed_mutations": [
+    {
+      "id": "prd-no-delete-req-if-referenced",
+      "description": "Cannot delete a functional requirement if any SDD model references it",
+      "rule": "no_delete_if_referenced",
+      "source_field": "functional_requirements",
+      "reference_artifact": "sdd",
+      "reference_field": "traceability_matrix.mappings"
+    },
+    {
+      "id": "prd-no-delete-stakeholder-if-referenced",
+      "description": "Cannot delete a stakeholder if referenced in SDD",
+      "rule": "no_delete_if_referenced",
+      "source_field": "stakeholders",
+      "reference_artifact": "sdd",
+      "reference_field": "stakeholders"
+    }
+  ]
+}

--- a/schemas/contracts/schema.contract.json
+++ b/schemas/contracts/schema.contract.json
@@ -1,0 +1,58 @@
+{
+  "artifact_type": "schema",
+  "version": "1.0",
+  "description": "Contract for schema.json (SSOT) artifacts produced by the Schema Manager.",
+  "invariants": [
+    {
+      "id": "schema-has-manifest",
+      "description": "schema.json must have a manifest with a module name",
+      "check": {"field": "manifest.name", "op": "min_length", "value": 3}
+    },
+    {
+      "id": "schema-has-models",
+      "description": "schema.json must define at least one model",
+      "check": {"field": "models", "op": "min_items", "value": 1}
+    },
+    {
+      "id": "schema-models-have-fields",
+      "description": "All models must have at least one field",
+      "check": {"field": "models", "op": "all_items_have_min_items_field", "value": {"field": "fields", "min": 1}}
+    },
+    {
+      "id": "schema-fields-have-type",
+      "description": "All fields must have a type property",
+      "check": {"field": "models", "op": "all_items_nested_field", "value": {"nested": "fields", "field": "type"}}
+    },
+    {
+      "id": "schema-has-views-or-empty",
+      "description": "schema.json must have a views array (can be empty)",
+      "check": {"field": "views", "op": "exists"}
+    }
+  ],
+  "ownership": {
+    "manifest": {"agent": "code-generator", "phase": "construction"},
+    "models": {"agent": "code-generator", "phase": "construction"},
+    "views": {"agent": "code-generator", "phase": "construction"},
+    "security": {"agent": "code-generator", "phase": "construction"},
+    "data": {"agent": "code-generator", "phase": "construction"}
+  },
+  "allowed_mutations": [
+    {
+      "id": "schema-no-remove-field-with-data",
+      "description": "Cannot remove a model field if data records reference it",
+      "rule": "cross_field_no_delete",
+      "source_field": "models",
+      "source_subfield": "fields",
+      "cross_field": "data",
+      "cross_check": "references_field"
+    },
+    {
+      "id": "schema-no-remove-model-with-related-views",
+      "description": "Cannot remove a model that has views defined for it",
+      "rule": "cross_field_no_delete",
+      "source_field": "models",
+      "cross_field": "views",
+      "cross_match": "model"
+    }
+  ]
+}

--- a/schemas/contracts/sdd.contract.json
+++ b/schemas/contracts/sdd.contract.json
@@ -1,0 +1,62 @@
+{
+  "artifact_type": "sdd",
+  "version": "1.0",
+  "description": "Contract for Software Design Document (SDD) artifacts.",
+  "invariants": [
+    {
+      "id": "sdd-has-module-name",
+      "description": "SDD must have a non-empty module name",
+      "check": {"field": "module_name", "op": "min_length", "value": 3}
+    },
+    {
+      "id": "sdd-has-models",
+      "description": "SDD must define at least one model",
+      "check": {"field": "models", "op": "min_items", "value": 1}
+    },
+    {
+      "id": "sdd-has-traceability",
+      "description": "SDD must have a traceability matrix",
+      "check": {"field": "traceability_matrix", "op": "exists"}
+    },
+    {
+      "id": "sdd-models-have-name",
+      "description": "All models must have a name field",
+      "check": {"field": "models", "op": "all_items_have_field", "value": "name"}
+    },
+    {
+      "id": "sdd-has-architecture-description",
+      "description": "SDD architecture must have a description of at least 10 chars",
+      "check": {"field": "architecture.description", "op": "min_length", "value": 10}
+    }
+  ],
+  "ownership": {
+    "module_name": {"agent": "documentador", "phase": "documentation"},
+    "module_display_name": {"agent": "documentador", "phase": "documentation"},
+    "version": {"agent": "documentador", "phase": "documentation"},
+    "architecture": {"agent": "planificador", "phase": "planning"},
+    "models": {"agent": "planificador", "phase": "planning"},
+    "views": {"agent": "planificador", "phase": "planning"},
+    "security": {"agent": "code-generator", "phase": "construction"},
+    "dependencies": {"agent": "planificador", "phase": "planning"},
+    "file_structure": {"agent": "planificador", "phase": "planning"},
+    "traceability_matrix": {"agent": "planificador", "phase": "planning"}
+  },
+  "allowed_mutations": [
+    {
+      "id": "sdd-no-delete-model-with-views",
+      "description": "Cannot delete a model that has associated views",
+      "rule": "cross_field_no_delete",
+      "source_field": "models",
+      "cross_field": "views",
+      "cross_match": "model"
+    },
+    {
+      "id": "sdd-no-delete-model-with-security",
+      "description": "Cannot delete a model that has associated security rules",
+      "rule": "cross_field_no_delete",
+      "source_field": "models",
+      "cross_field": "security.access_rights",
+      "cross_match": "model_name"
+    }
+  ]
+}

--- a/src/fba/cli.py
+++ b/src/fba/cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import click
 
 from fba import __version__
+from fba.contract_engine import ContractEngine, ContractError
 from fba.diff_engine import DiffEngine, DiffError
 from fba.gate import GateError
 from fba.schema_manager import SchemaManager
@@ -560,11 +561,18 @@ def gate(phase, all_gates, project_dir):
 @main.command()
 @click.argument("artifact", required=False)
 @PROJECT_DIR_OPTION
-def validate(artifact, project_dir):
-    """Validate project artifacts against their JSON schemas.
+@click.option("--contract", "contract_type", default=None, help="Validate against artifact contract (prd, sdd, schema) instead of JSON schema")
+def validate(artifact, project_dir, contract_type):
+    """Validate project artifacts against their JSON schemas or contracts.
 
     If no artifact is specified, validates all artifacts found in state.json.
+    Use --contract to validate business rules (invariants, ownership, mutations)
+    instead of structural JSON schema validation.
     """
+    if contract_type:
+        _validate_contract(contract_type, project_dir)
+        return
+
     target = _resolve_project_dir(project_dir)
 
     schemas_available = _list_schemas(target)
@@ -620,6 +628,40 @@ def validate(artifact, project_dir):
 
     if not all_valid:
         raise SystemExit(1)
+
+
+def _validate_contract(contract_type, project_dir):
+    """Validate an artifact against its business contract."""
+    target = _resolve_project_dir(project_dir)
+
+    art_path = target / ".factory" / f"{contract_type}.json"
+    if not art_path.exists():
+        click.echo(f"Error: Artifact file not found: {art_path}")
+        raise SystemExit(1)
+
+    try:
+        artifact_data = json.loads(art_path.read_text())
+    except json.JSONDecodeError as e:
+        click.echo(f"Error: Invalid JSON in {art_path}: {e}")
+        raise SystemExit(1)
+
+    engine = ContractEngine()
+
+    try:
+        violations = engine.validate_invariants(contract_type, artifact_data)
+    except ContractError as e:
+        click.echo(f"Error: {e}")
+        raise SystemExit(1)
+
+    if not violations:
+        click.echo(f"✅ Contract '{contract_type}': all invariants pass")
+        return
+
+    click.echo(f"❌ Contract '{contract_type}': {len(violations)} violation(s) found")
+    for v in violations:
+        click.echo(f"  - [{v['id']}] {v['description']}")
+        click.echo(f"    Field: {v['field']} — {v['detail']}")
+    raise SystemExit(1)
 
 
 _schema_group = click.group("schema")(lambda: None)

--- a/src/fba/contract_engine.py
+++ b/src/fba/contract_engine.py
@@ -1,0 +1,426 @@
+"""Artifact contract validation engine.
+
+Validates JSON artifacts against declarative contracts that define invariants,
+ownership rules, and allowed mutations between versions.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+
+class ContractError(Exception):
+    """Raised when contract validation fails."""
+
+
+class ContractEngine:
+    """Validates artifacts against declarative contracts.
+
+    Contracts are JSON files in schemas/contracts/ that define:
+    - Invariants: rules that must always hold for the artifact
+    - Ownership: which agent/phase can modify each field
+    - Allowed mutations: which changes are valid between versions
+
+    Usage:
+        engine = ContractEngine()
+        violations = engine.validate_invariants("prd", prd_data)
+        if violations:
+            for v in violations:
+                print(f"  - {v['id']}: {v['description']}")
+    """
+
+    CONTRACTS_DIR = Path(__file__).resolve().parent.parent.parent / "schemas" / "contracts"
+
+    SUPPORTED_TYPES = ["prd", "sdd", "schema"]
+
+    def __init__(self, contracts_dir: Optional[Path] = None):
+        self._contracts_dir = contracts_dir or self.CONTRACTS_DIR
+        self._cache: dict[str, dict] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def validate_invariants(self, artifact_type: str, data: dict) -> list[dict]:
+        """Validate all invariants for the given artifact.
+
+        Returns a list of violations. Empty list means all invariants pass.
+        Each violation is a dict with: id, description, field, detail.
+        """
+        contract = self._load_contract(artifact_type)
+        violations = []
+
+        for invariant in contract.get("invariants", []):
+            check = invariant["check"]
+            field = check["field"]
+            op = check["op"]
+            value = check.get("value")
+
+            ok, detail = self._check_invariant(data, field, op, value)
+            if not ok:
+                violations.append({
+                    "id": invariant["id"],
+                    "description": invariant["description"],
+                    "field": field,
+                    "detail": detail,
+                })
+
+        return violations
+
+    def validate_ownership(
+        self, artifact_type: str, field_path: str, agent: str, phase: str
+    ) -> Optional[str]:
+        """Check if an agent/phase can modify a field.
+
+        Returns None if allowed, otherwise returns the reason.
+        """
+        contract = self._load_contract(artifact_type)
+        ownership = contract.get("ownership", {})
+
+        field_key = field_path.split(".")[0]
+        rule = ownership.get(field_key)
+
+        if rule is None:
+            return f"Field '{field_path}' has no ownership rule defined"
+
+        if rule.get("agent") != agent:
+            return f"Field '{field_path}' can only be modified by '{rule['agent']}', not '{agent}'"
+        if rule.get("phase") != phase:
+            return f"Field '{field_path}' can only be modified in '{rule['phase']}' phase, not '{phase}'"
+
+        return None
+
+    def validate_mutations(
+        self,
+        artifact_type: str,
+        old_data: dict,
+        new_data: dict,
+        context: Optional[dict] = None,
+    ) -> list[dict]:
+        """Validate allowed mutations between two versions.
+
+        Checks that changes between old_data and new_data respect
+        the allowed_mutations rules in the contract.
+
+        Args:
+            artifact_type: Type of artifact (prd, sdd, schema).
+            old_data: Previous version of the artifact.
+            new_data: New version of the artifact.
+            context: Optional cross-artifact context (e.g., SDD data
+                when validating PRD mutations).
+
+        Returns a list of mutation violations.
+        """
+        contract = self._load_contract(artifact_type)
+        violations = []
+
+        for mutation_rule in contract.get("allowed_mutations", []):
+            rule_type = mutation_rule["rule"]
+            violations.extend(
+                self._check_mutation_rule(
+                    mutation_rule, old_data, new_data, context
+                )
+            )
+
+        return violations
+
+    # ------------------------------------------------------------------
+    # Internal: contract loading
+    # ------------------------------------------------------------------
+
+    def _load_contract(self, artifact_type: str) -> dict:
+        """Load a contract definition from disk."""
+        if artifact_type not in self.SUPPORTED_TYPES:
+            raise ContractError(
+                f"Unknown artifact type: '{artifact_type}'. "
+                f"Supported: {', '.join(self.SUPPORTED_TYPES)}"
+            )
+
+        if artifact_type in self._cache:
+            return self._cache[artifact_type]
+
+        contract_path = self._contracts_dir / f"{artifact_type}.contract.json"
+        if not contract_path.exists():
+            raise ContractError(f"Contract file not found: {contract_path}")
+
+        try:
+            contract = json.loads(contract_path.read_text())
+        except json.JSONDecodeError as e:
+            raise ContractError(f"Invalid contract JSON in {contract_path}: {e}")
+
+        self._cache[artifact_type] = contract
+        return contract
+
+    # ------------------------------------------------------------------
+    # Internal: invariant checks
+    # ------------------------------------------------------------------
+
+    def _check_invariant(
+        self, data: dict, field: str, op: str, value: Any
+    ) -> tuple[bool, str]:
+        """Check a single invariant rule against the data."""
+        actual = self._resolve_field(data, field)
+
+        if op == "exists":
+            if actual is None:
+                return False, f"Field '{field}' does not exist"
+            return True, "ok"
+
+        if op == "min_length":
+            if not isinstance(actual, str):
+                return False, f"Field '{field}' is not a string (got {type(actual).__name__})"
+            if len(actual) < value:
+                return False, f"Field '{field}' length is {len(actual)}, minimum is {value}"
+            return True, "ok"
+
+        if op == "min_items":
+            if not isinstance(actual, list):
+                return False, f"Field '{field}' is not an array (got {type(actual).__name__})"
+            if len(actual) < value:
+                return False, f"Field '{field}' has {len(actual)} items, minimum is {value}"
+            return True, "ok"
+
+        if op == "all_items_have_field":
+            if not isinstance(actual, list):
+                return False, f"Field '{field}' is not an array"
+            for i, item in enumerate(actual):
+                if not isinstance(item, dict) or value not in item:
+                    return False, f"Item {i} in '{field}' is missing field '{value}'"
+            return True, "ok"
+
+        if op == "all_items_have_fields":
+            if not isinstance(actual, list):
+                return False, f"Field '{field}' is not an array"
+            for i, item in enumerate(actual):
+                if not isinstance(item, dict):
+                    return False, f"Item {i} in '{field}' is not an object"
+                for req_field in value:
+                    if req_field not in item:
+                        return False, f"Item {i} in '{field}' is missing field '{req_field}'"
+            return True, "ok"
+
+        if op == "all_items_have_min_items_field":
+            nested_field = value["field"]
+            min_items = value["min"]
+            if not isinstance(actual, list):
+                return False, f"Field '{field}' is not an array"
+            for i, item in enumerate(actual):
+                if not isinstance(item, dict):
+                    return False, f"Item {i} in '{field}' is not an object"
+                nested = item.get(nested_field, [])
+                if not isinstance(nested, list):
+                    return False, f"Item {i} in '{field}'.'{nested_field}' is not an array"
+                if len(nested) < min_items:
+                    return False, (
+                        f"Item {i} in '{field}'.'{nested_field}' has {len(nested)} "
+                        f"items, minimum is {min_items}"
+                    )
+            return True, "ok"
+
+        if op == "all_items_nested_field":
+            nested = value["nested"]
+            req_field = value["field"]
+            if not isinstance(actual, list):
+                return False, f"Field '{field}' is not an array"
+            for i, item in enumerate(actual):
+                if not isinstance(item, dict):
+                    return False, f"Item {i} in '{field}' is not an object"
+                sub_items = item.get(nested, [])
+                if not isinstance(sub_items, list):
+                    return False, f"Item {i} in '{field}'.'{nested}' is not an array"
+                for j, sub in enumerate(sub_items):
+                    if not isinstance(sub, dict) or req_field not in sub:
+                        return False, (
+                            f"Item {i}.{j} in '{field}'.'{nested}' "
+                            f"is missing field '{req_field}'"
+                        )
+            return True, "ok"
+
+        return False, f"Unknown invariant operation: '{op}'"
+
+    # ------------------------------------------------------------------
+    # Internal: mutation checks
+    # ------------------------------------------------------------------
+
+    def _check_mutation_rule(
+        self,
+        rule: dict,
+        old_data: dict,
+        new_data: dict,
+        context: Optional[dict],
+    ) -> list[dict]:
+        """Check a single mutation rule."""
+        rule_type = rule["rule"]
+        violations = []
+
+        if rule_type == "no_delete_if_referenced":
+            violations.extend(
+                self._check_no_delete_if_referenced(rule, old_data, new_data, context)
+            )
+        elif rule_type == "cross_field_no_delete":
+            violations.extend(
+                self._check_cross_field_no_delete(rule, old_data, new_data)
+            )
+
+        return violations
+
+    def _check_no_delete_if_referenced(
+        self,
+        rule: dict,
+        old_data: dict,
+        new_data: dict,
+        context: Optional[dict],
+    ) -> list[dict]:
+        """Check that deleted items are not referenced in another artifact."""
+        violations = []
+        source_field = rule["source_field"]
+
+        old_items = old_data.get(source_field, [])
+        new_items = new_data.get(source_field, [])
+
+        if not isinstance(old_items, list) or not isinstance(new_items, list):
+            return []
+
+        old_ids = {item.get("id", item.get("name", "")) for item in old_items if isinstance(item, dict)}
+        new_ids = {item.get("id", item.get("name", "")) for item in new_items if isinstance(item, dict)}
+        deleted_ids = old_ids - new_ids
+
+        if not deleted_ids:
+            return []
+
+        if context is None:
+            return []
+
+        ref_artifact = rule.get("reference_artifact")
+        ref_field = rule.get("reference_field")
+
+        if ref_artifact and context:
+            ref_data = context.get(ref_artifact, {})
+            if not ref_data:
+                return [
+                    {
+                        "id": rule["id"],
+                        "description": rule["description"],
+                        "deleted": sorted(deleted_ids),
+                        "detail": f"Cannot verify: {ref_artifact} context not provided",
+                    }
+                ]
+
+            referenced = self._find_references(ref_data, ref_field, deleted_ids)
+            if referenced:
+                return [
+                    {
+                        "id": rule["id"],
+                        "description": rule["description"],
+                        "deleted": sorted(deleted_ids),
+                        "referenced_by": referenced,
+                        "detail": f"Deleted items are referenced in {ref_artifact}",
+                    }
+                ]
+
+        return []
+
+    def _check_cross_field_no_delete(
+        self, rule: dict, old_data: dict, new_data: dict
+    ) -> list[dict]:
+        """Check cross-field constraints within a single artifact."""
+        violations = []
+        source_field = rule["source_field"]
+        cross_field = rule.get("cross_field", "")
+        cross_match = rule.get("cross_match", "model")
+
+        old_items = old_data.get(source_field, [])
+        new_items = new_data.get(source_field, [])
+
+        if not isinstance(old_items, list) or not isinstance(new_items, list):
+            return []
+
+        old_names = {
+            item.get("name", item.get("id", ""))
+            for item in old_items if isinstance(item, dict)
+        }
+        new_names = {
+            item.get("name", item.get("id", ""))
+            for item in new_items if isinstance(item, dict)
+        }
+        deleted_names = old_names - new_names
+
+        if not deleted_names:
+            return []
+
+        cross_data = new_data
+        for part in cross_field.split("."):
+            if isinstance(cross_data, dict):
+                cross_data = cross_data.get(part, [])
+            elif isinstance(cross_data, list):
+                break
+            else:
+                cross_data = []
+
+        if isinstance(cross_data, list):
+            referenced = []
+            for item in cross_data:
+                if isinstance(item, dict) and item.get(cross_match) in deleted_names:
+                    referenced.append(item.get(cross_match) or item.get("name", "?"))
+            if referenced:
+                violations.append({
+                    "id": rule["id"],
+                    "description": rule["description"],
+                    "deleted": sorted(deleted_names),
+                    "referenced_by": sorted(referenced),
+                    "detail": (
+                        f"Deleted items from '{source_field}' are still "
+                        f"referenced in '{cross_field}'"
+                    ),
+                })
+
+        return violations
+
+    # ------------------------------------------------------------------
+    # Internal: helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _resolve_field(data: Any, path: str) -> Any:
+        """Resolve a dot-separated field path in a nested dict/list."""
+        current = data
+        for part in path.split("."):
+            if isinstance(current, dict):
+                current = current.get(part)
+            elif isinstance(current, list):
+                try:
+                    idx = int(part)
+                    current = current[idx] if idx < len(current) else None
+                except (ValueError, IndexError):
+                    return None
+            else:
+                return None
+            if current is None:
+                return None
+        return current
+
+    @staticmethod
+    def _find_references(
+        data: dict, field_path: str, target_ids: set
+    ) -> list[str]:
+        """Find references to target_ids within data at field_path."""
+        current = data
+        for part in field_path.split("."):
+            if isinstance(current, dict):
+                current = current.get(part)
+            elif isinstance(current, list):
+                break
+            else:
+                return []
+
+        if not isinstance(current, list):
+            current = [current] if current else []
+
+        found = []
+        for item in current:
+            if isinstance(item, dict):
+                req = item.get("requirement", item.get("id", item.get("name", "")))
+                if req in target_ids:
+                    found.append(req)
+
+        return found

--- a/tests/test_artifact_contracts.py
+++ b/tests/test_artifact_contracts.py
@@ -1,0 +1,368 @@
+"""Tests for artifact contract validation — invariants, ownership, and allowed mutations."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from fba.contract_engine import ContractEngine, ContractError
+
+
+def _make_prd(requirements=None, stakeholders=None):
+    """Create a minimal PRD artifact."""
+    return {
+        "vision": "A test product for validating contracts.",
+        "stakeholders": stakeholders if stakeholders is not None else [
+            {"name": "Alice", "role": "PM", "interest": "Success"},
+        ],
+        "objectives": ["Obj 1"],
+        "functional_requirements": requirements if requirements is not None else [
+            {"id": "RF-001", "description": "Login screen"},
+        ],
+        "non_functional_requirements": [],
+        "acceptance_criteria": [],
+        "glossary": [],
+    }
+
+
+def _make_sdd(models=None):
+    """Create a minimal SDD artifact."""
+    return {
+        "module_name": "test_module",
+        "module_display_name": "Test Module",
+        "version": "18.0.1.0.0",
+        "architecture": {"description": "A test architecture with enough detail."},
+        "models": models if models is not None else [
+            {"name": "test.model", "description": "A test model."},
+        ],
+        "views": [],
+        "security": {},
+        "dependencies": [],
+        "file_structure": [],
+        "traceability_matrix": {"mappings": []},
+    }
+
+
+def _make_schema_data(models=None):
+    """Create a minimal schema.json artifact."""
+    return {
+        "manifest": {"name": "test_module", "version": "18.0.1.0.0", "depends": ["base"]},
+        "models": models if models is not None else [
+            {"name": "test.model", "fields": [{"name": "name", "type": "char"}]},
+        ],
+        "views": [],
+        "security": {"groups": [], "access_rights": [], "record_rules": []},
+        "data": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Invariant tests: PRD
+# ---------------------------------------------------------------------------
+
+class TestPrdInvariants:
+    """Tests for PRD contract invariants."""
+
+    def test_prd_with_stakeholders_passes(self):
+        engine = ContractEngine()
+        prd = _make_prd(stakeholders=[{"name": "A", "role": "PM", "interest": "X"}])
+        violations = engine.validate_invariants("prd", prd)
+        assert violations == []
+
+    def test_prd_without_stakeholders_fails(self):
+        engine = ContractEngine()
+        prd = _make_prd(stakeholders=[])
+        violations = engine.validate_invariants("prd", prd)
+        assert len(violations) >= 1
+        assert any("stakeholder" in v["id"].lower() for v in violations)
+
+    def test_prd_without_functional_requirements_fails(self):
+        engine = ContractEngine()
+        prd = _make_prd(requirements=[])
+        violations = engine.validate_invariants("prd", prd)
+        assert len(violations) >= 1
+        assert any("functional" in v["id"].lower() for v in violations)
+
+    def test_prd_vision_too_short_fails(self):
+        engine = ContractEngine()
+        prd = _make_prd()
+        prd["vision"] = "Short"
+        violations = engine.validate_invariants("prd", prd)
+        assert len(violations) >= 1
+        assert any("vision" in v["id"].lower() for v in violations)
+
+    def test_prd_requirement_missing_id_fails(self):
+        engine = ContractEngine()
+        prd = _make_prd(requirements=[{"description": "No ID here"}])
+        violations = engine.validate_invariants("prd", prd)
+        assert len(violations) >= 1
+        assert any("id" in v["id"].lower() for v in violations)
+
+    def test_prd_stakeholder_missing_required_field_fails(self):
+        engine = ContractEngine()
+        prd = _make_prd(stakeholders=[{"name": "Bob"}])
+        violations = engine.validate_invariants("prd", prd)
+        assert len(violations) >= 1
+        assert any("stakeholder" in v["id"].lower() for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# Invariant tests: SDD
+# ---------------------------------------------------------------------------
+
+class TestSddInvariants:
+    """Tests for SDD contract invariants."""
+
+    def test_sdd_with_models_passes(self):
+        engine = ContractEngine()
+        sdd = _make_sdd(models=[{"name": "m1", "description": "A model"}])
+        violations = engine.validate_invariants("sdd", sdd)
+        assert violations == []
+
+    def test_sdd_without_models_fails(self):
+        engine = ContractEngine()
+        sdd = _make_sdd(models=[])
+        violations = engine.validate_invariants("sdd", sdd)
+        assert len(violations) >= 1
+        assert any("model" in v["id"].lower() for v in violations)
+
+    def test_sdd_model_missing_name_fails(self):
+        engine = ContractEngine()
+        sdd = _make_sdd(models=[{"description": "No name"}])
+        violations = engine.validate_invariants("sdd", sdd)
+        assert len(violations) >= 1
+
+    def test_sdd_architecture_too_short_fails(self):
+        engine = ContractEngine()
+        sdd = _make_sdd()
+        sdd["architecture"]["description"] = "Short"
+        violations = engine.validate_invariants("sdd", sdd)
+        assert len(violations) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Invariant tests: schema
+# ---------------------------------------------------------------------------
+
+class TestSchemaInvariants:
+    """Tests for schema.json contract invariants."""
+
+    def test_schema_with_models_passes(self):
+        engine = ContractEngine()
+        schema_data = _make_schema_data(models=[
+            {"name": "m1", "fields": [{"name": "f1", "type": "char"}]},
+        ])
+        violations = engine.validate_invariants("schema", schema_data)
+        assert violations == []
+
+    def test_schema_without_models_fails(self):
+        engine = ContractEngine()
+        schema_data = _make_schema_data(models=[])
+        violations = engine.validate_invariants("schema", schema_data)
+        assert len(violations) >= 1
+
+    def test_schema_field_missing_type_fails(self):
+        engine = ContractEngine()
+        schema_data = _make_schema_data(models=[
+            {"name": "m1", "fields": [{"name": "f1"}]},
+        ])
+        violations = engine.validate_invariants("schema", schema_data)
+        assert len(violations) >= 1
+        assert any("type" in v["id"].lower() for v in violations)
+
+    def test_schema_model_without_fields_fails(self):
+        engine = ContractEngine()
+        schema_data = _make_schema_data(models=[
+            {"name": "m1", "fields": []},
+        ])
+        violations = engine.validate_invariants("schema", schema_data)
+        assert len(violations) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Ownership tests
+# ---------------------------------------------------------------------------
+
+class TestOwnership:
+    """Tests for ownership validation."""
+
+    def test_owner_allowed(self):
+        engine = ContractEngine()
+        result = engine.validate_ownership("prd", "vision", "elicitador", "elicitation")
+        assert result is None
+
+    def test_owner_wrong_agent(self):
+        engine = ContractEngine()
+        result = engine.validate_ownership("prd", "vision", "code-generator", "elicitation")
+        assert result is not None
+        assert "elicitador" in result
+
+    def test_owner_wrong_phase(self):
+        engine = ContractEngine()
+        result = engine.validate_ownership("prd", "vision", "elicitador", "construction")
+        assert result is not None
+        assert "elicitation" in result
+
+    def test_owner_unowned_field(self):
+        engine = ContractEngine()
+        result = engine.validate_ownership("prd", "unknown_field", "elicitador", "elicitation")
+        assert result is not None
+        assert "ownership rule" in result
+
+
+# ---------------------------------------------------------------------------
+# Mutation tests
+# ---------------------------------------------------------------------------
+
+class TestMutations:
+    """Tests for allowed mutation validation."""
+
+    def test_mutation_no_changes_passes(self):
+        engine = ContractEngine()
+        prd = _make_prd()
+        violations = engine.validate_mutations("prd", prd, prd)
+        assert violations == []
+
+    def test_mutation_remove_model_not_referenced_passes(self):
+        engine = ContractEngine()
+        old_sdd = _make_sdd(models=[
+            {"name": "model.one", "description": "First"},
+            {"name": "model.two", "description": "Second"},
+        ])
+        new_sdd = _make_sdd(models=[
+            {"name": "model.one", "description": "First"},
+        ])
+        violations = engine.validate_mutations("sdd", old_sdd, new_sdd)
+        assert violations == []
+
+    def test_mutation_remove_model_with_view_fails(self):
+        engine = ContractEngine()
+        old_sdd = _make_sdd(models=[
+            {"name": "model.one", "description": "First"},
+        ])
+        new_sdd = _make_sdd(models=[])
+        new_sdd["views"] = [{"model": "model.one", "type": "tree"}]
+        violations = engine.validate_mutations("sdd", old_sdd, new_sdd)
+        assert len(violations) >= 1
+        assert any("view" in v["id"].lower() or "delete" in v["id"].lower() for v in violations)
+
+    def test_mutation_delete_req_with_context(self):
+        engine = ContractEngine()
+        old_prd = _make_prd(requirements=[
+            {"id": "RF-001", "description": "Login"},
+            {"id": "RF-002", "description": "Logout"},
+        ])
+        new_prd = _make_prd(requirements=[
+            {"id": "RF-001", "description": "Login"},
+        ])
+        context = {
+            "sdd": {
+                "traceability_matrix": {
+                    "mappings": [
+                        {"requirement": "RF-002", "model": "some.model"},
+                    ]
+                }
+            }
+        }
+        violations = engine.validate_mutations("prd", old_prd, new_prd, context=context)
+        assert len(violations) >= 1
+        assert any("RF-002" in str(v.get("deleted", "")) for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# Error handling tests
+# ---------------------------------------------------------------------------
+
+class TestContractErrors:
+    """Tests for error handling in contract validation."""
+
+    def test_unknown_artifact_type(self):
+        engine = ContractEngine()
+        with pytest.raises(ContractError, match="Unknown artifact type"):
+            engine.validate_invariants("unknown_type", {})
+
+    def test_unknown_artifact_type_ownership(self):
+        engine = ContractEngine()
+        with pytest.raises(ContractError, match="Unknown artifact type"):
+            engine.validate_ownership("unknown_type", "field", "agent", "phase")
+
+
+# ---------------------------------------------------------------------------
+# CLI tests
+# ---------------------------------------------------------------------------
+
+class TestContractCli:
+    """Tests for the fba validate --contract CLI command."""
+
+    def test_validate_contract_prd_passes(self, tmp_path):
+        from click.testing import CliRunner
+        from fba.cli import main
+
+        factory = tmp_path / ".factory"
+        factory.mkdir()
+        prd = _make_prd()
+        (factory / "prd.json").write_text(json.dumps(prd))
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "--contract", "prd", "--project-dir", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert "pass" in result.output.lower() or "✅" in result.output
+
+    def test_validate_contract_prd_fails(self, tmp_path):
+        from click.testing import CliRunner
+        from fba.cli import main
+
+        factory = tmp_path / ".factory"
+        factory.mkdir()
+        prd = _make_prd(stakeholders=[])
+        (factory / "prd.json").write_text(json.dumps(prd))
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "--contract", "prd", "--project-dir", str(tmp_path)])
+
+        assert result.exit_code != 0
+        assert "violation" in result.output.lower() or "❌" in result.output
+
+    def test_validate_contract_sdd_passes(self, tmp_path):
+        from click.testing import CliRunner
+        from fba.cli import main
+
+        factory = tmp_path / ".factory"
+        factory.mkdir()
+        sdd = _make_sdd()
+        (factory / "sdd.json").write_text(json.dumps(sdd))
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "--contract", "sdd", "--project-dir", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert "pass" in result.output.lower() or "✅" in result.output
+
+    def test_validate_contract_schema_passes(self, tmp_path):
+        from click.testing import CliRunner
+        from fba.cli import main
+
+        factory = tmp_path / ".factory"
+        factory.mkdir()
+        schema_data = _make_schema_data()
+        (factory / "schema.json").write_text(json.dumps(schema_data))
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "--contract", "schema", "--project-dir", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert "pass" in result.output.lower() or "✅" in result.output
+
+    def test_validate_contract_missing_file(self, tmp_path):
+        from click.testing import CliRunner
+        from fba.cli import main
+
+        factory = tmp_path / ".factory"
+        factory.mkdir()
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["validate", "--contract", "prd", "--project-dir", str(tmp_path)])
+
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower() or "Error" in result.output


### PR DESCRIPTION
## Summary
- ContractEngine in src/fba/contract_engine.py: validates invariants, ownership, and allowed mutations
- Declarative contract definitions in schemas/contracts/ for PRD, SDD, and schema artifacts
- Extended `fba validate --contract <type>` CLI command
- Invariant checks: min_length, min_items, exists, all_items_have_field, all_items_have_fields, all_items_have_min_items_field, all_items_nested_field
- Ownership validation: agent + phase restrictions per field
- Mutation rules: no_delete_if_referenced, cross_field_no_delete
- 29 tests covering: PRD/SDD/schema invariants, ownership, mutations, error handling, CLI

## Verification
```
pytest tests/test_artifact_contracts.py -v  → 29 passed
pytest                                   → 556 passed, 0 failures
```

Closes #119