### PR TITLE
feat(#121): Stable IDs Foundation — UUID v4 para entidades clave

### DIFF
--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.0",
-  "last_updated": "2026-05-12T23:59:00Z",
+  "last_updated": "2026-05-13T00:26:30Z",
   "last_session": {
     "date": "2026-05-12",
     "agent": "framework-registry",
-    "action": "feat/12.2 completado: artifact contracts con invariantes implementados | 12.1 y 12.2 finalizados, pendientes 12.3 y 12.4",
-    "completed_feats": ["12.1", "12.2"],
-    "pending_feats": ["12.3", "12.4"],
+    "action": "feat/12.3 completado: dependency integrity implemented | 12.1, 12.2, 12.3 finalizados, pendiente 12.4",
+    "completed_feats": ["12.1", "12.2", "12.3"],
+    "pending_feats": ["12.4"],
     "blockers": []
   },
   "active_milestone": {
@@ -15,8 +15,8 @@
     "branch": "milestone/12.0-diff-deps-traza",
     "status": "in_progress",
     "feats_total": 4,
-    "feats_done": 2,
-    "feats_pending": ["12.3", "12.4"],
+    "feats_done": 3,
+    "feats_pending": ["12.4"],
     "ready_for_user_review": false,
     "end_date": null
   },

--- a/schemas/contracts/prd.contract.json
+++ b/schemas/contracts/prd.contract.json
@@ -29,6 +29,11 @@
       "check": {"field": "functional_requirements", "op": "all_items_have_field", "value": "id"}
     },
     {
+      "id": "prd-requirements-have-uuids",
+      "description": "All functional requirements should have a stable UUID (uuid field)",
+      "check": {"field": "functional_requirements", "op": "all_items_have_field", "value": "uuid"}
+    },
+    {
       "id": "prd-stakeholders-have-required-fields",
       "description": "All stakeholders must have name, role, and interest fields",
       "check": {"field": "stakeholders", "op": "all_items_have_fields", "value": ["name", "role", "interest"]}
@@ -44,6 +49,14 @@
     "glossary": {"agent": "documentador", "phase": "documentation"}
   },
   "allowed_mutations": [
+    {
+      "id": "prd-uuids-are-immutable",
+      "description": "UUIDs must not change between versions — once assigned, immutable",
+      "rule": "uuid_immutability",
+      "source_field": "functional_requirements",
+      "stable_id_field": "uuid",
+      "id_field": "id"
+    },
     {
       "id": "prd-no-delete-req-if-referenced",
       "description": "Cannot delete a functional requirement if any SDD model references it",

--- a/src/fba/cli.py
+++ b/src/fba/cli.py
@@ -10,6 +10,7 @@ from fba.contract_engine import ContractEngine, ContractError
 from fba.dependency_analyzer import DependencyAnalyzer, DependencyError
 from fba.diff_engine import DiffEngine, DiffError
 from fba.gate import GateError
+from fba.stable_ids import StableIdManager, StableIdError
 from fba.schema_manager import SchemaManager
 from fba.state import StateManager, _atomic_write
 
@@ -992,6 +993,36 @@ def deps_check(project_dir):
         raise SystemExit(1)
 
     click.echo(f"\nAll {len(results)} module(s) have clean dependencies.")
+
+
+@main.command()
+@click.argument("entity_id")
+@PROJECT_DIR_OPTION
+def trace(entity_id, project_dir):
+    """Trace a stable UUID across all project artifacts.
+
+    Searches PRD, SDD, and schema.json for the given UUID and reports
+    where the entity is referenced.
+    """
+    target = _resolve_project_dir(project_dir)
+    factory_dir = target / ".factory"
+
+    try:
+        result = StableIdManager.trace(entity_id, factory_dir)
+    except StableIdError as e:
+        click.echo(f"Error: {e}", err=True)
+        raise SystemExit(1)
+
+    if result is None:
+        click.echo(f"UUID '{entity_id[:16]}...' not found in any artifact.")
+        raise SystemExit(1)
+
+    click.echo(f"🔍 Tracing UUID: {entity_id}")
+    click.echo(f"   Found in {result['found_in']} location(s):")
+    for loc in result["locations"]:
+        click.echo(f"   - [{loc['entity_type']}] {loc['entity_id']}")
+        click.echo(f"     Artifact: {loc['artifact']}")
+        click.echo(f"     Path: {loc['path']}")
 
 
 main.add_command(_deps_group)

--- a/src/fba/contract_engine.py
+++ b/src/fba/contract_engine.py
@@ -261,6 +261,10 @@ class ContractEngine:
             violations.extend(
                 self._check_cross_field_no_delete(rule, old_data, new_data)
             )
+        elif rule_type == "uuid_immutability":
+            violations.extend(
+                self._check_uuid_immutability(rule, old_data, new_data)
+            )
 
         return violations
 
@@ -371,6 +375,48 @@ class ContractEngine:
                     "detail": (
                         f"Deleted items from '{source_field}' are still "
                         f"referenced in '{cross_field}'"
+                    ),
+                })
+
+        return violations
+
+    def _check_uuid_immutability(
+        self, rule: dict, old_data: dict, new_data: dict
+    ) -> list[dict]:
+        """Check that UUID stable IDs are immutable across versions."""
+        source_field = rule["source_field"]
+        stable_id_field = rule.get("stable_id_field", "uuid")
+        id_field = rule.get("id_field", "id")
+
+        old_items = old_data.get(source_field, [])
+        new_items = new_data.get(source_field, [])
+
+        if not isinstance(old_items, list) or not isinstance(new_items, list):
+            return []
+
+        old_map = {
+            item.get(id_field, ""): item.get(stable_id_field)
+            for item in old_items
+            if isinstance(item, dict) and item.get(stable_id_field)
+        }
+
+        violations = []
+        for item in new_items:
+            if not isinstance(item, dict):
+                continue
+            logical_id = item.get(id_field, "")
+            old_uuid = old_map.get(logical_id)
+            new_uuid = item.get(stable_id_field)
+            if old_uuid and new_uuid and old_uuid != new_uuid:
+                violations.append({
+                    "id": rule["id"],
+                    "description": rule["description"],
+                    "logical_id": logical_id,
+                    "old_uuid": old_uuid,
+                    "new_uuid": new_uuid,
+                    "detail": (
+                        f"UUID for '{logical_id}' changed: "
+                        f"{old_uuid[:8]}... → {new_uuid[:8]}..."
                     ),
                 })
 

--- a/src/fba/stable_ids.py
+++ b/src/fba/stable_ids.py
@@ -1,0 +1,241 @@
+"""Stable ID system using UUID v4 for key entities across the pipeline.
+
+Assigns UUIDs to: functional requirements (RF-*), non-functional requirements
+(RNF-*), Odoo models, and model fields. IDs are assigned at entity creation time
+and are immutable once set.
+"""
+
+import json
+import uuid
+from pathlib import Path
+from typing import Any, Optional
+
+
+ENTITY_TYPES = ("requirement", "model", "field")
+
+
+class StableIdError(Exception):
+    """Raised when stable ID operations fail."""
+
+
+class StableIdManager:
+    """Manages UUID v4 stable IDs for traceable entities.
+
+    Usage:
+        mgr = StableIdManager()
+        entity_id = mgr.assign_id("RF-001", "requirement")
+        # Persist in artifact:
+        mgr.ensure_id(prd_data, "functional_requirements", "requirement")
+        # Trace:
+        result = mgr.trace(entity_id, factory_dir)
+    """
+
+    @staticmethod
+    def generate_id() -> str:
+        """Generate a new UUID v4 as a stable ID."""
+        return str(uuid.uuid4())
+
+    @staticmethod
+    def assign_id(label: str, entity_type: str) -> str:
+        """Assign a UUID v4 to an entity.
+
+        Args:
+            label: Human-readable label (e.g., "RF-001", "res.partner").
+            entity_type: One of 'requirement', 'model', 'field'.
+
+        Returns:
+            The generated UUID v4 string.
+        """
+        if entity_type not in ENTITY_TYPES:
+            raise StableIdError(
+                f"Unknown entity type: '{entity_type}'. "
+                f"Must be one of: {', '.join(ENTITY_TYPES)}"
+            )
+        return StableIdManager.generate_id()
+
+    @staticmethod
+    def ensure_ids_in_array(
+        items: list[dict],
+        entity_type: str,
+        id_field: str = "id",
+        stable_id_field: str = "uuid",
+    ) -> int:
+        """Ensure all items in an array have stable UUIDs.
+
+        If an item already has a UUID in stable_id_field, it is preserved.
+        Otherwise, a new UUID is generated and assigned.
+
+        Args:
+            items: List of entity dicts.
+            entity_type: Type label for error messages.
+            id_field: The field used as the item's logical ID.
+            stable_id_field: The field where UUID is stored.
+
+        Returns:
+            Number of new UUIDs assigned.
+        """
+        assigned = 0
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            if stable_id_field not in item or not item[stable_id_field]:
+                item[stable_id_field] = StableIdManager.generate_id()
+                assigned += 1
+        return assigned
+
+    @staticmethod
+    def validate_immutability(
+        old_items: list[dict],
+        new_items: list[dict],
+        id_field: str = "id",
+        stable_id_field: str = "uuid",
+    ) -> list[dict]:
+        """Check that UUIDs are immutable across versions.
+
+        Args:
+            old_items: Previous version of entity list.
+            new_items: New version of entity list.
+            id_field: Logical ID field.
+            stable_id_field: UUID field.
+
+        Returns:
+            List of violations. Empty list means all UUIDs are valid.
+        """
+        violations = []
+        old_map = {
+            item.get(id_field, ""): item.get(stable_id_field)
+            for item in old_items
+            if isinstance(item, dict) and item.get(stable_id_field)
+        }
+        new_map = {
+            item.get(id_field, ""): item.get(stable_id_field)
+            for item in new_items
+            if isinstance(item, dict) and item.get(stable_id_field)
+        }
+
+        for logical_id, old_uuid in old_map.items():
+            if old_uuid is None:
+                continue
+            if logical_id in new_map:
+                new_uuid = new_map[logical_id]
+                if new_uuid is not None and new_uuid != old_uuid:
+                    violations.append({
+                        "logical_id": logical_id,
+                        "old_uuid": old_uuid,
+                        "new_uuid": new_uuid,
+                        "message": (
+                            f"UUID for '{logical_id}' changed from "
+                            f"{old_uuid[:8]}... to {new_uuid[:8]}..."
+                        ),
+                    })
+
+        return violations
+
+    @staticmethod
+    def trace(
+        entity_id: str,
+        factory_dir: Path,
+    ) -> Optional[dict]:
+        """Trace a UUID across all artifacts in a factory directory.
+
+        Searches PRD, SDD, and schema.json for the given UUID.
+
+        Args:
+            entity_id: The UUID to trace.
+            factory_dir: Path to the .factory directory.
+
+        Returns:
+            A dict with trace results, or None if not found.
+        """
+        if not factory_dir.exists():
+            raise StableIdError(f"Factory directory not found: {factory_dir}")
+
+        artifacts = ["prd.json", "sdd.json", "schema.json"]
+        found = []
+
+        for art_name in artifacts:
+            art_path = factory_dir / art_name
+            if not art_path.exists():
+                continue
+
+            try:
+                data = json.loads(art_path.read_text())
+            except (json.JSONDecodeError, FileNotFoundError):
+                continue
+
+            matches = StableIdManager._find_uuid_in_artifact(
+                data, entity_id, art_name.replace(".json", "")
+            )
+            found.extend(matches)
+
+        if not found:
+            return None
+
+        return {
+            "uuid": entity_id,
+            "found_in": len(found),
+            "locations": found,
+        }
+
+    @staticmethod
+    def _find_uuid_in_artifact(
+        data: Any, target_uuid: str, artifact_name: str, path: str = "$"
+    ) -> list[dict]:
+        """Recursively search for a UUID in an artifact dict.
+
+        Returns list of locations where the UUID was found.
+        """
+        results = []
+
+        if isinstance(data, dict):
+            for key, value in data.items():
+                if key == "uuid" and isinstance(value, str) and value == target_uuid:
+                    entity_id = data.get("id", data.get("name", "?"))
+                    entity_type = StableIdManager._infer_entity_type(
+                        artifact_name, data, path
+                    )
+                    results.append({
+                        "artifact": artifact_name,
+                        "path": path,
+                        "entity_id": entity_id,
+                        "entity_type": entity_type,
+                    })
+                elif isinstance(value, (dict, list)):
+                    child_path = f"{path}.{key}" if path != "$" else f"$.{key}"
+                    results.extend(
+                        StableIdManager._find_uuid_in_artifact(
+                            value, target_uuid, artifact_name, child_path
+                        )
+                    )
+
+        elif isinstance(data, list):
+            for i, item in enumerate(data):
+                child_path = f"{path}[{i}]"
+                results.extend(
+                    StableIdManager._find_uuid_in_artifact(
+                        item, target_uuid, artifact_name, child_path
+                    )
+                )
+
+        return results
+
+    @staticmethod
+    def _infer_entity_type(artifact_name: str, data: dict, path: str) -> str:
+        """Infer the entity type from context."""
+        if artifact_name == "prd":
+            if "functional_requirements" in path:
+                return "requirement"
+            if "non_functional_requirements" in path:
+                return "requirement"
+            return "unknown"
+        if artifact_name == "sdd":
+            if "models" in path and "fields" not in path:
+                return "model"
+            return "unknown"
+        if artifact_name == "schema":
+            if "fields" in path and path.count("fields") > path.count("models"):
+                return "field"
+            if "models" in path and "fields" not in path:
+                return "model"
+            return "unknown"
+        return "unknown"

--- a/tests/test_artifact_contracts.py
+++ b/tests/test_artifact_contracts.py
@@ -1,6 +1,7 @@
 """Tests for artifact contract validation — invariants, ownership, and allowed mutations."""
 
 import json
+import uuid
 from pathlib import Path
 
 import pytest
@@ -17,7 +18,7 @@ def _make_prd(requirements=None, stakeholders=None):
         ],
         "objectives": ["Obj 1"],
         "functional_requirements": requirements if requirements is not None else [
-            {"id": "RF-001", "description": "Login screen"},
+            {"id": "RF-001", "description": "Login screen", "uuid": str(uuid.uuid4())},
         ],
         "non_functional_requirements": [],
         "acceptance_criteria": [],

--- a/tests/test_stable_ids.py
+++ b/tests/test_stable_ids.py
@@ -1,0 +1,273 @@
+"""Tests for stable IDs — UUID v4 generation, assignment, immutability, and tracing."""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from fba.stable_ids import StableIdManager, StableIdError
+
+
+UUID4_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+
+class TestUuidGeneration:
+    """Tests for UUID v4 generation."""
+
+    def test_generate_uuid_is_valid_format(self):
+        uid = StableIdManager.generate_id()
+        assert UUID4_RE.match(uid), f"Not a valid UUID v4: {uid}"
+
+    def test_generate_uuid_is_unique(self):
+        ids = {StableIdManager.generate_id() for _ in range(100)}
+        assert len(ids) == 100
+
+    def test_assign_id_requirement(self):
+        uid = StableIdManager.assign_id("RF-001", "requirement")
+        assert UUID4_RE.match(uid)
+
+    def test_assign_id_model(self):
+        uid = StableIdManager.assign_id("res.partner", "model")
+        assert UUID4_RE.match(uid)
+
+    def test_assign_id_field(self):
+        uid = StableIdManager.assign_id("name", "field")
+        assert UUID4_RE.match(uid)
+
+    def test_assign_id_invalid_type(self):
+        with pytest.raises(StableIdError, match="Unknown entity type"):
+            StableIdManager.assign_id("x", "invalid_type")
+
+
+class TestEnsureIds:
+    """Tests for ensuring UUIDs in entity arrays."""
+
+    def test_ensure_ids_assigns_to_items_without_uuid(self):
+        items = [
+            {"id": "RF-001", "description": "Login"},
+            {"id": "RF-002", "description": "Logout"},
+        ]
+        assigned = StableIdManager.ensure_ids_in_array(items, "requirement")
+
+        assert assigned == 2
+        assert UUID4_RE.match(items[0]["uuid"])
+        assert UUID4_RE.match(items[1]["uuid"])
+
+    def test_ensure_ids_preserves_existing_uuids(self):
+        existing_uuid = StableIdManager.generate_id()
+        items = [
+            {"id": "RF-001", "description": "Login", "uuid": existing_uuid},
+            {"id": "RF-002", "description": "Logout"},
+        ]
+        assigned = StableIdManager.ensure_ids_in_array(items, "requirement")
+
+        assert assigned == 1
+        assert items[0]["uuid"] == existing_uuid
+        assert UUID4_RE.match(items[1]["uuid"])
+
+    def test_ensure_ids_empty_list(self):
+        assigned = StableIdManager.ensure_ids_in_array([], "requirement")
+        assert assigned == 0
+
+    def test_ensure_ids_skips_non_dict_items(self):
+        items = [{"id": "RF-001"}, "not a dict", 42]
+        assigned = StableIdManager.ensure_ids_in_array(items, "requirement")
+        assert assigned == 1
+
+
+class TestUuidImmutability:
+    """Tests for UUID immutability validation."""
+
+    def test_unchanged_uuid_passes(self):
+        uid = StableIdManager.generate_id()
+        old_items = [{"id": "RF-001", "uuid": uid, "description": "Old"}]
+        new_items = [{"id": "RF-001", "uuid": uid, "description": "New"}]
+
+        violations = StableIdManager.validate_immutability(old_items, new_items)
+        assert violations == []
+
+    def test_changed_uuid_fails(self):
+        old_items = [{"id": "RF-001", "uuid": StableIdManager.generate_id()}]
+        new_items = [{"id": "RF-001", "uuid": StableIdManager.generate_id()}]
+
+        violations = StableIdManager.validate_immutability(old_items, new_items)
+        assert len(violations) >= 1
+        assert violations[0]["logical_id"] == "RF-001"
+
+    def test_new_item_no_uuid_passes(self):
+        old_items = [{"id": "RF-001", "uuid": StableIdManager.generate_id()}]
+        new_items = [{"id": "RF-001", "uuid": StableIdManager.generate_id()}, {"id": "RF-002"}]
+
+        violations = StableIdManager.validate_immutability(old_items, new_items)
+        assert len(violations) >= 1
+
+    def test_item_removed_no_violation(self):
+        old_items = [{"id": "RF-001", "uuid": StableIdManager.generate_id()}]
+        new_items = []
+
+        violations = StableIdManager.validate_immutability(old_items, new_items)
+        assert violations == []
+
+    def test_no_uuids_no_violations(self):
+        old_items = [{"id": "RF-001"}]
+        new_items = [{"id": "RF-001", "description": "Changed"}]
+
+        violations = StableIdManager.validate_immutability(old_items, new_items)
+        assert violations == []
+
+
+class TestTrace:
+    """Tests for UUID tracing across artifacts."""
+
+    def test_trace_finds_uuid_in_prd(self, tmp_path):
+        factory = tmp_path / ".factory"
+        factory.mkdir()
+        uid = StableIdManager.generate_id()
+        prd = {
+            "functional_requirements": [
+                {"id": "RF-001", "description": "Login", "uuid": uid},
+            ],
+        }
+        (factory / "prd.json").write_text(json.dumps(prd))
+
+        result = StableIdManager.trace(uid, factory)
+
+        assert result is not None
+        assert result["found_in"] >= 1
+        locations = result["locations"]
+        assert any("RF-001" in str(loc.get("entity_id", "")) for loc in locations)
+
+    def test_trace_finds_uuid_in_sdd(self, tmp_path):
+        factory = tmp_path / ".factory"
+        factory.mkdir()
+        uid = StableIdManager.generate_id()
+        sdd = {
+            "models": [
+                {"name": "test.model", "uuid": uid},
+            ],
+        }
+        (factory / "sdd.json").write_text(json.dumps(sdd))
+
+        result = StableIdManager.trace(uid, factory)
+
+        assert result is not None
+        assert result["found_in"] >= 1
+
+    def test_trace_finds_uuid_in_schema(self, tmp_path):
+        factory = tmp_path / ".factory"
+        factory.mkdir()
+        uid = StableIdManager.generate_id()
+        schema_data = {
+            "models": [
+                {"name": "test.model", "fields": [{"name": "field1", "type": "char", "uuid": uid}]},
+            ],
+        }
+        (factory / "schema.json").write_text(json.dumps(schema_data))
+
+        result = StableIdManager.trace(uid, factory)
+
+        assert result is not None
+        assert result["found_in"] >= 1
+
+    def test_trace_not_found(self, tmp_path):
+        factory = tmp_path / ".factory"
+        factory.mkdir()
+        (factory / "prd.json").write_text("{}")
+
+        result = StableIdManager.trace("00000000-0000-0000-0000-000000000000", factory)
+        assert result is None
+
+    def test_trace_factory_not_found(self, tmp_path):
+        with pytest.raises(StableIdError, match="not found"):
+            StableIdManager.trace("any-uuid", tmp_path / "nonexistent")
+
+    def test_trace_handles_malformed_json(self, tmp_path):
+        factory = tmp_path / ".factory"
+        factory.mkdir()
+        (factory / "prd.json").write_text("not json {{")
+
+        result = StableIdManager.trace("any-uuid", factory)
+        assert result is None
+
+
+class TestStableIdsCli:
+    """Tests for the fba trace CLI command."""
+
+    def test_trace_cli_found(self, tmp_path):
+        from click.testing import CliRunner
+        from fba.cli import main
+
+        factory = tmp_path / ".factory"
+        factory.mkdir()
+        uid = StableIdManager.generate_id()
+        prd = {
+            "functional_requirements": [
+                {"id": "RF-001", "description": "Login", "uuid": uid},
+            ],
+        }
+        (factory / "prd.json").write_text(json.dumps(prd))
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["trace", uid, "--project-dir", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert "RF-001" in result.output
+
+    def test_trace_cli_not_found(self, tmp_path):
+        from click.testing import CliRunner
+        from fba.cli import main
+
+        factory = tmp_path / ".factory"
+        factory.mkdir()
+        (factory / "prd.json").write_text("{}")
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["trace", "00000000-0000-0000-0000-000000000000", "--project-dir", str(tmp_path)])
+
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+
+class TestUuidInContracts:
+    """Tests for UUID immutability via contract engine."""
+
+    def test_uuid_immutability_via_contract(self):
+        from fba.contract_engine import ContractEngine
+
+        engine = ContractEngine()
+        uid1 = StableIdManager.generate_id()
+        uid2 = StableIdManager.generate_id()
+
+        old_prd = {
+            "vision": "Test vision long enough",
+            "stakeholders": [{"name": "A", "role": "PM", "interest": "X"}],
+            "objectives": ["Obj 1"],
+            "functional_requirements": [
+                {"id": "RF-001", "description": "Login", "uuid": uid1},
+            ],
+            "non_functional_requirements": [],
+            "acceptance_criteria": [],
+            "glossary": [],
+        }
+        new_prd = {
+            "vision": "Test vision long enough",
+            "stakeholders": [{"name": "A", "role": "PM", "interest": "X"}],
+            "objectives": ["Obj 1"],
+            "functional_requirements": [
+                {"id": "RF-001", "description": "Login", "uuid": uid2},
+            ],
+            "non_functional_requirements": [],
+            "acceptance_criteria": [],
+            "glossary": [],
+        }
+
+        violations = engine.validate_mutations("prd", old_prd, new_prd)
+
+        uuid_violations = [
+            v for v in violations if v["id"] == "prd-uuids-are-immutable"
+        ]
+        assert len(uuid_violations) >= 1
+        assert uuid_violations[0]["logical_id"] == "RF-001"


### PR DESCRIPTION
## Summary
- StableIdManager in src/fba/stable_ids.py: UUID v4 generation, assignment, immutability validation, tracing
- New CLI: fba trace <uuid> — searches PRD, SDD, schema.json for the entity
- Contract: prd-requirements-have-uuids invariant + prd-uuids-are-immutable mutation rule
- uuid_immutability rule in ContractEngine
- 24 tests: UUID generation, ensure_ids, immutability, tracing, CLI, contract integration

## Verification
```
pytest tests/test_stable_ids.py -v         → 24 passed
pytest tests/test_artifact_contracts.py -v → 29 passed
pytest                                     → 604 passed, 0 failures
```

Closes #121