### PR TITLE
docs(#146): preparar marco Codex para M16

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,0 +1,18 @@
+# Contexto local de .codex
+
+Esta carpeta contiene el marco de colaboracion entre Codex y el desarrollo del
+framework FBA. No forma parte del runtime de `fba`, no se copia a proyectos
+Odoo con `fba init`, y no reemplaza `.opencode/`.
+
+## Reglas
+
+- Mantener estos archivos como documentacion operativa para Codex.
+- No introducir dependencias, scripts runtime ni configuracion de producto aqui.
+- Respetar siempre las fuentes de verdad del repositorio:
+  - `AGENTS.md`
+  - `CONTRIBUTING.md`
+  - `ROADMAP.md`
+  - `CHANGELOG.md`
+- Si un cambio en `.codex` modifica el modo de trabajo del agente, registrar el
+  cambio en `CHANGELOG.md`.
+- Escribir en espanol, con identificadores tecnicos en ingles cuando aplique.

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,48 @@
+# Marco Codex para FBA
+
+`.codex/` define como trabajar con Codex en el meta-desarrollo de Factory Build
+Agent. Es equivalente en intencion al sistema `.opencode/`, pero no es runtime:
+son guias, roles y checklists para mantener el trabajo alineado con el flujo del
+repositorio.
+
+## Fuentes de verdad
+
+Antes de planificar o implementar, Codex debe leer o verificar:
+
+- `AGENTS.md` para arquitectura y convenciones del proyecto.
+- `CONTRIBUTING.md` para issue, branch, commit, PR y validacion.
+- `ROADMAP.md` para el milestone activo y dependencias.
+- `CHANGELOG.md` para registrar cambios notables.
+- `.factory/framework-state.json` para estado del meta-desarrollo.
+
+## Roles
+
+Los archivos en `.codex/agents/` no son agentes ejecutables. Son perfiles de
+trabajo que Codex usa como lentes segun la tarea:
+
+- `codex-framework-orchestrator.md`: coordina la sesion y protege el flujo.
+- `codex-framework-planner.md`: convierte intenciones en briefs ejecutables.
+- `codex-framework-builder.md`: implementa cambios acotados con tests.
+- `codex-framework-reviewer.md`: revisa riesgos, bugs y cobertura.
+- `codex-framework-git.md`: prepara operaciones git segun `CONTRIBUTING.md`.
+
+## Flujo de sesion
+
+1. Confirmar rama actual y estado del worktree.
+2. Verificar o crear issue antes de editar archivos.
+3. Trabajar desde una rama `feat/` derivada del milestone activo.
+4. Si la tarea es amplia, crear o actualizar un brief en `.factory/`.
+5. Implementar una sub-tarea por vez, con tests cuando aplique.
+6. Ejecutar verificacion relevante antes de cerrar.
+7. Registrar cambios notables en `CHANGELOG.md`.
+8. No abrir PR a `main` sin confirmacion explicita del usuario.
+
+## M16
+
+Para M16, el marco debe mantener separados:
+
+- Preparacion del entorno de colaboracion Codex: cambios en `.codex/`.
+- Implementacion del milestone: `feat/16.1`, `feat/16.2`, `feat/16.3`.
+
+La implementacion funcional de M16 empieza despues de tener issue, branch, brief
+y alcance confirmados.

--- a/.codex/agents/codex-framework-builder.md
+++ b/.codex/agents/codex-framework-builder.md
@@ -1,0 +1,31 @@
+# Codex Framework Builder
+
+## Proposito
+
+Implementar cambios del framework FBA de forma acotada, verificable y alineada
+con `CONTRIBUTING.md`.
+
+## Precondiciones
+
+- Existe issue de GitHub.
+- La rama activa no es `main`.
+- Para feats de milestone, la rama activa es `feat/X.Y-descripcion`.
+- El alcance esta claro en el mensaje del usuario o en un brief de `.factory/`.
+
+## Flujo
+
+1. Leer contexto relevante antes de editar.
+2. Si el cambio es de riesgo medio o alto, escribir o ajustar tests primero.
+3. Implementar solo lo necesario para el objetivo.
+4. Actualizar documentacion si cambia alcance, arquitectura, agentes, schemas o
+   comportamiento de usuario.
+5. Ejecutar verificacion relevante.
+6. Reportar resultados y blockers.
+
+## Limites
+
+- No hacer commits sin confirmacion del usuario.
+- No abrir PRs a `main`.
+- No iniciar el siguiente feat secuencial del milestone si el anterior aun no
+  fue mergeado, salvo instruccion explicita del usuario.
+- No tocar cambios no relacionados del worktree.

--- a/.codex/agents/codex-framework-git.md
+++ b/.codex/agents/codex-framework-git.md
@@ -1,0 +1,29 @@
+# Codex Framework Git
+
+## Proposito
+
+Preparar operaciones git para el meta-desarrollo de FBA respetando el flujo del
+repositorio.
+
+## Reglas criticas
+
+- Nunca commitear en `main`.
+- Nunca abrir PR a `main` sin confirmacion explicita del usuario.
+- No usar `--force`, `--no-verify` ni comandos destructivos sin permiso.
+- Todo commit debe referenciar issue: `tipo(#NN): descripcion`.
+
+## Operaciones habituales
+
+- Crear rama de milestone desde `main`: `milestone/X.0-descripcion`.
+- Crear rama de feature desde milestone: `feat/X.Y-descripcion`.
+- Preparar commit convencional despues de tests.
+- Preparar PR de `feat/` a `milestone/`.
+- Preparar PR de `milestone/` a `main` solo tras validacion manual.
+
+## Checklist pre-commit
+
+- `git status` revisado.
+- Archivos modificados pertenecen al alcance.
+- Tests/verificaciones ejecutadas.
+- `CHANGELOG.md` actualizado si el cambio es notable.
+- Mensaje sigue Conventional Commits con issue.

--- a/.codex/agents/codex-framework-orchestrator.md
+++ b/.codex/agents/codex-framework-orchestrator.md
@@ -1,0 +1,35 @@
+# Codex Framework Orchestrator
+
+## Proposito
+
+Coordinar sesiones de meta-desarrollo del framework FBA con Codex. Su trabajo es
+mantener contexto, proceso y alcance claros antes de planificar o implementar.
+
+## Responsabilidades
+
+- Leer contexto minimo: `AGENTS.md`, `CONTRIBUTING.md`, `ROADMAP.md`,
+  `CHANGELOG.md` y `.factory/framework-state.json`.
+- Confirmar branch y worktree antes de cambios.
+- Verificar que exista issue antes de escribir codigo o documentacion versionada.
+- Separar preparacion, planificacion, implementacion, revision y git.
+- Escalar al usuario decisiones que afectan PR a `main`, arquitectura o alcance.
+- Mantener los cambios acotados al objetivo de la sesion.
+
+## Reglas
+
+- No saltar `CONTRIBUTING.md`.
+- No asumir que `.codex/` es runtime del framework.
+- No modificar `.opencode/` salvo que el usuario lo pida explicitamente.
+- No mezclar preparacion del marco Codex con implementacion funcional de M16.
+- No usar subagentes de Codex salvo que el usuario pida delegacion o trabajo en
+  paralelo de forma explicita.
+
+## Cierre de sesion
+
+Reportar:
+
+- Issue usado.
+- Branch activo.
+- Archivos modificados.
+- Verificacion ejecutada.
+- Siguiente paso recomendado.

--- a/.codex/agents/codex-framework-planner.md
+++ b/.codex/agents/codex-framework-planner.md
@@ -1,0 +1,44 @@
+# Codex Framework Planner
+
+## Proposito
+
+Transformar intenciones del usuario en briefs ejecutables para el desarrollo del
+framework FBA.
+
+## Principio
+
+El planner define que debe lograrse, restricciones, dependencias y verificaciones.
+No pre-implementa la solucion ni fija detalles internos innecesarios.
+
+## Entradas
+
+- Intencion del usuario.
+- Milestone activo en `ROADMAP.md`.
+- Estado en `.factory/framework-state.json`.
+- Reglas de `CONTRIBUTING.md`.
+- Impacto documental esperado en `AGENTS.md`, `ROADMAP.md`, `CHANGELOG.md` y
+  `docs/testing/`.
+
+## Salida
+
+Un brief en `.factory/` cuando la tarea sea amplia o parte de un milestone. El
+brief debe incluir:
+
+- Issue.
+- Branch.
+- Objetivo medible.
+- Feats ordenados.
+- Restricciones.
+- Tests requeridos.
+- Definicion de Done.
+- Documentacion a actualizar.
+
+## Criterios para preguntar
+
+Preguntar antes de planificar si:
+
+- Falta confirmar alcance funcional.
+- No existe issue y Codex no puede crearlo.
+- El cambio contradice una decision arquitectonica documentada.
+- El usuario pide alterar el orden del roadmap.
+- El cambio podria requerir PR a `main`.

--- a/.codex/agents/codex-framework-reviewer.md
+++ b/.codex/agents/codex-framework-reviewer.md
@@ -1,0 +1,26 @@
+# Codex Framework Reviewer
+
+## Proposito
+
+Revisar cambios del framework con foco en bugs, regresiones, riesgos de proceso
+y cobertura faltante.
+
+## Prioridades
+
+1. Violaciones de `CONTRIBUTING.md`.
+2. Cambios que rompen arquitectura documentada en `AGENTS.md`.
+3. Regresiones funcionales o de CLI.
+4. Tests faltantes para comportamiento nuevo.
+5. Documentacion incompleta en `CHANGELOG.md`, `ROADMAP.md` o `docs/testing/`.
+
+## Formato de respuesta
+
+Cuando el usuario pida review:
+
+- Findings primero, ordenados por severidad.
+- Referencias a archivo y linea cuando sea posible.
+- Preguntas abiertas o supuestos.
+- Resumen breve al final.
+
+Si no hay hallazgos, decirlo claramente e indicar riesgo residual o tests no
+ejecutados.

--- a/.codex/checklists/m16-start.md
+++ b/.codex/checklists/m16-start.md
@@ -1,0 +1,14 @@
+# Checklist de inicio M16
+
+Usar antes de implementar funcionalidades de Foundation Intelligence.
+
+- [ ] Confirmar rama base: `milestone/16.0-foundation-intelligence`.
+- [ ] Crear o verificar epic issue de M16.
+- [ ] Crear sub-issue para `feat/16.1-module-registry-autoindexado`.
+- [ ] Crear rama `feat/16.1-module-registry-autoindexado` desde el milestone.
+- [ ] Leer `ROADMAP.md` seccion M16 completa.
+- [ ] Leer implementacion actual de `ModuleRegistry`.
+- [ ] Identificar schemas, CLI y tests existentes relacionados con registry.
+- [ ] Crear o actualizar brief M16 en `.factory/`.
+- [ ] Definir verificacion minima para `fba registry index` e inspect.
+- [ ] Registrar cambios notables en `CHANGELOG.md`.

--- a/.codex/templates/fw-brief-template.md
+++ b/.codex/templates/fw-brief-template.md
@@ -1,0 +1,26 @@
+# Brief: [objetivo en una oracion]
+
+- **Issue**: #[NN]
+- **Branch**: `feat/X.Y-descripcion`
+- **Objetivo**: [resultado medible]
+- **Complejidad**: baja / media / alta
+- **Restricciones**: [reglas, dependencias, limites]
+
+## Feats
+
+| Orden | Feat | Depende de | Que debe lograr |
+|-------|------|------------|-----------------|
+| 1 | feat/X.Y-descripcion | — | [resultado esperado] |
+
+## Tests requeridos
+
+- [ ] [escenario verificable]
+- [ ] [escenario verificable]
+
+## Definicion de Done
+
+- [ ] Issue y branch cumplen `CONTRIBUTING.md`.
+- [ ] Implementacion dentro del alcance.
+- [ ] Tests relevantes pasan.
+- [ ] Documentacion actualizada si aplica.
+- [ ] `CHANGELOG.md` actualizado si el cambio es notable.

--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -4,9 +4,9 @@
   "last_session": {
     "date": "2026-05-14",
     "agent": "codex",
-    "action": "Issue #144: integrado fba-mejoras-post-roadmap.md como roadmap post-M15 planificado (M16-M22), sin marcar features futuras como completadas.",
+    "action": "Preparacion M16: creados label milestone/16, epic #148, issue #147 para feat/16.1 y brief local .factory/fw-brief-m16.md.",
     "completed_feats": [],
-    "pending_feats": ["16.1", "16.2", "16.3"],
+    "pending_feats": ["16.1 (#147)", "16.2", "16.3"],
     "blockers": []
   },
   "active_milestone": {
@@ -86,6 +86,12 @@
       "description": "M14 Odoo Depth: 3 feats (wizards/workflows, migraciones, i18n)",
       "created": "2026-05-13T00:00:00Z",
       "status": "completed"
+    },
+    {
+      "file": ".factory/fw-brief-m16.md",
+      "description": "M16 Foundation Intelligence: preparacion de epic #148 y primer feat #147 (ModuleRegistry autoindexado)",
+      "created": "2026-05-14T00:00:00Z",
+      "status": "ready"
     }
   ],
   "pending_decisions": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased] - 2026-05-14
 
+### Infraestructura de colaboracion
+- #146: Creado marco `.codex/` para trabajar con Codex en el meta-desarrollo del framework, con roles operativos, checklist de inicio M16 y plantilla de brief sin modificar runtime ni templates.
+
 ### Planificacion
+- #148/#147: Preparado arranque de M16 con epic, primer issue funcional (`feat/16.1-module-registry-autoindexado`) y brief local `.factory/fw-brief-m16.md`.
 - #144: Integrado `fba-mejoras-post-roadmap.md` al roadmap oficial como milestones planificados M16-M22.
 - #144: Movido el detalle historico de milestones completados M0-M15 a `ROADMAP_CHECK.md`, dejando `ROADMAP.md` enfocado en el roadmap activo.
 - M16-M22 quedan ordenados por dependencias: Foundation Intelligence, Semantic Core, Input & Extension Layer, Governance & Observability, Graph Enforcement Gates, Learning Loop, y Sustainability & Cost Control.


### PR DESCRIPTION
## Resumen

- Agrega el marco operativo `.codex/` para sesiones Codex sobre el meta-desarrollo de FBA.
- Documenta roles, checklist de inicio M16 y plantilla de brief.
- Registra en el estado del framework el arranque preparado de M16 con epic #148 y feat #147.
- Actualiza CHANGELOG.md con la preparacion de colaboracion y planificacion M16.

## Validacion

- `python3 -m json.tool .factory/framework-state.json`
- `pytest` -> 731 passed, 1 warning

Closes #146
