### PR TITLE
chore(M17.3): actualizar estado, ROADMAP y CHANGELOG post-merge

### DIFF
--- a/.factory/framework-state.json
+++ b/.factory/framework-state.json
@@ -1,24 +1,27 @@
 {
   "schema_version": "1.0",
-  "last_updated": "2026-05-14T23:30:00Z",
+  "last_updated": "2026-05-15T04:55:00Z",
   "last_session": {
-    "date": "2026-05-14",
+    "date": "2026-05-15",
     "agent": "framework-orchestrator",
-    "action": "Cierre de feat 16.4 + creación milestone M23: CAFL-Plugins",
-    "completed_feats": ["feat/16.4-agent-observer-plugin"],
-    "pending_feats": [],
+    "action": "Cierre M17.3 — feat/17.3-agent-graph-emission mergeado a main via PR #163",
+    "completed_feats": ["feat/17.1-graph-ontology", "feat/17.2-graph-store-queries", "feat/17.3-agent-graph-emission"],
+    "pending_feats": ["feat/17.4-elicitation-method-stack"],
     "blockers": []
   },
   "active_milestone": {
-    "id": "M23",
-    "name": "CAFL-Plugins",
-    "branch": "milestone/23.0-cafl-plugins",
+    "id": "M17",
+    "name": "Semantic Core",
+    "branch": "milestone/17.0-semantic-core",
     "status": "in_progress",
-    "feats_total": 1,
-    "feats_done": 0,
-    "feats_pending": ["feat/23.1-agent-observer-plugin"],
+    "feats_total": 4,
+    "feats_done": 3,
+    "feats_pending": ["feat/17.4-elicitation-method-stack"],
     "feats": {
-      "feat/23.1-agent-observer-plugin": { "status": "planned" }
+      "feat/17.1-graph-ontology": { "status": "completed", "merged": true, "issue": 157 },
+      "feat/17.2-graph-store-queries": { "status": "completed", "merged": true, "issue": 159 },
+      "feat/17.3-agent-graph-emission": { "status": "completed", "merged": true, "issue": 161, "pr": 163 },
+      "feat/17.4-elicitation-method-stack": { "status": "planned" }
     },
     "ready_for_user_review": false,
     "start_date": "2026-05-14"
@@ -36,14 +39,14 @@
     "M13": "completed",
     "M14": "completed",
     "M15": "completed",
-    "M16": "completed_with_extras",
-    "M17": "planned",
+    "M16": "completed",
+    "M17": "in_progress",
     "M18": "planned",
     "M19": "planned",
     "M20": "planned",
     "M21": "planned",
     "M22": "planned",
-    "M23": "in_progress"
+    "M23": "paused"
   },
   "roadmap_summary": [
     {"milestone":"M0","name":"Fundacion","status":"completed","start_date":"2026-05-02","end_date":"2026-05-02"},
@@ -59,7 +62,7 @@
     {"milestone":"M14","name":"Odoo Depth (Capa 3)","status":"completed","start_date":"2026-05-13","end_date":"2026-05-13","caps":"Wizards/workflows + migraciones + i18n"},
     {"milestone":"M15","name":"Advanced QA (Capa 4)","status":"completed","start_date":"2026-05-13","end_date":"2026-05-13","caps":"Playwright + performance benchmarks + concurrency"},
     {"milestone":"M16","name":"Foundation Intelligence","status":"completed","start_date":"2026-05-14","end_date":"2026-05-14","caps":"ModuleRegistry autoindexado + Odoo Pattern Knowledge Base + version-aware knowledge"},
-    {"milestone":"M17","name":"Semantic Core","status":"planned","caps":"Semantic graph + ontologia + graph queries + agent emission"},
+    {"milestone":"M17","name":"Semantic Core","status":"in_progress","start_date":"2026-05-14","caps":"Semantic graph + ontologia + graph queries + agent emission"},
     {"milestone":"M18","name":"Input & Extension Layer","status":"planned","caps":"Connector specification ingestion + CKM + CREATE/EXTEND mode"},
     {"milestone":"M19","name":"Governance & Observability","status":"planned","caps":"Human checkpoints + agent decision observability"},
     {"milestone":"M20","name":"Graph Enforcement Gates","status":"planned","caps":"Architectural + semantic + delivery gates over graph/code/results"},
@@ -99,10 +102,16 @@
       "status": "completed"
     },
     {
+      "file": ".factory/fw-brief-m17.md",
+      "description": "M17 Semantic Core: feat/17.1 + feat/17.2 + feat/17.3 completados, feat/17.4 pendiente",
+      "created": "2026-05-14",
+      "status": "completed"
+    },
+    {
       "file": ".factory/fw-brief-m23.md",
       "description": "M23 CAFL-Plugins: plugin de observabilidad para agentes del framework",
       "created": "2026-05-14T00:00:00Z",
-      "status": "in_progress"
+      "status": "paused"
     }
   ],
   "pending_decisions": [
@@ -129,6 +138,14 @@
       "created": "2026-05-14",
       "resolved": "2026-05-14",
       "resolution": "M23 creado con feat 23.1 (agent-observer-plugin)"
+    },
+    {
+      "id": "D2026-05-15-001",
+      "description": "Cierre M17.3 — feat/17.3-agent-graph-emission mergeado a main via PR #163",
+      "status": "resolved",
+      "created": "2026-05-15",
+      "resolved": "2026-05-15",
+      "resolution": "PR #163 mergeado a main. M17 con feat/17.1 + feat/17.2 + feat/17.3 completados. feat/17.4 pendiente."
     }
   ],
   "agents": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/).
 ### M17 Semantic Core
 - #157 feat/17.1: Ontologia cerrada NodeType/EdgeType para el grafo semantico, schema `schemas/graph.schema.json`, comando `fba graph validate` y documentacion inicial de testing M17.
 - #159 feat/17.2: `GraphManager` persiste `.factory/graph.json` con atomic writes, genera UUID v4 via `StableIdManager` y expone queries `full_trace`, `impact_of`, `is_covered`, `orphan_nodes`, `dependents` y `governing_adrs` con comandos `fba graph trace/impact/orphans`.
+- #161 feat/17.3: Protocolo de emision semantica en `.factory/graph_emissions/*.json`, consolidacion idempotente con `fba graph consolidate`, y prompts de agentes actualizados para emitir trazabilidad.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,7 @@ Ver tambien: [README.md](README.md) | [AGENTS.md](AGENTS.md) | [docs/PRD.md](doc
 | M14: Odoo Depth | ✅ Completado | 2026-05-13 / 2026-05-13 |
 | M15: Advanced QA | ✅ Completado | 2026-05-13 / 2026-05-13 |
 | M16: Foundation Intelligence | ✅ Completado | 2026-05-14 / 2026-05-14 |
-| M17: Semantic Core | 🔄 En progreso | Feat 17.2 en desarrollo |
+| M17: Semantic Core | 🔄 En progreso | Feat 17.4 pendiente |
 | M18: Input & Extension Layer | ⏳ Planificado | Pendiente |
 | M19: Governance & Observability | ⏳ Planificado | Pendiente |
 | M20: Graph Enforcement Gates | ⏳ Planificado | Pendiente |
@@ -113,8 +113,8 @@ y emision gradual desde agentes existentes.
 | Orden | Feat | Depende de | Descripcion | Estado |
 |-------|------|------------|-------------|--------|
 | 1 | feat/17.1-graph-ontology | M16 | NodeType y EdgeType cerrados para BABOK, Impact Mapping, Event Storming, Example Mapping, Odoo, integraciones y calidad; schema `graph.schema.json` y `fba graph validate` | ✅ |
-| 2 | feat/17.2-graph-store-queries | feat/17.1 | Persistencia JSON + queries: impact_of, is_covered, orphan_nodes, dependents, governing_adrs, full_trace | 🔄 |
-| 3 | feat/17.3-agent-graph-emission | feat/17.2 | Protocolo para que Elicitador, Documentador, Planificador, Constructor, Tester y Revisores emitan nodos/aristas | ⏳ |
+| 2 | feat/17.2-graph-store-queries | feat/17.1 | Persistencia JSON + queries: impact_of, is_covered, orphan_nodes, dependents, governing_adrs, full_trace | ✅ |
+| 3 | feat/17.3-agent-graph-emission | feat/17.2 | Protocolo `.factory/graph_emissions/*.json` + `fba graph consolidate` para que Elicitador, Documentador, Planificador, Constructor, Tester y Revisores emitan nodos/aristas | ✅ |
 | 4 | feat/17.4-elicitation-method-stack | feat/17.3 | Encadenar BABOK + Impact Mapping + Event Storming + Example Mapping dentro de `/fba:elicit` | ⏳ |
 
 **Verificacion esperada**
@@ -123,6 +123,7 @@ y emision gradual desde agentes existentes.
 fba graph validate
 fba graph trace req_001
 fba graph impact req_001
+fba graph consolidate
 pytest tests/test_semantic_graph.py tests/test_graph_emission.py
 ```
 


### PR DESCRIPTION
## Summary
- Actualiza `.factory/framework-state.json` tras merge de M17.3 a main (PR #163)
- Marca feat/17.1, feat/17.2, feat/17.3 como completados en ROADMAP.md
- Agrega entrada de feat/17.3 al CHANGELOG.md

## Verificacion
```bash
pytest tests/test_semantic_graph.py tests/test_graph_emission.py -v
mypy src/fba/semantic_graph.py src/fba/graph_emission.py
```