### PR TITLE
feat(#161): add agent graph emission consolidation

### DIFF
--- a/src/fba/cli.py
+++ b/src/fba/cli.py
@@ -11,6 +11,7 @@ from fba.contract_engine import ContractEngine, ContractError
 from fba.dependency_analyzer import DependencyAnalyzer, DependencyError
 from fba.diff_engine import DiffEngine, DiffError
 from fba.gate import GateError
+from fba.graph_emission import GraphEmissionError, consolidate_graph_emissions
 from fba.i18n_manager import I18nManager
 from fba.migration_manager import MigrationError, MigrationManager
 from fba.performance import PerformanceError, PerformanceRunner
@@ -1155,6 +1156,26 @@ def _print_graph_orphans(project_dir: str | None) -> None:
     click.echo(f"Orphan nodes: {len(orphans)}")
     for node in orphans:
         click.echo(f"  - {node['label']} ({node['type']}) {node['id']}")
+
+
+@_graph_group.command("consolidate")
+@PROJECT_DIR_OPTION
+@click.option("--emissions-dir", default=None, type=click.Path(path_type=Path), help="Directory with agent graph emission JSON files")
+def graph_consolidate(project_dir: str | None, emissions_dir: Path | None) -> None:
+    """Merge agent graph emissions into .factory/graph.json."""
+    target = _resolve_project_dir(project_dir)
+    try:
+        result = consolidate_graph_emissions(target, emissions_dir=emissions_dir)
+    except GraphEmissionError as e:
+        click.echo(f"Error: {e}", err=True)
+        raise SystemExit(1)
+
+    click.echo("Graph emissions consolidated.")
+    click.echo(f"  Emissions: {result.emissions}")
+    click.echo(f"  Nodes added: {result.nodes_added}")
+    click.echo(f"  Nodes updated: {result.nodes_updated}")
+    click.echo(f"  Edges added: {result.edges_added}")
+    click.echo(f"  Edges skipped: {result.edges_skipped}")
 
 
 @main.command()

--- a/src/fba/graph_emission.py
+++ b/src/fba/graph_emission.py
@@ -1,0 +1,220 @@
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, cast
+
+from fba.semantic_graph import EDGE_TYPES, NODE_TYPES, GraphManager, SemanticGraphError
+from fba.stable_ids import StableIdManager
+
+
+class GraphEmissionError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class GraphEmissionResult:
+    emissions: int = 0
+    nodes_added: int = 0
+    nodes_updated: int = 0
+    edges_added: int = 0
+    edges_skipped: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+
+class GraphEmissionManager:
+    def __init__(self, project_dir: Path, emissions_dir: Path | None = None) -> None:
+        self.project_dir = project_dir
+        self.emissions_dir = emissions_dir or project_dir / ".factory" / "graph_emissions"
+        self.graph_manager = GraphManager(project_dir)
+
+    def consolidate(self) -> GraphEmissionResult:
+        graph = self.graph_manager.load()
+        node_by_id = {node["id"]: node for node in graph.get("nodes", [])}
+        node_by_ref = self._node_ref_map(graph)
+        edge_keys = {(edge["type"], edge["source"], edge["target"]) for edge in graph.get("edges", [])}
+        edge_ids = {edge["id"] for edge in graph.get("edges", [])}
+        stats = {
+            "emissions": 0,
+            "nodes_added": 0,
+            "nodes_updated": 0,
+            "edges_added": 0,
+            "edges_skipped": 0,
+        }
+        warnings: list[str] = []
+
+        for emission_path, emission in self._load_emissions():
+            stats["emissions"] += 1
+            agent = self._required_string(emission, "agent", emission_path)
+            artifact = emission.get("artifact")
+            if artifact is not None and not isinstance(artifact, str):
+                raise GraphEmissionError(f"{emission_path}: artifact must be a string")
+
+            for raw_node in emission.get("nodes", []):
+                node = self._normalize_node(raw_node, agent, artifact, emission_path)
+                ref = cast(dict[str, Any], node.get("properties", {})).get("ref")
+                existing = node_by_id.get(node["id"])
+                if existing is None and isinstance(ref, str):
+                    existing = node_by_ref.get(ref)
+                if existing is None:
+                    graph.setdefault("nodes", []).append(node)
+                    node_by_id[node["id"]] = node
+                    if isinstance(ref, str):
+                        node_by_ref[ref] = node
+                    stats["nodes_added"] += 1
+                    continue
+                self._merge_node(existing, node)
+                node_by_id[existing["id"]] = existing
+                if isinstance(ref, str):
+                    node_by_ref[ref] = existing
+                stats["nodes_updated"] += 1
+
+            for raw_edge in emission.get("edges", []):
+                edge = self._normalize_edge(raw_edge, node_by_id, node_by_ref, emission_path)
+                key = (edge["type"], edge["source"], edge["target"])
+                if edge["id"] in edge_ids or key in edge_keys:
+                    stats["edges_skipped"] += 1
+                    continue
+                graph.setdefault("edges", []).append(edge)
+                edge_ids.add(edge["id"])
+                edge_keys.add(key)
+                stats["edges_added"] += 1
+
+        self.graph_manager.save(graph)
+        return GraphEmissionResult(**stats, warnings=warnings)
+
+    def _load_emissions(self) -> list[tuple[Path, dict[str, Any]]]:
+        if not self.emissions_dir.exists():
+            return []
+        emissions: list[tuple[Path, dict[str, Any]]] = []
+        for path in sorted(self.emissions_dir.glob("*.json")):
+            try:
+                payload = json.loads(path.read_text())
+            except json.JSONDecodeError as e:
+                raise GraphEmissionError(f"Invalid JSON in {path}: {e}") from e
+            if isinstance(payload, list):
+                for item in payload:
+                    if not isinstance(item, dict):
+                        raise GraphEmissionError(f"{path}: emission entries must be objects")
+                    emissions.append((path, item))
+            elif isinstance(payload, dict):
+                emissions.append((path, payload))
+            else:
+                raise GraphEmissionError(f"{path}: emission payload must be an object or array")
+        return emissions
+
+    def _normalize_node(
+        self,
+        raw_node: dict[str, Any],
+        agent: str,
+        artifact: str | None,
+        path: Path,
+    ) -> dict[str, Any]:
+        if not isinstance(raw_node, dict):
+            raise GraphEmissionError(f"{path}: node entries must be objects")
+        node_type = self._required_string(raw_node, "type", path)
+        if node_type not in NODE_TYPES:
+            raise GraphEmissionError(f"{path}: unknown node type: {node_type}")
+        label = self._required_string(raw_node, "label", path)
+        node = {
+            "id": raw_node.get("id") or StableIdManager.generate_id(),
+            "type": node_type,
+            "label": label,
+        }
+        for key in ("description", "source_artifact"):
+            value = raw_node.get(key)
+            if value is not None:
+                if not isinstance(value, str):
+                    raise GraphEmissionError(f"{path}: node {key} must be a string")
+                node[key] = value
+        if artifact and "source_artifact" not in node:
+            node["source_artifact"] = artifact
+        properties = raw_node.get("properties", {})
+        if not isinstance(properties, dict):
+            raise GraphEmissionError(f"{path}: node properties must be an object")
+        merged_properties = {**properties, "agent": agent}
+        if "ref" in raw_node:
+            ref = raw_node["ref"]
+            if not isinstance(ref, str) or not ref:
+                raise GraphEmissionError(f"{path}: node ref must be a non-empty string")
+            merged_properties["ref"] = ref
+        node["properties"] = merged_properties
+        return node
+
+    def _normalize_edge(
+        self,
+        raw_edge: dict[str, Any],
+        node_by_id: dict[str, dict[str, Any]],
+        node_by_ref: dict[str, dict[str, Any]],
+        path: Path,
+    ) -> dict[str, Any]:
+        if not isinstance(raw_edge, dict):
+            raise GraphEmissionError(f"{path}: edge entries must be objects")
+        edge_type = self._required_string(raw_edge, "type", path)
+        if edge_type not in EDGE_TYPES:
+            raise GraphEmissionError(f"{path}: unknown edge type: {edge_type}")
+        source = self._resolve_endpoint(self._required_string(raw_edge, "source", path), node_by_id, node_by_ref, path)
+        target = self._resolve_endpoint(self._required_string(raw_edge, "target", path), node_by_id, node_by_ref, path)
+        edge = {
+            "id": raw_edge.get("id") or StableIdManager.generate_id(),
+            "type": edge_type,
+            "source": source,
+            "target": target,
+        }
+        label = raw_edge.get("label")
+        if label is not None:
+            if not isinstance(label, str):
+                raise GraphEmissionError(f"{path}: edge label must be a string")
+            edge["label"] = label
+        properties = raw_edge.get("properties")
+        if properties is not None:
+            if not isinstance(properties, dict):
+                raise GraphEmissionError(f"{path}: edge properties must be an object")
+            edge["properties"] = properties
+        return edge
+
+    @staticmethod
+    def _required_string(payload: dict[str, Any], key: str, path: Path) -> str:
+        value = payload.get(key)
+        if not isinstance(value, str) or not value:
+            raise GraphEmissionError(f"{path}: missing required string field: {key}")
+        return value
+
+    @staticmethod
+    def _node_ref_map(graph: dict[str, Any]) -> dict[str, dict[str, Any]]:
+        refs: dict[str, dict[str, Any]] = {}
+        for node in graph.get("nodes", []):
+            properties = node.get("properties", {})
+            if isinstance(properties, dict) and isinstance(properties.get("ref"), str):
+                refs[properties["ref"]] = node
+        return refs
+
+    @staticmethod
+    def _merge_node(existing: dict[str, Any], incoming: dict[str, Any]) -> None:
+        existing["label"] = incoming["label"]
+        for key in ("description", "source_artifact"):
+            if key in incoming:
+                existing[key] = incoming[key]
+        existing_properties = existing.setdefault("properties", {})
+        incoming_properties = incoming.get("properties", {})
+        if isinstance(existing_properties, dict) and isinstance(incoming_properties, dict):
+            existing_properties.update(incoming_properties)
+
+    @staticmethod
+    def _resolve_endpoint(
+        endpoint: str,
+        node_by_id: dict[str, dict[str, Any]],
+        node_by_ref: dict[str, dict[str, Any]],
+        path: Path,
+    ) -> str:
+        if endpoint in node_by_id:
+            return endpoint
+        if endpoint in node_by_ref:
+            return cast(str, node_by_ref[endpoint]["id"])
+        raise GraphEmissionError(f"{path}: edge endpoint does not match any node id or ref: {endpoint}")
+
+
+def consolidate_graph_emissions(project_dir: Path, emissions_dir: Path | None = None) -> GraphEmissionResult:
+    try:
+        return GraphEmissionManager(project_dir, emissions_dir=emissions_dir).consolidate()
+    except SemanticGraphError as e:
+        raise GraphEmissionError(str(e)) from e

--- a/templates/.opencode/agents/code-generator.md
+++ b/templates/.opencode/agents/code-generator.md
@@ -723,6 +723,30 @@ Manifest rules:
 4. Per-task commits — each task gets its own git commit
 5. No interpretation — the schema IS the SSOT. Render exactly what it specifies.
 
+### Semantic Graph Emission
+
+After schema assembly or code rendering, write or update
+`.factory/graph_emissions/code-generator.json` with generated implementation nodes:
+
+```json
+{
+  "agent": "code-generator",
+  "artifact": ".factory/schema.json",
+  "nodes": [
+    {"ref": "model:<model.name>", "type": "odoo_model", "label": "<model.name>"},
+    {"ref": "field:<model.name>.<field.name>", "type": "odoo_field", "label": "<field.name>"},
+    {"ref": "view:<view.name>", "type": "odoo_view", "label": "<view.name>"}
+  ],
+  "edges": [
+    {"type": "owned_by", "source": "field:<model.name>.<field.name>", "target": "model:<model.name>"},
+    {"type": "implements", "source": "RF-01", "target": "model:<model.name>"}
+  ]
+}
+```
+
+Use refs from `schema.json` and existing traceability arrays. Do not write
+directly to `.factory/graph.json`; consolidation is done with `fba graph consolidate`.
+
 ### Odoo v18 Prohibited Patterns (DO NOT USE)
 
 - `<tree>` — use `<list>`

--- a/templates/.opencode/agents/documentador.md
+++ b/templates/.opencode/agents/documentador.md
@@ -116,6 +116,29 @@ Render the PRD as a well-formatted Markdown document with these sections:
 | ... | ... |
 ```
 
+## Semantic Graph Emission
+
+After generating `.factory/prd.json`, also write or update
+`.factory/graph_emissions/documentador.json` with PRD traceability nodes:
+
+```json
+{
+  "agent": "documentador",
+  "artifact": ".factory/prd.json",
+  "nodes": [
+    {"ref": "RF-01", "type": "functional_requirement", "label": "RF-01"},
+    {"ref": "RNF-01", "type": "non_functional_requirement", "label": "RNF-01"},
+    {"ref": "CA-01", "type": "acceptance_criterion", "label": "CA-01"}
+  ],
+  "edges": [
+    {"type": "validates", "source": "CA-01", "target": "RF-01"}
+  ]
+}
+```
+
+Use `ref` equal to PRD requirement and acceptance-criterion IDs. Do not write
+directly to `.factory/graph.json`; consolidation is done with `fba graph consolidate`.
+
 ## Validation
 
 After generating prd.json, validate it:

--- a/templates/.opencode/agents/elicitador.md
+++ b/templates/.opencode/agents/elicitador.md
@@ -178,6 +178,31 @@ Regardless of how questions are asked, the final output is always
 - At least 1 acceptance criterion must be defined
 - All IDs must follow patterns: RF-NN, RNF-NN, CA-NN
 
+## Semantic Graph Emission
+
+After generating `.factory/context/elicitation.json`, also write or update
+`.factory/graph_emissions/elicitador.json` with semantic nodes discovered in
+elicitation:
+
+```json
+{
+  "agent": "elicitador",
+  "artifact": ".factory/context/elicitation.json",
+  "nodes": [
+    {"ref": "stakeholder:<name>", "type": "stakeholder", "label": "<name>"},
+    {"ref": "RF-01", "type": "functional_requirement", "label": "<short RF label>"},
+    {"ref": "RNF-01", "type": "non_functional_requirement", "label": "<short RNF label>"},
+    {"ref": "CA-01", "type": "acceptance_criterion", "label": "<criterion summary>"}
+  ],
+  "edges": [
+    {"type": "validates", "source": "CA-01", "target": "RF-01"}
+  ]
+}
+```
+
+Use stable `ref` values matching artifact IDs so `fba graph consolidate` can
+merge emissions idempotently.
+
 ## Record Completion
 After the orchestrator generates and saves elicitation.json:
 - Run: `fba record elicitation_complete --data '{"methodology":"BABOK","rf_count":X,"rnf_count":Y}'`

--- a/templates/.opencode/agents/planificador.md
+++ b/templates/.opencode/agents/planificador.md
@@ -356,6 +356,30 @@ The traceability matrix must satisfy:
 - Every RNF from the PRD must appear in at least one traceability entry
 - No orphan SDD components (all must trace back to a PRD requirement)
 
+## Semantic Graph Emission
+
+After generating `.factory/sdd.json`, also write or update
+`.factory/graph_emissions/planificador.json` with design nodes and requirement links:
+
+```json
+{
+  "agent": "planificador",
+  "artifact": ".factory/sdd.json",
+  "nodes": [
+    {"ref": "module:<module_name>", "type": "odoo_module", "label": "<module_name>"},
+    {"ref": "model:<model.name>", "type": "odoo_model", "label": "<model.name>"},
+    {"ref": "field:<model.name>.<field.name>", "type": "odoo_field", "label": "<field.name>"}
+  ],
+  "edges": [
+    {"type": "implements", "source": "RF-01", "target": "model:<model.name>"},
+    {"type": "owned_by", "source": "field:<model.name>.<field.name>", "target": "model:<model.name>"}
+  ]
+}
+```
+
+Use requirement refs from PRD traceability arrays. Do not write directly to
+`.factory/graph.json`; consolidation is done with `fba graph consolidate`.
+
 ## Validation
 
 After generating sdd.json, validate it:

--- a/templates/.opencode/agents/revisor_artefactos.md
+++ b/templates/.opencode/agents/revisor_artefactos.md
@@ -32,6 +32,27 @@ agent that owns the artifact for correction.
 - `.factory/gate_report.json` — Machine-readable validation report
 - Gate pass/fail displayed to the user with actionable diagnostics
 
+## Semantic Graph Emission
+
+After generating `.factory/gate_report.json`, write or update
+`.factory/graph_emissions/revisor_artefactos.json` with validation coverage:
+
+```json
+{
+  "agent": "revisor_artefactos",
+  "artifact": ".factory/gate_report.json",
+  "nodes": [
+    {"ref": "gate:<phase>", "type": "quality_attribute", "label": "Gate <phase>"}
+  ],
+  "edges": [
+    {"type": "validates", "source": "gate:<phase>", "target": "RF-01"}
+  ]
+}
+```
+
+Use refs already emitted by artifact-producing agents. Do not write directly to
+`.factory/graph.json`; consolidation is done with `fba graph consolidate`.
+
 ## Validation Levels
 
 ### Level 1: Artifact Existence

--- a/templates/.opencode/agents/revisor_codigo.md
+++ b/templates/.opencode/agents/revisor_codigo.md
@@ -33,6 +33,27 @@ categorized by severity: critical, warning, or info.
 - `.factory/review_report.json` — structured machine-readable review report
 - `.factory/review_report.md` — human-readable review report with findings
 
+## Semantic Graph Emission
+
+After generating `.factory/review_report.json`, write or update
+`.factory/graph_emissions/revisor_codigo.json` with review findings:
+
+```json
+{
+  "agent": "revisor_codigo",
+  "artifact": ".factory/review_report.json",
+  "nodes": [
+    {"ref": "review:<finding_id>", "type": "risk", "label": "<finding summary>"}
+  ],
+  "edges": [
+    {"type": "validates", "source": "review:<finding_id>", "target": "model:<model.name>"}
+  ]
+}
+```
+
+Use refs from `schema.json` and generated reports. Do not write directly to
+`.factory/graph.json`; consolidation is done with `fba graph consolidate`.
+
 ## Review Dimensions
 
 ### 1. Code Quality

--- a/templates/.opencode/agents/tester_qa.md
+++ b/templates/.opencode/agents/tester_qa.md
@@ -36,6 +36,28 @@ traceability to the SSOT.
 - `.factory/test_report.json` — structured machine-readable report
 - `.factory/test_report.md` — human-readable report
 
+## Semantic Graph Emission
+
+After generating `.factory/test_report.json`, also write or update
+`.factory/graph_emissions/tester_qa.json` with test coverage nodes:
+
+```json
+{
+  "agent": "tester_qa",
+  "artifact": ".factory/test_report.json",
+  "nodes": [
+    {"ref": "test:<test_name>", "type": "test_case", "label": "<test_name>"}
+  ],
+  "edges": [
+    {"type": "tests", "source": "test:<test_name>", "target": "RF-01"},
+    {"type": "covers", "source": "test:<test_name>", "target": "model:<model.name>"}
+  ]
+}
+```
+
+Use requirement/model refs from `schema.json` traceability. Do not write
+directly to `.factory/graph.json`; consolidation is done with `fba graph consolidate`.
+
 ## Procedure
 
 ### 1. Load the SSOT

--- a/templates/.opencode/agents/validador_semantico.md
+++ b/templates/.opencode/agents/validador_semantico.md
@@ -32,6 +32,27 @@ prevent that.
 
 - `.factory/semantic_report.json` — structured validation report
 
+## Semantic Graph Emission
+
+After generating `.factory/semantic_report.json`, write or update
+`.factory/graph_emissions/validador_semantico.json` with semantic validation nodes:
+
+```json
+{
+  "agent": "validador_semantico",
+  "artifact": ".factory/semantic_report.json",
+  "nodes": [
+    {"ref": "semantic:<phase>", "type": "quality_attribute", "label": "Semantic validation <phase>"}
+  ],
+  "edges": [
+    {"type": "validates", "source": "semantic:<phase>", "target": "RF-01"}
+  ]
+}
+```
+
+Use refs already emitted by artifact-producing agents. Do not write directly to
+`.factory/graph.json`; consolidation is done with `fba graph consolidate`.
+
 ## Procedure
 
 ### 1. Identify the Semantic Check Rule

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -26,6 +26,7 @@ El estado actual del proyecto se encuentra en `.factory/state.json`.
 El registro de eventos esta en `.factory/events.jsonl`.
 El registry liviano de modelos Odoo esta en `.factory/module_registry.json`.
 El indice profundo de addons existentes esta en `.factory/registry_index.json` cuando se genera con `fba registry index`.
+El grafo semantico persistido esta en `.factory/graph.json`; los agentes pueden emitir nodos y aristas en `.factory/graph_emissions/*.json` y consolidarlos con `fba graph consolidate`.
 
 ## Artefactos
 
@@ -37,6 +38,8 @@ Los artefactos generados se almacenan en `.factory/`:
 - `tasks.md` - Lista de tareas implementables
 - `module_registry.json` - Registry compatible usado por `SchemaManager`
 - `registry_index.json` - Indice profundo de addons Odoo existentes: modelos, campos, vistas, controllers, seguridad, data/demo, crons, wizards y OWL
+- `graph.json` - Grafo semantico consolidado para trazabilidad de requisitos, diseno, codigo, pruebas y revisiones
+- `graph_emissions/` - Emisiones parciales de nodos/aristas generadas por agentes antes de consolidar
 - `playwright/` - Specs y reportes de browser automation generados por `fba test --playwright`
 - `perf/` - Reportes de benchmarks generados por `fba perf`
 

--- a/tests/test_graph_emission.py
+++ b/tests/test_graph_emission.py
@@ -1,0 +1,113 @@
+import json
+
+from click.testing import CliRunner
+
+from fba.cli import main
+from fba.graph_emission import GraphEmissionError, GraphEmissionManager
+
+
+def _project(tmp_path):
+    project = tmp_path / "project"
+    (project / ".factory" / "graph_emissions").mkdir(parents=True)
+    return project
+
+
+def _write_emission(project, name, payload):
+    path = project / ".factory" / "graph_emissions" / name
+    path.write_text(json.dumps(payload))
+    return path
+
+
+def test_graph_emission_consolidates_agent_nodes_and_edges(tmp_path):
+    project = _project(tmp_path)
+    _write_emission(
+        project,
+        "documentador.json",
+        {
+            "agent": "documentador",
+            "artifact": ".factory/prd.json",
+            "nodes": [
+                {"ref": "RF-01", "type": "functional_requirement", "label": "Registrar vehiculos"},
+                {"ref": "CA-01", "type": "acceptance_criterion", "label": "Crear vehiculo"},
+            ],
+            "edges": [
+                {"type": "validates", "source": "CA-01", "target": "RF-01"},
+            ],
+        },
+    )
+
+    result = GraphEmissionManager(project).consolidate()
+
+    graph = json.loads((project / ".factory" / "graph.json").read_text())
+    assert result.emissions == 1
+    assert result.nodes_added == 2
+    assert result.edges_added == 1
+    assert [node["properties"]["ref"] for node in graph["nodes"]] == ["RF-01", "CA-01"]
+    assert graph["edges"][0]["source"] == graph["nodes"][1]["id"]
+    assert graph["edges"][0]["target"] == graph["nodes"][0]["id"]
+
+
+def test_graph_emission_is_idempotent_by_ref_and_edge_key(tmp_path):
+    project = _project(tmp_path)
+    payload = {
+        "agent": "planificador",
+        "artifact": ".factory/sdd.json",
+        "nodes": [
+            {"ref": "RF-01", "type": "functional_requirement", "label": "Registrar activos"},
+            {"ref": "model:fleet.vehicle", "type": "odoo_model", "label": "fleet.vehicle"},
+        ],
+        "edges": [
+            {"type": "implements", "source": "RF-01", "target": "model:fleet.vehicle"},
+        ],
+    }
+    _write_emission(project, "planificador.json", payload)
+
+    first = GraphEmissionManager(project).consolidate()
+    second = GraphEmissionManager(project).consolidate()
+
+    graph = json.loads((project / ".factory" / "graph.json").read_text())
+    assert first.nodes_added == 2
+    assert second.nodes_added == 0
+    assert second.nodes_updated == 2
+    assert second.edges_skipped == 1
+    assert len(graph["nodes"]) == 2
+    assert len(graph["edges"]) == 1
+
+
+def test_graph_emission_rejects_unknown_edge_endpoint(tmp_path):
+    project = _project(tmp_path)
+    _write_emission(
+        project,
+        "tester.json",
+        {
+            "agent": "tester_qa",
+            "nodes": [{"ref": "TC-01", "type": "test_case", "label": "Prueba CRUD"}],
+            "edges": [{"type": "tests", "source": "TC-01", "target": "RF-404"}],
+        },
+    )
+
+    try:
+        GraphEmissionManager(project).consolidate()
+    except GraphEmissionError as e:
+        assert "RF-404" in str(e)
+    else:
+        raise AssertionError("GraphEmissionError was not raised")
+
+
+def test_graph_consolidate_cli_reports_summary(tmp_path):
+    project = _project(tmp_path)
+    _write_emission(
+        project,
+        "elicitador.json",
+        {
+            "agent": "elicitador",
+            "nodes": [{"ref": "stakeholder:operador", "type": "stakeholder", "label": "Operador"}],
+            "edges": [],
+        },
+    )
+
+    result = CliRunner().invoke(main, ["graph", "consolidate", "-d", str(project)])
+
+    assert result.exit_code == 0
+    assert "Graph emissions consolidated" in result.output
+    assert "Nodes added: 1" in result.output


### PR DESCRIPTION
## Summary
- Add `GraphEmission` class and `fba graph consolidate` CLI command to merge per-agent graph emissions into `.factory/graph.json`
- 12 files changed, 538 insertions across src, templates, tests, and docs
- All 4 tests passing

## Files included
- `src/fba/graph_emission.py` — GraphEmission class for consolidation
- `src/fba/cli.py` — CLI integration (graph consolidate command)
- `templates/.opencode/agents/*.md` — Agent definitions updated with graph emission support
- `tests/test_graph_emission.py` — Unit tests for consolidation logic

## Tests passed
```
tests/test_graph_emission.py::test_graph_emission_consolidates_agent_nodes_and_edges PASSED
tests/test_graph_emission.py::test_graph_emission_is_idempotent_by_ref_and_edge_key PASSED
tests/test_graph_emission.py::test_graph_emission_rejects_unknown_edge_endpoint PASSED
tests/test_graph_emission.py::test_graph_consolidate_cli_reports_summary PASSED
```

Closes #161